### PR TITLE
Avoid deleting the benchmark to track the status in CI

### DIFF
--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -5,13 +5,13 @@ source ./common.sh
 
 pairs=(1)
 
-oc -n my-ripsaw delete benchmark/uperf-benchmark
+oc -n my-ripsaw delete benchmark/uperf-benchmark-hostnetwork --wait
 
 cat << EOF | oc create -f -
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: uperf-benchmark
+  name: uperf-benchmark-hostnetwork
   namespace: my-ripsaw
 spec:
   elasticsearch:
@@ -55,11 +55,11 @@ sleep 30
 
 uperf_state=1
 for i in {1..240}; do
-  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
+  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-hostnetwork -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
     echo "Cerberus status is False, Cluster is unhealthy"
     exit 1
   fi
-  oc describe -n my-ripsaw benchmarks/uperf-benchmark | grep State | grep Complete
+  oc describe -n my-ripsaw benchmarks/uperf-benchmark-hostnetwork | grep State | grep Complete
   if [ $? -eq 0 ]; then
           echo "UPerf Workload done"
           uperf_state=$?
@@ -73,7 +73,7 @@ if [ "$uperf_state" == "1" ] ; then
   exit 1
 fi
 
-compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
+compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-hostnetwork -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
 baseline_uperf_uuid=${_baseline_hostnet_uuid}
 
 if [[ ${COMPARE} == "true" ]]; then
@@ -84,8 +84,6 @@ fi
 
 ../run_compare.sh ${baseline_uperf_uuid} ${compare_uperf_uuid} ${pairs}
 pairs_array=( "${pairs_array[@]}" "compare_output_${pairs}p.yaml" )
-
-oc -n my-ripsaw delete benchmark/uperf-benchmark
 
 python3 csv_gen.py --files $(echo "${pairs_array[@]}") --latency_tolerance=$latency_tolerance --throughput_tolerance=$throughput_tolerance
 

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -3,7 +3,7 @@ set -x
 
 source ./common.sh
 
-oc -n my-ripsaw delete benchmark/uperf-benchmark
+oc -n my-ripsaw delete benchmark/uperf-benchmark-pod-network --wait
 
 for pairs in "${client_server_pairs[@]}"
 do
@@ -12,7 +12,7 @@ cat << EOF | oc create -f -
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: uperf-benchmark
+  name: uperf-benchmark-pod-network
   namespace: my-ripsaw
 spec:
   elasticsearch:
@@ -56,11 +56,11 @@ sleep 30
 
 uperf_state=1
 for i in {1..240}; do
-  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
+  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-pod-network -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
     echo "Cerberus status is False, Cluster is unhealthy"
     exit 1
   fi
-  oc describe -n my-ripsaw benchmarks/uperf-benchmark | grep State | grep Complete
+  oc describe -n my-ripsaw benchmarks/uperf-benchmark-pod-network | grep State | grep Complete
   if [ $? -eq 0 ]; then
           echo "UPerf Workload done"
           uperf_state=$?
@@ -74,7 +74,7 @@ if [ "$uperf_state" == "1" ] ; then
   exit 1
 fi
 
-compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
+compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-pod-network -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
 if [ "${pairs}" == "1" ] ; then
   baseline_uperf_uuid=${_baseline_pod_1p_uuid}
 elif [ "${pairs}" == "2" ] ; then
@@ -91,8 +91,6 @@ fi
 
 ../run_compare.sh ${baseline_uperf_uuid} ${compare_uperf_uuid} ${pairs}
 pairs_array=( "${pairs_array[@]}" "compare_output_${pairs}p.yaml" )
-
-oc -n my-ripsaw delete benchmark/uperf-benchmark
 
 done
 

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -3,7 +3,7 @@ set -x
 
 source ./common.sh
 
-oc -n my-ripsaw delete benchmark/uperf-benchmark
+oc -n my-ripsaw delete benchmark/uperf-benchmark-service-network --wait
 
 for pairs in "${client_server_pairs[@]}"
 do
@@ -12,7 +12,7 @@ cat << EOF | oc create -f -
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
 kind: Benchmark
 metadata:
-  name: uperf-benchmark
+  name: uperf-benchmark-service-network
   namespace: my-ripsaw
 spec:
   elasticsearch:
@@ -57,11 +57,11 @@ sleep 30
 
 uperf_state=1
 for i in {1..240}; do
-  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
+  if [ "$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-service-network -n my-ripsaw -o jsonpath='{.items[0].status.state}')" == "Error" ]; then
     echo "Cerberus status is False, Cluster is unhealthy"
     exit 1
   fi
-  oc describe -n my-ripsaw benchmarks/uperf-benchmark | grep State | grep Complete
+  oc describe -n my-ripsaw benchmarks/uperf-benchmark-service-network | grep State | grep Complete
   if [ $? -eq 0 ]; then
           echo "UPerf Workload done"
           uperf_state=$?
@@ -75,7 +75,7 @@ if [ "$uperf_state" == "1" ] ; then
   exit 1
 fi
 
-compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
+compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-service-network -n my-ripsaw -o jsonpath='{.items[0].status.uuid}')
 if [ "${pairs}" == "1" ] ; then
   baseline_uperf_uuid=${_baseline_svc_1p_uuid}
 elif [ "${pairs}" == "2" ] ; then
@@ -92,8 +92,6 @@ fi
 
 ./run_compare.sh ${baseline_uperf_uuid} ${compare_uperf_uuid} ${pairs}
 pairs_array=( "${pairs_array[@]}" "compare_output_${pairs}p.yaml" )
-
-oc -n my-ripsaw delete benchmark/uperf-benchmark
 
 done
 

--- a/workloads/scale-perf/run_scale_fromgit.sh
+++ b/workloads/scale-perf/run_scale_fromgit.sh
@@ -3,7 +3,7 @@ set -x
 
 source ./common.sh
 
-oc -n my-ripsaw delete benchmark/scale --ignore-not-found
+oc -n my-ripsaw delete benchmark/scale --ignore-not-found --wait
 
 # Scale up/down $_runs times
 for x in $(seq 1 $_runs); do
@@ -86,8 +86,6 @@ EOF
           exit 1
         fi
       fi
-
-      oc -n my-ripsaw delete benchmark/scale --ignore-not-found --wait
 
     fi
 

--- a/workloads/storage-perf/run_storage_tests_fromgit.sh
+++ b/workloads/storage-perf/run_storage_tests_fromgit.sh
@@ -36,7 +36,7 @@ oc apply -f /tmp/ripsaw/resources/operator.yaml
 oc adm policy -n my-ripsaw add-scc-to-user privileged -z benchmark-operator
 oc adm policy -n my-ripsaw add-scc-to-user privileged -z backpack-view
 
-oc delete -n my-ripsaw benchmark/fio-benchmark
+oc delete -n my-ripsaw benchmark/fio-benchmark --wait
 sleep 30
 
 cat << EOF | oc create -n my-ripsaw -f -


### PR DESCRIPTION
This commit modifies the e2e scripts to avoid deleting the benchmark
at the end of the run to be able to capture the status of the run in
CI. The benchmark is cleaned up before kicking off a new run instead.