### PR TITLE
Etcd workload refactor

### DIFF
--- a/workloads/etcd-perf/Dockerfile
+++ b/workloads/etcd-perf/Dockerfile
@@ -1,2 +1,0 @@
-FROM registry.svc.ci.openshift.org/ocp/4.3:cli
-COPY workloads/etcd-perf/run_etcd_tests_fromgit.sh /usr/bin/run_etcd_tests_fromgit.sh

--- a/workloads/etcd-perf/README.md
+++ b/workloads/etcd-perf/README.md
@@ -1,0 +1,33 @@
+# Etcd e2e benchmark
+
+The purpose of this benchmark is to run a FIO workload to verify the host's disk meets the I/O latency requirements to run etcd safely.
+This test uses FIO to trigger an i/o benchmark that emulates an etcd workload, this is done by running several FIO samples using sync as ioengine, fdatasync and a block size of 2300 bytes.
+
+By default the FIO server pod is executed in one of the master nodes thanks to the nodeSelector and tolerations parameters, in addition, the this pod mounts a *hostPath* volume avoid the *overlayfs* layer. 
+
+Once the benchmark is finished, the highest latency obtained from the executed FIO samples is compared with the latency threshold configured by *LATENCY_TH* (10 ms by default), exiting with RC=1 if higher.
+ 
+## Environment variables
+
+All scripts can be tweaked with the following environment variables:
+
+| Variable             | Description                         | Default |
+|----------------------|-------------------------------------|---------|
+| **ES_SERVER**        | Elastic search endpoint         | https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com|
+| **ES_INDEX**         | Elastic search index            | ripsaw-fio-results |
+| **METADATA_COLLECTION**    | Enable metadata collection | true |
+| **LOG_STREAMING**    | Enable log streaming of FIO client pod | true |
+| **TOLERATIONS**      | FIO server pod tolerations | `[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule", "operator": "Exists"}]` |
+| **NODE_SELECTOR**    | FIO server pod node selector | `{"node-role.kubernetes.io/master": ""}` |
+| **CLOUD_NAME**       | cloud_name field | test_cloud |
+| **TEST_USER**        | test_user field | test_cloud-etcd |
+| **FILE_SIZE**        | FIO File size | 50MiB |
+| **SAMPLES**          | FIO samples | 5 |
+| **LATENCY_TH**       | Latency threshold in ns | 10000000 |
+
+**Note**: You can use basic authentication when indexing in ES using the notation `http(s)://[username]:[password]@[address]` in **ES_SERVER**.
+
+## Configuration file
+
+An [env.sh](env.sh) file is provided with all the available configuration parameters.
+

--- a/workloads/etcd-perf/README.md
+++ b/workloads/etcd-perf/README.md
@@ -24,6 +24,8 @@ All scripts can be tweaked with the following environment variables:
 | **FILE_SIZE**        | FIO File size | 50MiB |
 | **SAMPLES**          | FIO samples | 5 |
 | **LATENCY_TH**       | Latency threshold in ns | 10000000 |
+| **OPERATOR_REPO**    | benchmark-operator repo   | https://github.com/cloud-bulldozer/benchmark-operator.git |
+| **OPERATOR_BRANCH**  | benchmark-operator branch                     | master  |
 
 **Note**: You can use basic authentication when indexing in ES using the notation `http(s)://[username]:[password]@[address]` in **ES_SERVER**.
 

--- a/workloads/etcd-perf/common.sh
+++ b/workloads/etcd-perf/common.sh
@@ -1,0 +1,77 @@
+OPERATOR_REPO=https://github.com/cloud-bulldozer/benchmark-operator.git
+CURL_BODY='{"_source": false, "aggs": {"max-fsync-lat-99th": {"max": {"field": "fio.sync.lat_ns.percentile.99.000000"}}}}'
+
+export TERM=screen-256color
+export METADATA_COLLECTION=${METADATA_COLLECTION:-true}
+export ES_SERVER=${ES_SERVER:-https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com}
+export ES_INDEX=${ES_INDEX:-ripsaw-fio-results}
+export TOLERATIONS='[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule", "operator": "Exists"}]'
+export NODE_SELECTOR='{"node-role.kubernetes.io/master": ""}'
+export LOG_STREAMING=${LOG_STREAMING:-true}
+export CLOUD_NAME=${CLOUD_NAME:-test_cloud}
+export TEST_USER=${TEST_USER:-test_cloud-etcd}
+export FILE_SIZE=${FILE_SIZE:-50MiB}
+export SAMPLES=${SAMPLES:-5}
+export LATENCY_TH=${LATENCY_TH:-10000000}
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+
+log() {
+  echo ${bold}$(date "+%d-%m-%YT%H:%M:%S") ${@}${normal}
+}
+
+deploy_operator() {
+  log "Cloning benchmark-operator from ${OPERATOR_REPO}"
+  rm -rf benchmark-operator
+  git clone ${OPERATOR_REPO} --depth 1
+  log "Deploying benchmark-operator"
+  oc apply -f benchmark-operator/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
+  oc apply -f benchmark-operator/resources/namespace.yaml
+  oc apply -f benchmark-operator/resources/backpack_role.yaml
+  oc apply -f benchmark-operator/deploy
+  oc adm policy add-scc-to-user -n my-ripsaw privileged -z benchmark-operator
+  oc adm policy add-scc-to-user -n my-ripsaw privileged -z backpack-view
+  oc apply -f benchmark-operator/resources/operator.yaml
+  log "Waiting for benchmark-operator to be available"
+  oc wait --for=condition=available -n my-ripsaw deployment/benchmark-operator --timeout=180s
+}
+
+deploy_workload() {
+  oc delete benchmark -n my-ripsaw etcd-fio --ignore-not-found
+  log "Deploying FIO benchmark"
+  envsubst < fio-etcd-crd.yaml | oc apply -f -
+}
+
+wait_for_benchmark() {
+  rc=0
+  log "Waiting for FIO job to be created"
+  until oc get benchmark -n my-ripsaw etcd-fio -o jsonpath="{.status.state}" | grep -q Running; do
+    sleep 1
+  done
+  log "Waiting for etcd-fio job to start"
+  suuid=$(oc get benchmark -n my-ripsaw etcd-fio  -o jsonpath="{.status.suuid}")
+  until oc get pod -n my-ripsaw -l job-name=fio-client-${suuid} --ignore-not-found -o jsonpath="{.items[*].status.phase}" | grep -q Running; do
+    sleep 1
+  done
+  log "Benchmark in progress"
+  until oc get benchmark -n my-ripsaw etcd-fio -o jsonpath="{.status.state}" | grep -Eq "Complete|Failed"; do
+    if [[ ${LOG_STREAMING} == "true" ]]; then
+      oc logs -n my-ripsaw -f -l job-name=fio-client-${suuid}
+      sleep 20
+    fi
+    sleep 1
+  done
+  uuid=$(oc get benchmark -n my-ripsaw etcd-fio -o jsonpath="{.status.uuid}")
+}
+
+
+verify_fsync_latency() {
+  log "Verifying max fsync latency < ${LATENCY_TH} ns"
+  fsync_lat=$(curl -Ss ${ES_SERVER}/${ES_INDEX}/_search?q=uuid:${uuid} -H "Content-Type: application/json" -d "${CURL_BODY}" | python -c 'import sys,json;print(int(json.loads(sys.stdin.read())["aggregations"]["max-fsync-lat-99th"]["value"]))')
+  log "Max observed latency across ${SAMPLES} samples: ${fsync_lat} ns"
+  if [[ ${fsync_lat} -gt ${LATENCY_TH} ]]; then
+    log "FSync latency greater than the configured threshold: ${latency_th} ns"
+    rc=1
+  fi
+}

--- a/workloads/etcd-perf/common.sh
+++ b/workloads/etcd-perf/common.sh
@@ -1,4 +1,5 @@
-OPERATOR_REPO=https://github.com/cloud-bulldozer/benchmark-operator.git
+OPERATOR_REPO=${OPERATOR_REPO:=https://github.com/cloud-bulldozer/benchmark-operator.git}
+OPERATOR_BRANCH=${OPERATOR_BRANCH:=master}
 CURL_BODY='{"_source": false, "aggs": {"max-fsync-lat-99th": {"max": {"field": "fio.sync.lat_ns.percentile.99.000000"}}}}'
 
 export TERM=screen-256color
@@ -24,7 +25,7 @@ log() {
 deploy_operator() {
   log "Cloning benchmark-operator from ${OPERATOR_REPO}"
   rm -rf benchmark-operator
-  git clone ${OPERATOR_REPO} --depth 1
+  git clone --single-branch --branch ${OPERATOR_BRANCH} ${OPERATOR_REPO} --depth 1
   log "Deploying benchmark-operator"
   oc apply -f benchmark-operator/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
   oc apply -f benchmark-operator/resources/namespace.yaml

--- a/workloads/etcd-perf/env.sh
+++ b/workloads/etcd-perf/env.sh
@@ -1,0 +1,16 @@
+
+# Benchmark-operator
+export METADATA_COLLECTION=true
+export ES_SERVER=https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
+export ES_INDEX=ripsaw-fio-results
+export TOLERATIONS='[{"key": "node-role.kubernetes.io/master", "effect": "NoSchedule", "operator": "Exists"}]'
+export NODE_SELECTOR='{"node-role.kubernetes.io/master": ""}'
+export CLOUD_NAME=test_cloud
+export TEST_USER=test_cloud-etcd
+
+
+# Workload 
+export LOG_STREAMING=true
+export FILE_SIZE=50MiB
+export SAMPLES=5
+export LATENCY_TH=10000000

--- a/workloads/etcd-perf/fio-etcd-crd.yaml
+++ b/workloads/etcd-perf/fio-etcd-crd.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: my-ripsaw
 spec:
   elasticsearch:
-    server: ${ES_SERVER}
+    url: ${ES_SERVER}
   clustername: ${CLOUD_NAME}
   test_user: ${TEST_USER}
   metadata:

--- a/workloads/etcd-perf/fio-etcd-crd.yaml
+++ b/workloads/etcd-perf/fio-etcd-crd.yaml
@@ -1,0 +1,35 @@
+apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
+kind: Benchmark
+metadata:
+  name: etcd-fio
+  namespace: my-ripsaw
+spec:
+  elasticsearch:
+    server: ${ES_SERVER}
+  clustername: ${CLOUD_NAME}
+  test_user: ${TEST_USER}
+  metadata:
+    collection: ${METADATA_COLLECTION}
+    serviceaccount: backpack-view
+    privileged: true
+  hostpath: /var/lib/etcd/fio-etcd
+  workload:
+    name: fio_distributed
+    args:
+      tolerations: ${TOLERATIONS}
+      nodeselector: ${NODE_SELECTOR}
+      iodepth: 1
+      log_sample_rate: 1000
+      samples: ${SAMPLES}
+      servers: 1
+      jobs:
+      - write
+      bs:
+      - 2300
+      numjobs:
+      - 1
+      filesize: ${FILE_SIZE}
+  global_overrides:
+    - fdatasync=1
+    - ioengine=sync
+    - direct=0

--- a/workloads/etcd-perf/run_etcd_tests_fromgit.sh
+++ b/workloads/etcd-perf/run_etcd_tests_fromgit.sh
@@ -1,94 +1,15 @@
-#!/usr/bin/env bash
-set -x
+#!/usr/bin/bash -eu
 
-trap "rm -rf /tmp/benchmark-operator" EXIT
-_es=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
-latency_th=${LATENCY_TH:-10000000}
-index=ripsaw-fio-results
-curl_body='{"_source": false, "aggs": {"max-fsync-lat-99th": {"max": {"field": "fio.sync.lat_ns.percentile.99.000000"}}}}'
+set -eu
 
-if [ ! -z ${2} ]; then
-  export KUBECONFIG=${2}
+. common.sh
+
+deploy_operator
+deploy_workload
+wait_for_benchmark
+if [[ ${rc} == 1 ]] ; then
+  log "Workload failed"
+  exit ${rc}
 fi
-
-cloud_name=$1
-if [ "$cloud_name" == "" ]; then
-  cloud_name="test_cloud"
-fi
-
-echo "Starting test for cloud: $cloud_name"
-
-rm -rf /tmp/benchmark-operator
-
-oc create ns my-ripsaw
-oc create ns backpack
-
-git clone http://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator --depth 1
-oc apply -f /tmp/benchmark-operator/deploy
-oc apply -f /tmp/benchmark-operator/resources/backpack_role.yaml
-oc apply -f /tmp/benchmark-operator/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml
-oc apply -f /tmp/benchmark-operator/resources/operator.yaml
-
-oc adm policy add-scc-to-user -n my-ripsaw privileged -z benchmark-operator
-oc adm policy add-scc-to-user -n my-ripsaw privileged -z backpack-view
-
-cat << EOF | oc create -n my-ripsaw -f -
-apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
-kind: Benchmark
-metadata:
-  name: etcd-fio
-  namespace: my-ripsaw
-spec:
-  elasticsearch:
-    url: ${_es}
-  clustername: ${cloud_name}
-  test_user: ${cloud_name}-ci
-  metadata:
-    collection: true
-    serviceaccount: backpack-view
-    privileged: true
-  hostpath: /var/lib/fio-etcd
-  workload:
-    name: fio_distributed
-    args:
-      iodepth: 1
-      log_sample_rate: 1000
-      samples: 5
-      servers: 1
-      jobs:
-        - write
-      bs:
-        - 2300
-      numjobs:
-        - 1
-      filesize: 22Mib
-  global_overrides:
-    - fdatasync=1
-    - ioengine=sync
-    - direct=0
-EOF
-
-fio_state=1
-for i in {1..60}; do
-  if [[ $(oc get benchmark -n my-ripsaw etcd-fio -o jsonpath='{.status.complete}') == true ]]; then
-    echo "FIO Workload done"
-    fio_state=$?
-    uuid=$(oc get benchmark -n my-ripsaw etcd-fio -o jsonpath="{.status.uuid}")
-    break
-  fi
-  sleep 30
-done
-
-if [ "$fio_state" == "1" ] ; then
-  echo "Workload failed"
-  exit 1
-fi
-
-fsync_lat=$(curl -s ${_es}/${index}/_search?q=uuid:${uuid} -H "Content-Type: application/json" -d "${curl_body}" | python -c 'import sys,json;print(int(json.loads(sys.stdin.read())["aggregations"]["max-fsync-lat-99th"]["value"]))')
-echo "Max 99th fsync latency observed: ${fsync_lat} ns"
-if [[ ${fsync_lat} -gt ${latency_th} ]]; then
-  echo "Latency greater than configured threshold: ${latency_th} ns"
-  exit 1
-fi
-
-exit 0
+verify_fsync_latency
+exit ${rc}


### PR DESCRIPTION
Changes:
- Added documentation
- Using nodeSelector. Default to run in master nodes
- Using tolerations. It tolerates default master node taints
- Improved stdout and error handling

Output example:
![image](https://user-images.githubusercontent.com/4614641/98839852-5c502900-2446-11eb-8d2d-2c8d0238da97.png)
```
rsevilla@wonderland ~/labs/cloud-bulldozer/plow/workloads/etcd-perf (etcd-workload-refactor) $ oc get node ip-10-0-212-9.us-west-2.compute.internal
NAME                                       STATUS   ROLES    AGE   VERSION
ip-10-0-212-9.us-west-2.compute.internal   Ready    master   25h   v1.19.0+d59ce34
```

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>