### PR TITLE
Fix running kube-burner benchmark

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -12,8 +12,8 @@ All scripts can be tweaked with the following environment variables:
 
 | Variable         | Description                         | Default |
 |------------------|-------------------------------------|---------|
-| **QPS**              | Queries/sec                     | 10      |
-| **BURST**            | Burst queries                   | 10      |
+| **QPS**              | Queries/sec                     | 20      |
+| **BURST**            | Burst queries                   | 20      |
 | **ES_SERVER**        | Elastic search endpoint         | https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com|
 | **ES_PORT**          | Elastic search port             | 443 |
 | **ES_INDEX**         | Elastic search index            | ripsaw-kube-burner|

--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -44,7 +44,8 @@ Each iteration creates the following objects:
 - 2 deployments with 1 pod replicas (sleep) mounting two secrets. deployment-1pod
 - 3 services, one pointing to deployment-2pod, and other two pointing to deployment-1pod
 - 3 route. 1 pointing to the service deployment-2pod and other two pointing to deployment-1pod
-- 20 secrets
+- 10 secrets. 2 of them mounted by the previous deployments.
+- 10 configMaps. 2 of them mounted by the previous deployments.
 
 
 ### kubelet-density and kubelet-density-heavy variables

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -1,7 +1,7 @@
 export METADATA_COLLECTION=${METADATA_COLLECTION:-true}
 export CERBERUS_URL=${CERBERUS_URL}
-export QPS=${QPS:-10}
-export BURST=${BURST:-10}
+export QPS=${QPS:-20}
+export BURST=${BURST:-20}
 export ES_SERVER=${ES_SERVER:-https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com}
 export ES_PORT=${ES_PORT:-443}
 export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
@@ -83,6 +83,7 @@ wait_for_benchmark() {
   if [[ ${status} == "Failed" ]]; then
     rc=1
   fi
+  oc get benchmark -n my-ripsaw
 }
 
 label_nodes() {
@@ -126,9 +127,10 @@ unlabel_nodes() {
 }
 
 check_running_benchmarks() {
-  benchmarks=$(oc get benchmark -n my-ripsaw --ignore-not-found | grep -vE "Failed|Complete" | wc -l)
+  benchmarks=$(oc get benchmark -n my-ripsaw | awk '{ if ($2 == "kube-burner")print}'| grep -vE "Failed|Complete" | wc -l)
   if [[ ${benchmarks} -gt 1 ]]; then
     log "Another kube-burner benchmark is running at the moment" && exit 1
+    oc get benchmark -n my-ripsaw
   fi
 }
 

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -1,7 +1,7 @@
 
 # Common
-export QPS=10
-export BURST=10
+export QPS=20
+export BURST=20
 export ES_SERVER=https://search-cloud-perf-lqrf3jjtaqo7727m7ynd2xyt4y.us-west-2.es.amazonaws.com
 export ES_PORT=443
 export ES_INDEX=ripsaw-kube-burner


### PR DESCRIPTION
The current implementation doesn't verify if a running benchmark is of the kind kube-burner.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>