### PR TITLE
Setting metadata collection to be done via daemonset for serviceip

### DIFF
--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -42,6 +42,7 @@ spec:
     collection: ${_metadata_collection}
     serviceaccount: backpack-view
     privileged: true
+    targeted: false
   cerberus_url: "$CERBERUS_URL" 
   workload:
     name: uperf


### PR DESCRIPTION
The ServiceIP test was having issues due to the restricted port range. When metadata collection was done the Elasticsearch ports were not being released so port 20000 was frequently in use and would cause uperf to fail.