### PR TITLE
add metadata.targeted; set it false for serviceip

### DIFF
--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -31,6 +31,7 @@ export_defaults() {
   export _es=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
   _es_baseline=${ES_SERVER_BASELINE:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
   export _metadata_collection=${METADATA_COLLECTION:=true}
+  export _metadata_targeted=true
   COMPARE=${COMPARE:=false}
   gold_sdn=${GOLD_SDN:=openshiftsdn}
   throughput_tolerance=${THROUGHPUT_TOLERANCE:=5}
@@ -52,6 +53,7 @@ export_defaults() {
     export serviceip=false
   elif [ ${WORKLOAD} == "service" ]
   then
+    export _metadata_targeted=false
     export hostnetwork=false
     export serviceip=true
   else

--- a/workloads/network-perf/ripsaw-uperf-crd.yaml
+++ b/workloads/network-perf/ripsaw-uperf-crd.yaml
@@ -14,6 +14,7 @@ spec:
     collection: ${_metadata_collection}
     serviceaccount: backpack-view
     privileged: true
+    targeted: ${_metadata_targeted}
   cerberus_url: "$CERBERUS_URL"
   workload:
     name: uperf


### PR DESCRIPTION
there have been clashes for the limited open ports (20000-20011)
this commit enables backpack daemonset mode for serviceip so that we don't see any clashes 