### PR TITLE
add router test (mb client) to plow scripts

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -10,6 +10,7 @@ There are 4 types network tests:
 Running from CLI:
 
 ```sh
+pip3 install -r requirements.txt
 $ ./run_<test-name>_network_test_fromgit.sh 
 ```
 

--- a/workloads/router-perf/README.md
+++ b/workloads/router-perf/README.md
@@ -1,0 +1,90 @@
+# Router Script
+
+The purpose of the router script is to run e2e router workload on the Openshift Cluster.
+
+Running from CLI:    
+First make changes to `env.sh` according to the the env vars mentioned here https://github.com/openshift-scale/workloads/blob/master/docs/http.md and below
+```sh
+pip3 install -r requirements.txt
+$ ./run_router_test.sh 
+```
+
+## Environment variables
+
+### ES_USER
+Default: ``     
+Username for elasticsearch instance
+
+### ES_PASSWORD
+Default: ``             
+Password for elasticsearch instance
+
+### ES_SERVER
+Default: `milton.aws.com`                
+Elasticsearch server to index the results of the current run
+
+### ES_PORT
+Default: ``              
+Port number for elasticsearch server
+
+### COMPARE
+Default: `false`    
+Enable/Disable the ability to compare two uperf runs. If set to `true`, the next set of environment variables pertaining to the type of test are required
+
+### ES_USER_BASELINE
+Default: ``             
+Username for elasticsearch instance
+
+### ES_PASSWORD_BASELINE
+Default: ``               
+Password for elasticsearch instance
+
+### ES_SERVER_BASELINE 
+Default: ``    
+Elasticsearch server used used by the baseline run 
+
+### ES_PORT_BASELINE
+Default: `80`   
+Port number for the elasticsearch server used by the baseline run
+
+### BASELINE_ROUTER_UUID
+Default: ``    
+Baseline UUID for router test  
+
+### BASELINE_CLOUD_NAME
+Default: ``               
+Name you would like to give your baseline cloud. It will appear as a header in the CSV file
+
+### THROUGHPUT_TOLERANCE
+Default: `5`   
+Accepeted deviation in percentage for throughput when compared to a baseline run
+
+### LATENCY_TOLERANCE
+Default: `5`   
+Accepeted deviation in percentage for latency when compared to a baseline run
+
+### CERBERUS_URL
+Default: ``     
+URL to check the health of the cluster using Cerberus (https://github.com/openshift-scale/cerberus)
+
+### GSHEET_KEY
+Default: *Commented out*               
+Service account key to generate google sheets
+
+### GSHEET_KEY_LOCATION
+Default: *Commented out*              
+Path to service account key to generate google sheets
+
+### EMAIL_ID_FOR_RESULTS_SHEET
+Default: *Commented out*        
+It will push your local results CSV to Google Spreadsheets and send an email with the attachment
+
+## Suggested configurations for a smoke test
+
+```sh
+export PBENCH_SERVER=''
+export COMPARE=false
+export HTTP_TEST_SUFFIX='smoke-test'
+export HTTP_TEST_SMOKE_TEST=true
+```
+

--- a/workloads/router-perf/csv_gen.py
+++ b/workloads/router-perf/csv_gen.py
@@ -1,0 +1,176 @@
+#!/usr/bin/python3
+import yaml
+from collections import defaultdict
+import csv
+import argparse
+import datetime
+import os
+import re
+from oauth2client.service_account import ServiceAccountCredentials
+import gspread
+from gspread_formatting import *
+
+regexp = re.compile(r"^\D*(\d+)\D*$")
+
+# Globals
+main_metric_rps = {"http": "avg(requests_per_second)", "edge": "avg(requests_per_second)", "mix": "avg(requests_per_second)"}
+label_map = {"http": "http", "edge": "edge", "mix": "mix"}
+main_metric_latency = {"http": "avg(latency_95pctl)", "edge": "avg(latency_95pctl)", "mix": "avg(latency_95pctl)"}
+
+def get_uuid_mapping(file_name):
+    uuid_map = {}
+    uuid_titles = []
+    with open(file_name, "r") as f:
+        for line in f.readlines():
+            if not uuid_titles:
+                uuid_titles = [title.strip() for title in line.split(",")]
+                continue
+            uuids = line.split(",")
+            for i, title in enumerate(uuid_titles):
+                uuid_map[uuids[i].strip()] = title
+    return uuid_map, uuid_titles
+
+
+def read_yaml(yaml_files):
+    data = {}
+    for yaml_file in yaml_files:
+        with open(yaml_file) as f:
+            match = regexp.match(yaml_file)
+            data[match.group(1) if match else yaml_file] = yaml.load(f, Loader=yaml.FullLoader)
+    return data
+
+
+def create_table_mappings(data, uuid_map, metric_map):
+    tables = {} 
+    for file_num, datum in data.items():
+        for test_type in datum["test_type"]:
+            for routes in datum["test_type"][test_type]["routes"]:
+                for cpt in datum["test_type"][test_type]["routes"][routes]["conn_per_targetroute"]:
+                    for keepalive in datum["test_type"][test_type]["routes"][routes]["conn_per_targetroute"][cpt]["keepalive"]:
+                        level_dict = datum["test_type"][test_type]["routes"][routes]["conn_per_targetroute"][cpt]["keepalive"][keepalive]
+                        table = tables.setdefault((routes, label_map[test_type], cpt), defaultdict(lambda: defaultdict(dict)),)
+                        if metric_map == "rps":
+                            for uuid in level_dict[main_metric_rps[test_type]]:
+                                table[file_num][f"{keepalive}"][uuid_map[uuid]] = level_dict[main_metric_rps[test_type]][uuid]
+                        else:
+                            for uuid in level_dict[main_metric_latency[test_type]]:
+                                table[file_num][f"{keepalive}"][uuid_map[uuid]] = level_dict[main_metric_latency[test_type]][uuid]
+    return tables
+
+
+def write_to_csv(
+    table_dictionary, uuid_titles, metric_write, extract_thread_count=None, result_csv_file="results.csv",
+):
+    with open(result_csv_file, "a+") as csv_file:
+        w = csv.writer(csv_file, quotechar="'")
+        if metric_write == "rps":
+            w.writerow(["Requests per Second"])
+        else:
+            w.writerow(["Latency_95Pctl (milliseconds)"])
+        for key in table_dictionary.keys():
+            if not extract_thread_count or (extract_thread_count and key[2] == extract_thread_count):
+                w.writerow([f"{key[0]} {key[1]} routes - {key[2]} parallel conns per route"])
+                header_row = [
+                    "Number of Keepalive Messages",
+                    *uuid_titles,
+                ]
+                if os.environ["COMPARE"] == "true":
+                    w.writerow(header_row + [" ", "Percent Change", "P/F"])
+                else:
+                    w.writerow(header_row)
+                for file_num in table_dictionary[key].keys():
+                    for cpt, value in table_dictionary[key][file_num].items():
+                        row = [cpt] + [value.get(k, "NaN") for k in uuid_titles]
+                        row.append(" ")
+                        if os.environ["COMPARE"] == "true":
+                            row.append("%.1f%%" % percent_change(float(row[-2]), float(row[-3])))
+                            if "latency" in metric_write.lower():
+                                row.append(get_pass_fail(float(row[-3]), float(row[-4]), int(params.latency_tolerance[0]), ltcy_flag=True,))
+                            else:
+                                row.append(get_pass_fail(float(row[-3]), float(row[-4]), int(params.throughput_tolerance[0]), ltcy_flag=False,))
+                        w.writerow(row)
+                w.writerow([])
+        w.writerow([])
+        w.writerow([])
+
+ 
+def percent_change(value, reference):
+    if reference:
+        return ((value - reference) * 1.0 / reference) * 100
+    else:
+        return -1
+
+
+def get_pass_fail(val, ref, tolerance, ltcy_flag=False):
+    percent_diff = abs(percent_change(val, ref))
+    if val < ref and percent_diff > tolerance:
+        if ltcy_flag:
+            return "Pass"
+        else:
+            return "Fail"
+    elif val > ref and percent_diff > tolerance:
+        if ltcy_flag:
+            return "Fail"
+        else:
+            return "Pass"
+    else:
+        return "Pass"
+
+
+def generate_csv(yaml_files, result_csv_file="results.csv", extract_keepalive=None):
+    uuid_map, uuid_titles = get_uuid_mapping(file_name="uuid.txt")
+    data = read_yaml(yaml_files)
+    metric_type = ["rps", "latency"]
+    for metric in metric_type:
+        tables = create_table_mappings(data, uuid_map, metric_map=metric)
+        write_to_csv(tables, uuid_titles, metric, extract_keepalive, result_csv_file)
+    print(f"\n            Test Completed!\n            Results file generated -> {params.sheetname}.csv")
+
+
+def push_to_gsheet(csv_file_name, google_svc_acc_key, email_id):
+    fmt = cellFormat(
+        # backgroundColor=color(1, 0.9, 0.9),
+        # textFormat=textFormat(bold=True, foregroundColor=color(1, 0, 1)),
+        horizontalAlignment="RIGHT"
+    )
+    scope = [
+        "https://spreadsheets.google.com/feeds",
+        "https://www.googleapis.com/auth/drive",
+    ]
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(google_svc_acc_key, scope)
+    gc = gspread.authorize(credentials)
+
+    sh = gc.create(params.sheetname)  # Specify name of the Spreadsheet
+    sh.share(email_id, perm_type="user", role="writer")
+    spreadsheet_id = sh.id
+    spreadsheet_url = f"https://docs.google.com/spreadsheets/d/{sh.id}"
+    with open(csv_file_name, "r") as f:
+        gc.import_csv(spreadsheet_id, f.read())
+    worksheet = sh.get_worksheet(0)
+    format_cell_range(worksheet, "1:1000", fmt)
+    set_column_width(worksheet, "A", 290)
+    print(f"            Google Spreadsheet link -> {spreadsheet_url}\n")
+
+
+# Main
+now = datetime.datetime.today()
+timestamp = now.strftime("%Y-%m-%d-%H.%M.%S")
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--sheetname", help="Google Spreadsheet name", nargs=1, required=False, dest="sheetname", default=f"Router-Test-Results-{str(timestamp)}",
+)
+parser.add_argument(
+    "-f", "--files", help="YAML files to scrape output from", nargs="+", required=False, dest="yaml_files",
+)
+parser.add_argument(
+    "-l", "--latency_tolerance", help="Accepted deviation (+/-) from the reference result", nargs=1, required=False, dest="latency_tolerance", default="5",
+)
+parser.add_argument(
+    "-t", "--throughput_tolerance", help="Accepted deviation (+/-) from the reference result", nargs=1, required=False, dest="throughput_tolerance", default="5",
+)
+params = parser.parse_args()
+generate_csv(params.yaml_files, f"{params.sheetname}.csv")
+if "EMAIL_ID_FOR_RESULTS_SHEET" and "GSHEET_KEY_LOCATION" in os.environ:
+    push_to_gsheet(
+        f"{params.sheetname}.csv", os.environ["GSHEET_KEY_LOCATION"], os.environ["EMAIL_ID_FOR_RESULTS_SHEET"],
+    )

--- a/workloads/router-perf/env.sh
+++ b/workloads/router-perf/env.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+export PBENCH_SERVER=''
+export GSHEET_KEY=
+export GSHEET_KEY_LOCATION=''
+export ES_SERVER=''
+export ES_PORT=
+export EMAIL_ID_FOR_RESULTS_SHEET=''
+export COMPARE=false
+export BASELINE_ROUTER_UUID=''
+export BASESLINE_CLOUD_NAME=''
+
+#HTTP benchmarks specific parameters:
+export HTTP_TEST_SUFFIX='smoke-test'
+export HTTP_TEST_APP_PROJECTS=10                                           
+export HTTP_TEST_APP_TEMPLATES=10                                       # 10 for small scale test and 50 for large scale test
+export HTTP_TEST_ROUTE_TERMINATION=''                                   # http, edge, passthrough, reencrypt and mix
+export HTTP_TEST_SMOKE_TEST=true
+

--- a/workloads/router-perf/requirements.txt
+++ b/workloads/router-perf/requirements.txt
@@ -1,0 +1,4 @@
+gspread
+gspread-formatting
+oauth2client
+pyyaml

--- a/workloads/router-perf/run_router_compare.sh
+++ b/workloads/router-perf/run_router_compare.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 datasource="elasticsearch"
-tool="uperf"
-function="compare"
-_es=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
-_es_port=80
-_es_baseline=search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
-_es_baseline_port=80
-
+tool="mb"
+_es=${ES_SERVER:-search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com}
+_es_port=${ES_PORT:-80}
 
 if [[ ${ES_SERVER} ]] && [[ ${ES_PORT} ]] && [[ ${ES_USER} ]] && [[ ${ES_PASSWORD} ]]; then
   _es=${ES_USER}:${ES_PASSWORD}@${ES_SERVER}
@@ -16,6 +12,9 @@ elif [[ ${ES_SERVER} ]] && [[ ${ES_PORT} ]]; then
   _es_port=${ES_PORT}
 fi
 
+_es_baseline=${ES_SERVER_BASELINE:-$_es}
+_es_baseline_port=${ES_PORT_BASELINE:-$_es_port}
+
 if [[ ${ES_SERVER_BASELINE} ]] && [[ ${ES_PORT_BASELINE} ]] && [[ ${ES_USER_BASELINE} ]] && [[ ${ES_PASSWORD_BASELINE} ]]; then
   _es_baseline=${ES_USER_BASELINE}:${ES_PASSWORD_BASELINE}@${ES_SERVER_BASELINE}
   _es_baseline_port=${ES_PORT_BASELINE}
@@ -24,6 +23,7 @@ elif [[ ${ES_SERVER_BASELINE} ]] && [[ ${ES_PORT_BASELINE} ]]; then
   _es_port=${ES_PORT_BASELINE}
 fi
 
+
 if [[ ${COMPARE} != "true" ]]; then
   compare_uuid=$1
 else
@@ -31,15 +31,17 @@ else
   compare_uuid=$2
 fi
 
+
 python3 -m venv ./venv
 source ./venv/bin/activate
 pip3 install git+https://github.com/cloud-bulldozer/touchstone
+
 if [[ $? -ne 0 ]] ; then
   echo "Unable to execute compare - Failed to install touchstone"
   exit 1
 fi
 set -x
-touchstone_compare $tool $datasource ripsaw -url $_es_baseline:$_es_baseline_port $_es:$_es_port -u $base_uuid $compare_uuid -o yaml | tee ../compare_output_${!#}p.yaml
+touchstone_compare $tool $datasource ripsaw -url $_es:$_es_port $_es_baseline:$_es_baseline_port -u $base_uuid $compare_uuid -o yaml | tee compare.yaml
 if [[ $? -ne 0 ]] ; then
   echo "Unable to execute compare - Failed to run touchstone"
   exit 1

--- a/workloads/router-perf/run_router_test.sh
+++ b/workloads/router-perf/run_router_test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -x
+
+# Check cluster's health
+if [[ ${CERBERUS_URL} ]]; then
+  response=$(curl ${CERBERUS_URL})
+  if [ "$response" != "True" ]; then
+    echo "Cerberus status is False, Cluster is unhealthy"
+    exit 1
+  fi
+fi
+
+date
+oc get clusterversion
+if [ $? -ne 0 ]; then
+  echo "Workload Failed for $HTTP_TEST_SUFFIX , Unable to connect to the cluster"
+  exit 1
+fi
+
+if [[ ${COMPARE} == "true" ]]; then
+  echo $BASELINE_CLOUD_NAME,$HTTP_TEST_SUFFIX > uuid.txt
+else
+  echo $HTTP_TEST_SUFFIX > uuid.txt
+fi
+
+
+echo "Starting test for: $HTTP_TEST_SUFFIX"
+#git clone http://github.com/openshift-scale/workloads /tmp/workloads
+git clone -b change_index http://github.com/mohit-sheth/workloads /tmp/workloads
+echo "[orchestration]" > /tmp/workloads/inventory; echo "${ORCHESTRATION_HOST:-localhost}" >> /tmp/workloads/inventory
+time ansible-playbook -vv -i /tmp/workloads/inventory /tmp/workloads/workloads/http.yml
+oc logs --timestamps -n scale-ci-tooling -f job/scale-ci-http
+oc get job -n scale-ci-tooling scale-ci-http -o json | jq -e '.status.succeeded==1'
+￼
+router_state=1
+oc describe job scale-ci-http | grep "1 Succeeded"
+if [ $? -eq 0 ]; then
+        echo "Router Workload done"
+        router_state=$?
+fi
+if [ "$router_state" == "1" ] ; then
+  echo "Workload failed"
+  exit 1
+fi
+
+compare_router_uuid=$(oc logs $(oc get pods | grep "scale-ci-http" |awk '{print $1}') | grep UUID | awk '{print $3}')
+baseline_router_uuid=${BASELINE_ROUTER_UUID}
+
+if [[ ${COMPARE} == "true" ]]; then
+  echo ${baseline_router_uuid},${compare_router_uuid} >> uuid.txt
+else
+  echo ${compare_router_uuid} >> uuid.txt
+fi
+
+./run_router_compare.sh ${baseline_router_uuid} ${compare_router_uuid}
+
+python3 csv_gen.py --files compare.yaml


### PR DESCRIPTION
similar to uperf we will compare two runs using touchstone https://github.com/cloud-bulldozer/benchmark-comparison/pull/27.
`run_router_test.sh` will be a wrapper which does e2e (initiating, comparing, exporting to gsheet with Pass/Fail) benchmarking.
@jtaleric @chaitanyaenr 

test run https://docs.google.com/spreadsheets/d/1QL77aX2Np-bbz8gLVHJuvng7EYHWK1YGIc2lSWYa-2I/edit#gid=1374708479