### PR TITLE
Add a current/desired worker count status message

### DIFF
--- a/workloads/scale-perf/run_scale_fromgit.sh
+++ b/workloads/scale-perf/run_scale_fromgit.sh
@@ -61,6 +61,9 @@ EOF
 
       scale_state=1
       for i in $(seq 1 $_timeout); do
+        current_workers=`oc get nodes -l node-role.kubernetes.io/worker= | grep -v NAME | wc -l`
+        echo "Current worker count: "${current_workers}
+        echo "Desired worker count: "${size}
         oc describe -n my-ripsaw benchmarks/scale | grep State | grep Complete
         if [ $? -eq 0 ]; then
           echo "Scaling Complete"


### PR DESCRIPTION
Adding a status message so we know what the scale is currently at and what is desired.

example output:
```
...
+ echo 'Current worker count: 3'
Current worker count: 3
+ echo 'Desired worker count: 4'
Desired worker count: 4
...
```