### PR TITLE
Substract kube-burner pod from the node-density pod count

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -21,7 +21,7 @@ All scripts can be tweaked with the following environment variables:
 | **PROM_URL**         | Prometheus endpoint         | https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091|
 | **JOB_TIMEOUT**      | kube-burner's job timeout, in seconds      | 17500 |
 | **POD_READY_TIMEOUT**| Timeout for kube-burner and benchmark-operator pods to be running | 1200 |
-| **WORKLOAD_NODE**    | Workload node name              | "" (don't pin kube-burner to any server)|
+| **WORKLOAD_NODE**    | Workload node selector          | {"node-role.kubernetes.io/worker": ""} |
 | **CERBERUS_URL**     | URL to check the health of the cluster using [Cerberus](https://github.com/openshift-scale/cerberus) | "" (don't check)|
 | **STEP_SIZE**        | Prometheus step size, useful for long benchmarks | 30s|
 | **METRICS_PROFILE**        | Metric profile that indicates what prometheus metrics kube-burner will collect, accepts __metrics.yaml__ or __metrics-aggregated.yaml__ | metrics.yaml for node-density workloads and metrics-aggregated.yaml for cluster-density workloads |

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -112,7 +112,13 @@ label_nodes() {
     pods=$(oc describe ${n} | awk '/Non-terminated/{print $3}' | sed "s/(//g")
     pod_count=$((pods + pod_count))
   done
-  total_pod_count=$((PODS_PER_NODE * NODE_COUNT - pod_count))
+  if [[ -z ${WORKLOAD_NODE} ]]; then
+    # Number of pods to deploy per node * number of labeled nodes - pods running - kube-burner pod
+    total_pod_count=$((PODS_PER_NODE * NODE_COUNT - pod_count -1))
+  else
+    # Number of pods to deploy per node * number of labeled nodes - pods running
+    total_pod_count=$((PODS_PER_NODE * NODE_COUNT - pod_count))
+  fi
   log "Total running pods across nodes: ${pod_count}"
   if [[ ${total_pod_count} -le 0 ]]; then
     log "Number of pods to deploy <= 0"

--- a/workloads/kube-burner/kube-burner-crd.yaml
+++ b/workloads/kube-burner/kube-burner-crd.yaml
@@ -33,7 +33,7 @@ spec:
       # Number of job iterations
       job_iterations: ${JOB_ITERATIONS}
       # Pin kube-burner to a node using the value of the label kubernetes.io/hostname
-      pin_server: ${PIN_SERVER}
+      pin_server: ${WORKLOAD_NODE}
       # Wait for pods to be runnig before finishing kube-burner workload
       wait_when_finished: ${WAIT_WHEN_FINISHED}
       # Wait for all pods to be running before moving forward to the next job iteration


### PR DESCRIPTION
We're not counting the kube-burner pod itself when calculating the number of pods to deploy. This is generating issues since this pod can't be scheduled, thus kube-burner times out waiting for it to be ready.

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>