### PR TITLE
Fix env.sh to accept parameters for NODE_COUNT and PODS_PER_NODE

### DIFF
--- a/ci/env.sh
+++ b/ci/env.sh
@@ -11,8 +11,8 @@ export RUNS=1
 export JOB_ITERATIONS=3
 export CLEANUP=true
 export CLEANUP_WHEN_FINISH=true
-export NODE_COUNT=1
-export PODS_PER_NODE=100
+export NODE_COUNT=${NODE_COUNT:-1}
+export PODS_PER_NODE=${PODS_PER_NODE:-100}
 
 #for upgrade perf
 export VERSION=`oc get clusterversion | grep -o [0-9.]* | head -1`


### PR DESCRIPTION
# Description

I and @mffiedler were trying to run node-density tests in our CI. When we ran it in the CI we saw that it was defaulting to 1 node and 100 pods all the time. After much of debugging I saw it was changed recently in this commit https://github.com/cloud-bulldozer/e2e-benchmarking/pull/144/commits/3f306b639034372d3cae155114f3be9f8ba7959b 

We think it is a parameter we would certainly want to modify in our end of the environments. 

Fixes # (issue)

To address above issue, the fix is to source the values from env vars for these parameters, and then set to default to default values, if env vars are not set.


@rsevilla87 @mohit-sheth @chaitanyaenr  kindly review.