### PR TITLE
Renaming variables in the spirit of consistency

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -75,7 +75,7 @@ Each iteration of this workload can be broken down in:
 
 ### Max-namespaces
 
-The number of namespaces created by Kube-burner is defined by the variable `JOB_ITERATIONS`. Each namespace is created with the following objects:
+The number of namespaces created by Kube-burner is defined by the variable `NAMESPACE_COUNT`. Each namespace is created with the following objects:
 
 - 1 deployment holding a postgresql database
 - 5 deployments consisting of a client application for the previous database
@@ -85,7 +85,7 @@ The number of namespaces created by Kube-burner is defined by the variable `JOB_
 
 ### Max-services
 
-It creates n-replicas of an application deployment (hello-openshift) and a service in a single namespace as defined by the environment variable `JOB_ITERATIONS`.
+It creates n-replicas of an application deployment (hello-openshift) and a service in a single namespace as defined by the environment variable `SERVICE_COUNT`.
 
 
 ### Pod-density

--- a/workloads/kube-burner/run_maxnamespaces_test_fromgit.sh
+++ b/workloads/kube-burner/run_maxnamespaces_test_fromgit.sh
@@ -4,7 +4,7 @@ set -e
 
 export WORKLOAD=max-namespaces
 export METRICS_PROFILE=${METRICS_PROFILE:-metrics-aggregated.yaml}
-export JOB_ITERATIONS=${JOB_ITERATIONS:-1000}
+export JOB_ITERATIONS=${NAMESPACE_COUNT:-1000}
 
 . common.sh
 

--- a/workloads/kube-burner/run_maxservices_test_fromgit.sh
+++ b/workloads/kube-burner/run_maxservices_test_fromgit.sh
@@ -4,7 +4,7 @@ set -e
 
 export WORKLOAD=max-services
 export METRICS_PROFILE=${METRICS_PROFILE:-metrics-aggregated.yaml}
-export JOB_ITERATIONS=${JOB_ITERATIONS:-1000}
+export JOB_ITERATIONS=${SERVICE_COUNT:-1000}
 
 . common.sh
 


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description
In the Pod Density workload we are using env var named `PODS` here: https://github.com/cloud-bulldozer/e2e-benchmarking/blob/master/workloads/kube-burner/run_poddensity_test_fromgit.sh

For services and namespace workloads we are calling it `JOB_ITERATIONS`. It leads to lack of consistency and potential confusion. 

### Fixes
Variable names for Maximum Namespaces and Services workloads.

Potentially we need a fix in scale-ci jobs where you run these jobs. Please let me know if you'd like me to go there are update it. 

cc: @rsevilla87 @mohit-sheth @chaitanyaenr  @mffiedler