### PR TITLE
Add support to upgrade to the latest version

### DIFF
--- a/workloads/upgrade-perf/README.md
+++ b/workloads/upgrade-perf/README.md
@@ -13,12 +13,19 @@ $ ./run_<test-name>_fromgit.sh
 
 ### VERSION
 Default: ''
-The target version of the cluster. THIS IS A REQUIRED VARIABLE
+The version to upgrade to. The version must be on the list of previous or available updates.
 
-## TOIMAGE
+### TOIMAGE
 Default: ''
-This is an optional location of an image to upgrade to. If set you will STILL need to assign
-the VERSION variable as well to match what the end result will be.
+This is an optional location of an image to upgrade to.
+
+### LATEST
+Default: ''
+Upgrades to the latest version available in the channel when set to true.
+
+### CHANNEL
+Channel to set for the upgrade to find the image to upgrade to, they can found at https://github.com/openshift/cincinnati-graph-data/blob/master/channels/. 
+The channel set on the cluster is not tweaked if this variable is not set.
 
 ### POLL_INTERVAL
 Default: 5

--- a/workloads/upgrade-perf/common.sh
+++ b/workloads/upgrade-perf/common.sh
@@ -16,13 +16,6 @@ _poll_interval=${POLL_INTERVAL:=5}
 COMPARE=${COMPARE:=false}
 _timeout=${TIMEOUT:=240}
 
-if [[ -n $VERSION ]]; then
-  _version=${VERSION}
-else
-  echo "Desired version not set. Exiting"
-  exit 1
-fi
-
 if [[ -n $UUID ]]; then
   _uuid=${UUID}
 else
@@ -76,6 +69,18 @@ echo "Target version: $_version"
 echo "Current version $_init_version"
 echo "UUID: $_uuid"
 
-if [[ -n $TOIMAGE ]]; then
+# fail if the version to upgrade to is not set
+if [[ -z $TOIMAGE ]] && [[ -z $LATEST ]] && [[ -z $VERSION ]]; then
+  echo "Looks like the version to upgrade to is not set, please set either TOIMAGE, LATEST or VERSION environment vars"
+  exit 1
+fi
+
+# fail if both TOIMAGE and LATEST vars are set to make sure the correct version is picked to upgrade to
+if [[ -n $TOIMAGE ]] && [[ -n $LATEST ]]; then
+  echo "Looks like both TOIMAGE and LATEST vars are set, please select one of the options"
+  exit 1
+elif [[ -n $TOIMAGE ]]; then
   echo "To-Image: $TOIMAGE"
+elif [[ -n $LATEST ]]; then
+  echo "LATEST option is set, upgrading to the latest version available in the channel"
 fi


### PR DESCRIPTION
This commit:
- Adds an option to upgrade to the latest version available
  in the channel when set.
- Adds support to switch the channel to find the builds for
  the upgrade.