### PR TITLE
Add support to upgrade to OCP nightly builds

### DIFF
--- a/workloads/upgrade-perf/README.md
+++ b/workloads/upgrade-perf/README.md
@@ -24,7 +24,8 @@ Default: ''
 Upgrades to the latest version available in the channel when set to true.
 
 ### CHANNEL
-Channel to set for the upgrade to find the image to upgrade to, they can found at https://github.com/openshift/cincinnati-graph-data/blob/master/channels/. 
+Channel to set for the upgrade to find the image to upgrade to, they can found at https://github.com/openshift/cincinnati-graph-data/blob/master/channels/.
+Set CHANNEL=nightlies in case of upgrading to nightly builds which are not part of the upgrade path in cincinnati.
 The channel set on the cluster is not tweaked if this variable is not set.
 
 ### POLL_INTERVAL

--- a/workloads/upgrade-perf/run_upgrade_fromgit.sh
+++ b/workloads/upgrade-perf/run_upgrade_fromgit.sh
@@ -6,7 +6,11 @@ source ./common.sh
 # set the channel to find the builds to upgrade to
 if [[ -n $CHANNEL ]]; then
   echo "Setting the upgrade channel to $CHANNEL"
-  oc patch clusterversion/version -p '{"spec":{"channel":"'$CHANNEL'"}}' --type=merge
+  if [[ "$CHANNEL" == "nightlies" ]]; then
+    oc patch clusterversion version --type json -p '[{"op": "add", "path": "/spec/upstream", "value": "https://amd64.ocp.releases.ci.openshift.org/graph"}, {"op": "add", "path": "/spec/channel", "value": "nightly"}]'
+  else
+    oc patch clusterversion version -p '{"spec":{"channel":"'$CHANNEL'"}}' --type=merge
+  fi
 else
   echo "Using the default upgrade channel set on the cluster for the upgrades"
 fi


### PR DESCRIPTION
This commit enables to track the upstream channel for nightly OpenShift
builds which are not part of the upgrade path tracked in cincinnati since
it has only the GA builds.
