### PR TITLE
kube-burner log streaming fix

### DIFF
--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -70,6 +70,7 @@ wait_for_benchmark() {
   until oc get benchmark -n my-ripsaw kube-burner-${1}-${UUID} -o jsonpath="{.status.state}" | grep -Eq "Complete|Failed"; do
     if [[ ${LOG_STREAMING} == "true" ]]; then
       oc logs -n my-ripsaw -f -l job-name=kube-burner-${suuid}
+      sleep 20
     fi
     sleep 1
   done


### PR DESCRIPTION
When job finishes, the log_streaming loop iterates several times (and therefore printing duplicated logs) before exiting because the benchmark hasn't been marked as Completed|Failed yet. This adds an extra time period to let benchmark-operator update it on time.


Signed-off-by: Raul Sevilla <rsevilla@redhat.com>