### PR TITLE
Provide prereqs for Python code for router-perf-v2

### DIFF
--- a/workloads/router-perf-v2/README.md
+++ b/workloads/router-perf-v2/README.md
@@ -27,6 +27,7 @@ Apart from the k8s/oc clients, running this script has several requirements:
 
 - jq
 - podman
+- pip install -r requirements.txt
 
 ## Configuration
 It's possible to tune the default configuration through environment variables. They are described in the table below:

--- a/workloads/router-perf-v2/csv_gen.py
+++ b/workloads/router-perf-v2/csv_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 import yaml
 from collections import defaultdict
 import csv

--- a/workloads/router-perf-v2/requirements.txt
+++ b/workloads/router-perf-v2/requirements.txt
@@ -1,0 +1,6 @@
+PyYAML
+oauth2client>=4.1.3
+gspread
+gspread-formatting
+numpy
+elasticsearch


### PR DESCRIPTION
Provide an easy way to install pre-reqs for workload.py and csv_gen.py.

Additionally, update csv_gen.py to not rely on system python3 in case user is running in a virtualenv

Fixes #140 

@rsevilla87 @mohit-sheth PTAL

