### PR TITLE
Test routes

### DIFF
--- a/workloads/router-perf-v2/ingress-performance.sh
+++ b/workloads/router-perf-v2/ingress-performance.sh
@@ -8,6 +8,7 @@ deploy_infra
 tune_workload_node apply
 client_pod=$(oc get pod -l app=http-scale-client -n http-scale-client | grep Running | awk '{print $1}')
 tune_liveness_probe
+test_routes
 for termination in ${TERMINATIONS}; do
   if [[ ${termination} ==  "mix" ]]; then
     for clients in ${CLIENTS_MIX}; do

--- a/workloads/router-perf-v2/workload.py
+++ b/workloads/router-perf-v2/workload.py
@@ -43,10 +43,14 @@ def run_mb(mb_config, runtime, output):
             result_codes[hit[2]] = 0
         result_codes[hit[2]] += 1
         latency_list.append(int(hit[1]))
-    p95_latency = numpy.percentile(latency_list, 95)
-    p99_latency = numpy.percentile(latency_list, 99)
-    avg_latency = numpy.average(latency_list)
-    return result_codes, p95_latency, p99_latency, avg_latency
+    if latency_list:
+        p95_latency = numpy.percentile(latency_list, 95)
+        p99_latency = numpy.percentile(latency_list, 99)
+        avg_latency = numpy.average(latency_list)
+        return result_codes, p95_latency, p99_latency, avg_latency
+    else:
+        print("Warning: Empty latency result list, returning 0")
+        return result_codes, 0, 0, 0
 
 
 def main():


### PR DESCRIPTION
### Description
I have observed a performance degradation that happens during the first iteration of the first test-scenario (also [happens in CI](https://ec2-52-39-240-23.us-west-2.compute.amazonaws.com:8443/job/e2e-benchmarking-ci/61/consoleFull)). I think the reason could be that the static content is not cached by nginx during this first iteration causing it's an extra delay to serve it. This commit adds a new action to the benchmark `test_routes`  to trigger a cURL to all routes before triggering any workload.

We shouldn't observe a big performance degradation of this iteration. (CI can help to verify this)


Signed-off-by: Raul Sevilla <rsevilla@redhat.com>