### PR TITLE
Allocate only required ports in services

### DIFF
--- a/workloads/router-perf-v2/http-perf.yml.tmpl
+++ b/workloads/router-perf-v2/http-perf.yml.tmpl
@@ -60,7 +60,7 @@ jobs:
       inputVars:
         nodeSelector: "{node-role.kubernetes.io/worker: }"
 
-    - objectTemplate: templates/http-service.yml
+    - objectTemplate: templates/https-service.yml
       replicas: ${NUMBER_OF_ROUTES}
       inputVars:
         serviceType: ${SERVICE_TYPE}
@@ -83,7 +83,7 @@ jobs:
       inputVars:
         nodeSelector: "{node-role.kubernetes.io/worker: }"
 
-    - objectTemplate: templates/http-service.yml
+    - objectTemplate: templates/https-service.yml
       replicas: ${NUMBER_OF_ROUTES}
       inputVars:
         serviceType: ${SERVICE_TYPE}

--- a/workloads/router-perf-v2/templates/https-service.yml
+++ b/workloads/router-perf-v2/templates/https-service.yml
@@ -6,10 +6,10 @@ metadata:
   name: http-perf-{{.Replica}}
 spec:
   ports:
-  - name: http
-    port: 8080
+  - name: https
+    port: 8443
     protocol: TCP
-    targetPort: 8080
+    targetPort: 8443
   selector:
     app: nginx-{{.Replica}}
   type: {{.serviceType}}


### PR DESCRIPTION
### Description
Allocate 8443 in passthrough and reencrypt terminations, and 8080 in edge and http terminations.

### Fixes
Prevents running out of ports in large-scale scenarios: 
```
time="2021-03-25 05:08:20" level=error msg="Error creating object: Internal error occurred: failed to allocate a nodePort: range is full"
```

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>