### PR TITLE
Compare and gen CSV only when COMPARE is true

### DIFF
--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -190,7 +190,8 @@ assign_uuid() {
 }
 
 run_benchmark_comparison() {
-  ../run_compare.sh ${baseline_uperf_uuid} ${compare_uperf_uuid} ${pairs}
+  source ../run_compare.sh
+  compare uperf "${baseline_uperf_uuid}" "${compare_uperf_uuid}" "${1}"
   pairs_array=( "${pairs_array[@]}" "compare_output_${pairs}p.yaml" )
 }
 

--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -9,7 +9,7 @@ wait_for_benchmark
 assign_uuid
 delete_benchmark
 if [[ ${COMPARE} == "true" ]]; then
-  run_benchmark_comparison
-  generate_csv
+  run_benchmark_comparison compare_output_${pairs}.yaml
+  generate_csv compare_output_${pairs}.yaml
 fi
 print_uuid

--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -7,7 +7,9 @@ export pairs=1
 deploy_workload
 wait_for_benchmark
 assign_uuid
-run_benchmark_comparison
 delete_benchmark
+if [[ ${COMPARE} == "true" ]]; then
+  run_benchmark_comparison
+  generate_csv
+fi
 print_uuid
-generate_csv

--- a/workloads/network-perf/run_multus_network_tests_fromgit.sh
+++ b/workloads/network-perf/run_multus_network_tests_fromgit.sh
@@ -3,7 +3,7 @@ set -x
 
 source ./common.sh
 
-pairs=1
+pairs={$PAIR:-1}
 
 MULTUS=false
 if [[ ${MULTUS_CLIENT_NAD} ]]; then
@@ -13,9 +13,6 @@ if [[ ${MULTUS_SERVER_NAD} ]]; then
   MULTUS=true
 fi
 
-if [[ ${PAIR} ]]; then
-  pairs=${PAIR}
-fi
 
 if ${MULTUS} ; then
 oc -n my-ripsaw delete benchmark/uperf-benchmark-multus-network --wait
@@ -99,17 +96,15 @@ compare_uperf_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-
 baseline_uperf_uuid=${_baseline_multus_uuid}
 
 if [[ ${COMPARE} == "true" ]]; then
+  run_benchmark_comparison compare_output_${pairs}.yaml
   echo ${baseline_uperf_uuid},${compare_uperf_uuid} >> uuid.txt
 else
   echo ${compare_uperf_uuid} >> uuid.txt
 fi
 
-../run_compare.sh ${baseline_uperf_uuid} ${compare_uperf_uuid} ${pairs}
-pairs_array=( "${pairs_array[@]}" "compare_output_${pairs}p.yaml" )
+run_benchmark_comparison compare_output_${pairs}.yaml
+generate_csv compare_output_${pairs}.yaml
 
-python3 csv_gen.py --files $(echo "${pairs_array[@]}") --latency_tolerance=$latency_tolerance --throughput_tolerance=$throughput_tolerance
-
-fi
 
 # Cleanup
 rm -rf /tmp/ripsaw

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -9,11 +9,12 @@ for pairs in 1 2 4; do
   wait_for_benchmark
   assign_uuid
   if [[ ${COMPARE} == "true" ]]; then
-    run_benchmark_comparison
+    comparison_files=+="compare_output_${pairs}.yaml "
+    run_benchmark_comparison compare_output_${pairs}.yaml
   fi
   delete_benchmark
 done
 print_uuid
 if [[ ${COMPARE} == "true" ]]; then
-  generate_csv
+  generate_csv ${comparison_files}
 fi

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -8,8 +8,12 @@ for pairs in 1 2 4; do
   deploy_workload
   wait_for_benchmark
   assign_uuid
-  run_benchmark_comparison
+  if [[ ${COMPARE} == "true" ]]; then
+    run_benchmark_comparison
+  fi
   delete_benchmark
 done
 print_uuid
-generate_csv
+if [[ ${COMPARE} == "true" ]]; then
+  generate_csv
+fi

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -9,11 +9,12 @@ for pairs in 1 2 4; do
   wait_for_benchmark
   assign_uuid
   if [[ ${COMPARE} == "true" ]]; then
-    run_benchmark_comparison
+    comparison_files=+="compare_output_${pairs}.yaml "
+    run_benchmark_comparison compare_output_${pairs}.yaml
   fi
   delete_benchmark
 done
 print_uuid
 if [[ ${COMPARE} == "true" ]]; then
-  generate_csv
+  generate_csv ${comparison_files}
 fi

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -8,8 +8,12 @@ for pairs in 1 2 4; do
   deploy_workload
   wait_for_benchmark
   assign_uuid
-  run_benchmark_comparison
+  if [[ ${COMPARE} == "true" ]]; then
+    run_benchmark_comparison
+  fi
   delete_benchmark
 done
 print_uuid
-generate_csv
+if [[ ${COMPARE} == "true" ]]; then
+  generate_csv
+fi

--- a/workloads/router-perf/run_router_test.sh
+++ b/workloads/router-perf/run_router_test.sh
@@ -75,6 +75,7 @@ else
   echo ${compare_router_uuid} >> uuid.txt
 fi
 
-../run_compare.sh ${baseline_router_uuid} ${compare_router_uuid} mb
+. ../run_compare.sh
+compare mb "${baseline_router_uuid}" "${compare_router_uuid}" router_compare.yaml
 
-python3 csv_gen.py --files compare.yaml
+python3 csv_gen.py --files router_compare.yaml

--- a/workloads/run_compare.sh
+++ b/workloads/run_compare.sh
@@ -1,37 +1,22 @@
 #!/usr/bin/env bash
-datasource="elasticsearch"
-tool="mb"
-_es=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
-_es_baseline=${ES_SERVER_BASELINE:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 
-if [[ ${COMPARE} != "true" ]]; then
-  compare_uuid=$1
-else
-  base_uuid=$1
-  compare_uuid=$2
-fi
-
-python3 -m venv ./venv
-source ./venv/bin/activate
-pip3 install git+https://github.com/cloud-bulldozer/touchstone
-
-if [[ $? -ne 0 ]] ; then
-  echo "Unable to execute compare - Failed to install touchstone"
-  exit 1
-fi
-
-set -x
-if [[ ${!#} == "mb" ]]; then
-  touchstone_compare mb elasticsearch ripsaw -url $_es $_es_baseline -u $compare_uuid $base_uuid -o yaml | tee compare.yaml
-else
-  touchstone_compare uperf elasticsearch ripsaw -url $_es $_es_baseline -u $compare_uuid $base_uuid -o yaml | tee compare_output_${!#}p.yaml
-fi
-set +x
-
-if [[ $? -ne 0 ]] ; then
-  echo "Unable to execute compare - Failed to run touchstone"
-  exit 1
-fi
-
-deactivate
-rm -rf venv
+compare(){
+  local benchmark=${1}
+  local base_uuid=${2}
+  local compare_uuid=${3}
+  local output_file=${4}
+  python3 -m venv ./venv
+  source ./venv/bin/activate
+  pip3 install git+https://github.com/cloud-bulldozer/touchstone
+  if [[ $? -ne 0 ]] ; then
+    echo "Unable to execute compare - Failed to install touchstone"
+    exit 1
+  fi
+  touchstone_compare ${benchmark} elasticsearch ripsaw -url ${ES_SERVER} ${ES_SERVER_BASELINE} -u ${base_uuid} ${compare_uuid} -o yaml | tee ${output_file}
+  if [[ $? -ne 0 ]] ; then
+    echo "Unable to execute compare - Failed to run touchstone"
+    exit 1
+  fi
+  deactivate
+  rm -rf venv
+}


### PR DESCRIPTION
The current implementation doesn't allow to run uperf w/o comparing or generating CSV, we should to be able to generate a CSV w/o needing a baseline UUID in the future. That should  be addressed in a different patch.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>