### PR TITLE
Add removal of /tmp/ripsaw before git clone

### DIFF
--- a/workloads/etcd-perf/run_etcd_tests_fromgit.sh
+++ b/workloads/etcd-perf/run_etcd_tests_fromgit.sh
@@ -26,6 +26,8 @@ fi
 
 echo "Starting test for cloud: $cloud_name"
 
+rm -rf /tmp/ripsaw
+
 oc create ns my-ripsaw
 oc create ns backpack
 

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -67,6 +67,8 @@ fi
 
 echo "Starting test for cloud: $cloud_name"
 
+rm -rf /tmp/ripsaw
+
 oc create ns my-ripsaw
 
 git clone http://github.com/cloud-bulldozer/ripsaw /tmp/ripsaw

--- a/workloads/router-perf/run_router_test.sh
+++ b/workloads/router-perf/run_router_test.sh
@@ -25,6 +25,9 @@ fi
 
 
 echo "Starting test for: $HTTP_TEST_SUFFIX"
+
+rm -rf /tmp/workloads
+
 git clone http://github.com/openshift-scale/workloads /tmp/workloads
 echo "[orchestration]" > /tmp/workloads/inventory; echo "${ORCHESTRATION_HOST:-localhost}" >> /tmp/workloads/inventory
 time ansible-playbook -vv -i /tmp/workloads/inventory /tmp/workloads/workloads/http.yml

--- a/workloads/scale-perf/common.sh
+++ b/workloads/scale-perf/common.sh
@@ -72,6 +72,8 @@ fi
 
 echo "Starting test for cloud: $cloud_name"
 
+rm -rf /tmp/ripsaw
+
 oc create ns my-ripsaw
 
 git clone http://github.com/cloud-bulldozer/ripsaw /tmp/ripsaw

--- a/workloads/storage-perf/run_storage_tests_fromgit.sh
+++ b/workloads/storage-perf/run_storage_tests_fromgit.sh
@@ -23,6 +23,8 @@ fi
 
 echo "Starting test for cloud: $cloud_name"
 
+rm -rf /tmp/ripsaw
+
 oc create ns my-ripsaw
 
 git clone http://github.com/cloud-bulldozer/ripsaw /tmp/ripsaw


### PR DESCRIPTION
The test could potentially fail if /tmp/ripsaw existed so we'll delete the directory first.