### PR TITLE
consume gold-index for comparison

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -17,19 +17,19 @@ $ ./run_<test-name>_network_test_fromgit.sh
 ## Environment variables
 
 ### ES_USER
-Default: `` 
+Default: ``    
 Username for elasticsearch instance
 
 ### ES_PASSWORD
-Default: `` 
+Default: ``     
 Password for elasticsearch instance
 
 ### ES_SERVER
-Default: `milton.aws.com`  
+Default: `milton.aws.com`    
 Elasticsearch server to index the results of the current run
 
 ### ES_PORT
-Default: ``  
+Default: ``    
 Port number for elasticsearch server
 
 ### METADATA_COLLECTION
@@ -37,15 +37,32 @@ Default: `true`
 Enable/Disable collection of metadata
 
 ### COMPARE
-Default: `false`   
+Default: `false`        
 Enable/Disable the ability to compare two uperf runs. If set to `true`, the next set of environment variables pertaining to the type of test are required
 
+### COMPARE_WITH_GOLD
+Default: ``     
+If COMPARE is set to true and COMPARE_WITH_GOLD is set to true then the current run will be compared against our gold-index
+Note: Make sure that elasticsearch baseline uuid (example: BASELINE_POD_1P_UUID, BASELINE_POD_2P_UUID ...) vars are not set or else it will override the uuids
+
+### GOLD_SDN
+Default: `openshiftsdn`   
+Compares the current run with gold-index with the sdn type of GOLD_SDN. Options: `openshiftsdn` and `ovnkubernetes`
+
+### GOLD_OCP_VERSION
+Default: ``     
+The openshift version you want to compare the current run to
+
+### ES_GOLD
+Default: ``     
+The ES server that houses gold-index. Format `user:pass@<es_server>:<es_port>
+
 ### ES_USER_BASELINE
-Default: `` 
+Default: ``         
 Username for elasticsearch instance
 
 ### ES_PASSWORD_BASELINE
-Default: ``
+Default: ``     
 Password for elasticsearch instance
 
 ### BASELINE_CLOUD_NAME
@@ -122,9 +139,13 @@ export ES_SERVER=
 export ES_PORT=
 export METADATA_COLLECTION=
 export COMPARE=false
+export COMPARE_WITH_GOLD=
+export GOLD_SDN=
+export GOLD_OCP_VERSION=
+export ES_GOLD=
 export BASELINE_CLOUD_NAME=
 export ES_USER_BASELINE=
-export ES_PASSWORD_BASELINE
+export ES_PASSWORD_BASELINE=
 export ES_SERVER_BASELINE=
 export ES_PORT_BASELINE=
 export BASELINE_HOSTNET_UUID=

--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -5,14 +5,6 @@ source ./common.sh
 
 pairs=(1)
 
-if [[ ${COMPARE} == "true" ]]; then
-  _baseline_hostnet_uuid=
-fi
-
-if [[ ${BASELINE_HOSTNET_UUID} ]]; then
-  _baseline_hostnet_uuid=${BASELINE_HOSTNET_UUID}
-fi
-
 oc -n my-ripsaw delete benchmark/uperf-benchmark
 
 cat << EOF | oc create -f -

--- a/workloads/network-perf/run_multus_network_tests_fromgit.sh
+++ b/workloads/network-perf/run_multus_network_tests_fromgit.sh
@@ -5,14 +5,6 @@ source ./common.sh
 
 pairs=1
 
-if [[ ${COMPARE} == "true" ]]; then
-  _baseline_multus_uuid=
-fi 
-
-if [[ ${BASELINE_MULTUS_UUID} ]]; then
-  _baseline_multus_uuid=${BASELINE_MULTUS_UUID}
-fi
-
 MULTUS=false
 if [[ ${MULTUS_CLIENT_NAD} ]]; then
   MULTUS=true

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -3,24 +3,6 @@ set -x
 
 source ./common.sh
 
-if [[ ${COMPARE} == "true" ]]; then
-  _baseline_pod_1p_uuid=
-  _baseline_pod_2p_uuid=
-  _baseline_pod_4p_uuid=
-fi
-
-if [[ ${BASELINE_POD_1P_UUID} ]]; then
-  _baseline_pod_1p_uuid=${BASELINE_POD_1P_UUID}
-fi
-
-if [[ ${BASELINE_POD_2P_UUID} ]]; then
-  _baseline_pod_2p_uuid=${BASELINE_POD_2P_UUID}
-fi
-
-if [[ ${BASELINE_POD_4P_UUID} ]]; then
-  _baseline_pod_4p_uuid=${BASELINE_POD_4P_UUID}
-fi
-
 oc -n my-ripsaw delete benchmark/uperf-benchmark
 
 for pairs in "${client_server_pairs[@]}"

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -3,24 +3,6 @@ set -x
 
 source ./common.sh
 
-if [[ ${COMPARE} == "true" ]]; then
-  _baseline_svc_1p_uuid=
-  _baseline_svc_2p_uuid=
-  _baseline_svc_4p_uuid=
-fi
-
-if [[ ${BASELINE_SVC_1P_UUID} ]]; then
-  _baseline_svc_1p_uuid=${BASELINE_SVC_1P_UUID}
-fi
-
-if [[ ${BASELINE_SVC_2P_UUID} ]]; then
-  _baseline_svc_2p_uuid=${BASELINE_SVC_2P_UUID}
-fi
-
-if [[ ${BASELINE_SVC_4P_UUID} ]]; then
-  _baseline_svc_4p_uuid=${BASELINE_SVC_4P_UUID}
-fi
-
 oc -n my-ripsaw delete benchmark/uperf-benchmark
 
 for pairs in "${client_server_pairs[@]}"

--- a/workloads/network-perf/smoke_test.sh
+++ b/workloads/network-perf/smoke_test.sh
@@ -3,24 +3,6 @@ set -x
 
 source ./common.sh
 
-if [[ ${COMPARE} == "true" ]]; then
-  _baseline_pod_1p_uuid=
-  _baseline_pod_2p_uuid=
-  _baseline_pod_4p_uuid=
-fi
-
-if [[ ${BASELINE_POD_1P_UUID} ]]; then
-  _baseline_pod_1p_uuid=${BASELINE_POD_1P_UUID}
-fi
-
-if [[ ${BASELINE_POD_2P_UUID} ]]; then
-  _baseline_pod_2p_uuid=${BASELINE_POD_2P_UUID}
-fi
-
-if [[ ${BASELINE_POD_4P_UUID} ]]; then
-  _baseline_pod_4p_uuid=${BASELINE_POD_4P_UUID}
-fi
-
 oc -n my-ripsaw delete benchmark/uperf-benchmark
 
 for pairs in "${client_server_pairs[@]}"

--- a/workloads/router-perf/README.md
+++ b/workloads/router-perf/README.md
@@ -31,6 +31,23 @@ Port number for elasticsearch server
 Default: `false`    
 Enable/Disable the ability to compare two uperf runs. If set to `true`, the next set of environment variables pertaining to the type of test are required
 
+### COMPARE_WITH_GOLD
+Default: ``     
+If COMPARE is set to true and COMPARE_WITH_GOLD is set to true then the current run will be compared against our gold-index
+Note: Make sure that elasticsearch baseline uuid (example: BASELINE_ROUTER_UUID) vars are not set or else it will override the uuids
+
+### GOLD_SDN
+Default: `you current cluster's sdn`   
+Compares the current run with gold-index with the sdn type of GOLD_SDN. Options: `openshiftsdn` and `ovnkubernetes`
+
+### GOLD_OCP_VERSION
+Default: ``     
+The openshift version you want to compare the current run to
+
+### ES_GOLD
+Default: ``     
+The ES server that houses gold-index. Format `user:pass@<es_server>:<es_port>
+
 ### ES_USER_BASELINE
 Default: ``             
 Username for elasticsearch instance


### PR DESCRIPTION
With this commit we can use gold-index for comparison. We can also manually add the uuids which will override the gold-index uuids. 
If we want to compare against gold, we need to specify the ocp version to compare against and the sdn type to compare against (defaults to cluster sdn)
Also, we need to specify the elasticsearch server where the gold-index is housed