### PR TITLE
Add export to fix indexing issue

### DIFF
--- a/workloads/upgrade-perf/common.sh
+++ b/workloads/upgrade-perf/common.sh
@@ -76,9 +76,9 @@ python3 -m venv upgrade
 source upgrade/bin/activate
 pip3 install -e /tmp/snafu
 
-es_index="openshift-upgrade-timings"
-es=${_es}
-es_port=${_es_port}
+export es_index="openshift-upgrade-timings"
+export es=${_es}
+export es_port=${_es_port}
 _init_version=`oc get clusterversions.config.openshift.io | grep version | awk '{print $2}'`
 
 echo "Starting upgrade test for:"


### PR DESCRIPTION
The upgrade was not properly passing the ES index/port/server information to snafu. Adding the export in front of the variable definition resolves the issue.