### PR TITLE
adding ns to oc command

### DIFF
--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -131,7 +131,7 @@ deploy_workload() {
 check_logs_for_errors() {
 client_pod=$(oc get pods -n my-ripsaw --no-headers | awk '{print $1}' | grep uperf-client | awk 'NR==1{print $1}')
 if [ ! -z "$client_pod" ]; then
-  num_critical=$(oc logs ${client_pod} | grep CRITICAL | wc -l)
+  num_critical=$(oc logs ${client_pod} -n my-ripsaw | grep CRITICAL | wc -l)
   if [ $num_critical -gt 3 ] ; then
     log "Encountered CRITICAL condition more than 3 times in uperf-client logs"
     log "Log dump of uperf-client pod"


### PR DESCRIPTION
https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/RIPSAW-UPERF/263/console
avoids 
```
Thu Dec 3 15:09:09 UTC 2020: Current status of the uperf hostnet benchmark with 1 pair/s is Running
Error from server (NotFound): pods "uperf-client-10.0.128.214-885cd499-89l8b" not found
```