### PR TITLE
Prometheus sizing workload

### DIFF
--- a/workloads/prometheus-sizing/README.md
+++ b/workloads/prometheus-sizing/README.md
@@ -1,0 +1,43 @@
+# Prometheus sizing benchmark
+
+The scripts in this folder are meant to generate a workload that allow to measure the maximum Prometheus resource usage in a period of time.
+According to docs, Prometheus WAL files (stored in wal directory in 128MiB segments) will retain at least 2 hours of raw data before rotatio & compaction. This WAL data is persisted in disk to be secured against crashes and stored in memory to improve query performance.
+
+At the moment two different scenarios are being considered:
+
+- Static scenario: Performed by `prometheus-sizing-static.sh`. This scenario fills all worker nodes across the cluster with 250 pods each, and then sleeps for `JOB_PAUSE`.
+- Churning scenario: Performed by `prometheus-sizing-churning.sh`. This scenario generates pod churning across the worker nodes of the cluster. This pod churning consists of initally creating a certain number of namespaces in the cluster (this namespaces are holding a set of pods), and then delete and recreate each of those namespaces (with all its pods) each `POD_CHURNING_PERIOD`.
+
+## Static scenario
+
+Handled by the script `prometheus-sizing-churning.sh`, it can be customized with the following variables:
+
+| Variable         | Description                         | Default |
+|------------------|-------------------------------------|---------|
+| **JOB_PAUSE**        | How long to wait before finishing the kube-burner job and index metrics | 125m |
+| **QPS**              | Kube-burner's QPS                     | 40 |
+| **BURST**              | Kube-burner's Burst rate            | 40 |
+| **BURST**              | Kube-burner's Burst rate            | 40 |
+| **CLEANUP_WHEN_FINISH** | Delete workload's namespaces after running it | false |
+| **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
+| **ES_SERVER**        | Elastic search endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443 (You can disable indexing with `export ES_SERVER=""`)|
+| **ES_INDEX**         | Elastic search index            | ripsaw-kube-burner |
+
+## Churning scenario
+
+Handled by the script `prometheus-sizing-churning.sh`, it can be customized with the following variables:
+
+| Variable         | Description                         | Default |
+|------------------|-------------------------------------|---------|
+| **PODS_PER_NODE**    | How many pods to deploy in each node  | 50 |
+| **POD_CHURNING_PERIOD**    | How often a namespace rotation  | 15m |
+| **NUMBER_OF_NS**    | How many namespaces create             | 8 |
+| **QPS**              | Kube-burner's QPS                     | 40 |
+| **BURST**              | Kube-burner's Burst rate            | 40 |
+| **BURST**              | Kube-burner's Burst rate            | 40 |
+| **CLEANUP_WHEN_FINISH** | Delete workload's namespaces after running it | false |
+| **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
+| **ES_SERVER**        | Elastic search endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443 (You can disable indexing with `export ES_SERVER=""`)|
+| **ES_INDEX**         | Elastic search index            | ripsaw-kube-burner |
+
+> Note: With the variables above, the total duration of the benchmark is given by `NUMBER_OF_NS * POD_CHURNING_PERIOD`.

--- a/workloads/prometheus-sizing/README.md
+++ b/workloads/prometheus-sizing/README.md
@@ -1,12 +1,12 @@
 # Prometheus sizing benchmark
 
 The scripts in this folder are meant to generate a workload that allow to measure the maximum Prometheus resource usage in a period of time.
-According to docs, Prometheus WAL files (stored in wal directory in 128MiB segments) will retain at least 2 hours of raw data before rotatio & compaction. This WAL data is persisted in disk to be secured against crashes and stored in memory to improve query performance.
+According to docs, Prometheus WAL files (stored in wal directory in 128MiB segments) will retain at least 2 hours of raw data before rotation & compaction. This WAL data is persisted in disk to be secured against crashes and stored in memory to improve query performance.
 
 At the moment two different scenarios are being considered:
 
 - Static scenario: Performed by `prometheus-sizing-static.sh`. This scenario fills all worker nodes across the cluster with 250 pods each, and then sleeps for `JOB_PAUSE`.
-- Churning scenario: Performed by `prometheus-sizing-churning.sh`. This scenario generates pod churning across the worker nodes of the cluster. This pod churning consists of initally creating a certain number of namespaces in the cluster (this namespaces are holding a set of pods), and then delete and recreate each of those namespaces (with all its pods) each `POD_CHURNING_PERIOD`.
+- Churning scenario: Performed by `prometheus-sizing-churning.sh`. This scenario generates pod churning across the worker nodes of the cluster. This pod churning consists of initially creating a certain number of namespaces in the cluster (this namespaces are holding a set of pods), and then delete and recreate each of those namespaces (with all its pods) each `POD_CHURNING_PERIOD`.
 
 ## Common variables
 
@@ -40,4 +40,4 @@ Handled by the script `prometheus-sizing-churning.sh`, it can be customized with
 | **POD_CHURNING_PERIOD**    | How often a namespace rotation  | 15m |
 | **NUMBER_OF_NS**    | How many namespaces create             | 8 |
 
-> Note: With the variables above, the total duration of the benchmark is given by `NUMBER_OF_NS * POD_CHURNING_PERIOD`.
+> Note: With the variables above, the total duration of the benchmark is given by `NUMBER_OF_NS * POD_CHURNING_PERIOD`. If the cluster has 3 worker nodes, it will create 150 pods across 8 namespaces.

--- a/workloads/prometheus-sizing/README.md
+++ b/workloads/prometheus-sizing/README.md
@@ -8,6 +8,20 @@ At the moment two different scenarios are being considered:
 - Static scenario: Performed by `prometheus-sizing-static.sh`. This scenario fills all worker nodes across the cluster with 250 pods each, and then sleeps for `JOB_PAUSE`.
 - Churning scenario: Performed by `prometheus-sizing-churning.sh`. This scenario generates pod churning across the worker nodes of the cluster. This pod churning consists of initally creating a certain number of namespaces in the cluster (this namespaces are holding a set of pods), and then delete and recreate each of those namespaces (with all its pods) each `POD_CHURNING_PERIOD`.
 
+## Common variables
+
+These environment variables can be customized in both scenarios
+
+| Variable         | Description                         | Default |
+|------------------|-------------------------------------|---------|
+| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz` |
+| **QPS**              | Kube-burner's QPS                     | 40 |
+| **BURST**              | Kube-burner's Burst rate            | 40 |
+| **CLEANUP_WHEN_FINISH** | Delete workload's namespaces after running it | false |
+| **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
+| **ES_SERVER**        | ElasticSearch endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|
+| **ES_INDEX**         | ElasticSearch index            | ripsaw-kube-burner |
+
 ## Static scenario
 
 Handled by the script `prometheus-sizing-churning.sh`, it can be customized with the following variables:
@@ -15,13 +29,6 @@ Handled by the script `prometheus-sizing-churning.sh`, it can be customized with
 | Variable         | Description                         | Default |
 |------------------|-------------------------------------|---------|
 | **JOB_PAUSE**        | How long to wait before finishing the kube-burner job and index metrics | 125m |
-| **QPS**              | Kube-burner's QPS                     | 40 |
-| **BURST**              | Kube-burner's Burst rate            | 40 |
-| **BURST**              | Kube-burner's Burst rate            | 40 |
-| **CLEANUP_WHEN_FINISH** | Delete workload's namespaces after running it | false |
-| **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
-| **ES_SERVER**        | Elastic search endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443 (You can disable indexing with `export ES_SERVER=""`)|
-| **ES_INDEX**         | Elastic search index            | ripsaw-kube-burner |
 
 ## Churning scenario
 
@@ -32,12 +39,5 @@ Handled by the script `prometheus-sizing-churning.sh`, it can be customized with
 | **PODS_PER_NODE**    | How many pods to deploy in each node  | 50 |
 | **POD_CHURNING_PERIOD**    | How often a namespace rotation  | 15m |
 | **NUMBER_OF_NS**    | How many namespaces create             | 8 |
-| **QPS**              | Kube-burner's QPS                     | 40 |
-| **BURST**              | Kube-burner's Burst rate            | 40 |
-| **BURST**              | Kube-burner's Burst rate            | 40 |
-| **CLEANUP_WHEN_FINISH** | Delete workload's namespaces after running it | false |
-| **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
-| **ES_SERVER**        | Elastic search endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443 (You can disable indexing with `export ES_SERVER=""`)|
-| **ES_INDEX**         | Elastic search index            | ripsaw-kube-burner |
 
 > Note: With the variables above, the total duration of the benchmark is given by `NUMBER_OF_NS * POD_CHURNING_PERIOD`.

--- a/workloads/prometheus-sizing/common.sh
+++ b/workloads/prometheus-sizing/common.sh
@@ -38,8 +38,8 @@ run_test(){
   export POD_REPLICAS
   curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz
   ./kube-burner init -c ${1} --uuid=${UUID} -u=${PROM_URL} --token=${PROM_TOKEN} -m=metrics.yaml
-if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then
-  log "Cleaning up benchmark stuff"
-  kube-burner destroy -u ${UUID}
-fi
+  if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then
+    log "Cleaning up benchmark stuff"
+    kube-burner destroy -u ${UUID}
+  fi
 }

--- a/workloads/prometheus-sizing/common.sh
+++ b/workloads/prometheus-sizing/common.sh
@@ -1,0 +1,44 @@
+export UUID=$(uuidgen)
+export QPS=${QPS:-40}
+export BURST=${BURSTS:-40}
+export CLEANUP_WHEN_FINISH=${CLEANUP_WHEN_FINISH:-true}
+export LOG_LEVEL=${LOG_LEVEL:-info}
+export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
+export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
+export PROM_URL=https://$(oc get route -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")
+export PROM_TOKEN=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+
+log(){
+  echo -e "\033[1m$(date "+%d-%m-%YT%H:%M:%S") ${@}\033[0m"
+}
+
+get_number_of_pods(){
+  POD_REPLICAS=0
+  if [[ -n ${PODS_PER_NODE} ]]; then
+    local NUMBER_OF_NODES=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= --no-headers | wc -l)
+    POD_REPLICAS=$((NUMBER_OF_NODES * PODS_PER_NODE))
+  else
+    log "Calculating number of pods required to fill all worker nodes"
+    for n in $(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= -o jsonpath="{.items[*].metadata.name}"); do
+       local pods_in_node=$(oc get pod -A --field-selector=spec.nodeName=${n} | grep -cw Running)
+       let POD_REPLICAS=${POD_REPLICAS}+249-${pods_in_node}
+    done
+    if [[ ${POD_REPLICAS} -le 0 ]]; then
+      log "Wrong number of pods: ${POD_REPLICAS}"
+      exit
+    fi
+  fi
+  log "Pods to deploy across worker nodes: ${POD_REPLICAS}"
+}
+
+get_pods_per_namespace(){
+  export PODS_PER_NS=$((POD_REPLICAS / NUMBER_OF_NS))
+  log "We'll create ${NUMBER_OF_NS} namespaces with ${PODS_PER_NS} pods each"
+}
+
+# Receives the kube-burner configuration file as parameter
+run_test(){
+  log "Running kube-burner using config ${1}"
+  export POD_REPLICAS
+  kube-burner init -c ${1} --uuid=${UUID} -u=${PROM_URL} --token=${PROM_TOKEN} --log-level=${LOG_LEVEL} -m=metrics.yaml
+}

--- a/workloads/prometheus-sizing/env.sh
+++ b/workloads/prometheus-sizing/env.sh
@@ -12,8 +12,8 @@ export JOB_PAUSE=${JOB_PAUSE:-125m}
 
 # prometheus-sizing-churning specific
 # How many pods to create in each node
-export PODS_PER_NODE=50
+export PODS_PER_NODE=${PODS_PER_NODE:-50}
 # How often pod churning happens
-export POD_CHURNING_PERIOD=15m
+export POD_CHURNING_PERIOD=${POD_CHURNING_PERIOD:-15m}
 # Number of namespaces
-export NUMBER_OF_NS=8
+export NUMBER_OF_NS=${NUMBER_OF_NS:-8}

--- a/workloads/prometheus-sizing/env.sh
+++ b/workloads/prometheus-sizing/env.sh
@@ -1,0 +1,19 @@
+
+export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz}
+export QPS=${QPS:-40}
+export BURST=${BURSTS:-40}
+export CLEANUP_WHEN_FINISH=${CLEANUP_WHEN_FINISH:-true}
+export ENABLE_INDEXING=${ENABLE_INDEXING:-true}
+export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
+export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
+
+# prometheus-sizing-static specific
+export JOB_PAUSE=${JOB_PAUSE:-125m}
+
+# prometheus-sizing-churning specific
+# How many pods to create in each node
+export PODS_PER_NODE=50
+# How often pod churning happens
+export POD_CHURNING_PERIOD=15m
+# Number of namespaces
+export NUMBER_OF_NS=8

--- a/workloads/prometheus-sizing/metrics.yaml
+++ b/workloads/prometheus-sizing/metrics.yaml
@@ -1,14 +1,14 @@
 metrics:
-  - query: sum(irate(container_cpu_usage_seconds_total{name!="",namespace="openshift-monitoring"}[2m]) * 100) by (pod, namespace, node)
+  - query: (sum(irate(container_cpu_usage_seconds_total{name!="",namespace="openshift-monitoring"}[2m]) * 100) by (pod, namespace, node) and on (node) kube_node_role{role="infra"})
     metricName: podCPU
 
-  - query: sum(container_memory_rss{name!="",namespace="openshift-monitoring"}) by (pod, namespace, node)
+  - query: (sum(container_memory_rss{name!="",namespace="openshift-monitoring"}) by (pod, namespace, node) and on (node) kube_node_role{role="infra"})
     metricName: podMemory
 
-  - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance)  and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+  - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
     metricName: nodeCPU
 
-  - query: (avg(node_memory_MemAvailable_bytes) by (instance)  and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+  - query: (avg(node_memory_MemAvailable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
     metricName: nodeMemoryAvailable
 
   - query: (avg(node_memory_Active_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
@@ -28,6 +28,12 @@ metrics:
 
   - query: (rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
     metricName: nodeDiskReadBytes
+
+  - query: (rate(node_disk_writes_completed_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: nodeDiskWriteOps
+
+  - query: (rate(node_disk_reads_completed_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: nodeDiskReadOps
 
   - query: sum(kube_pod_status_phase{}) by (phase)
     metricName: podStatusCount

--- a/workloads/prometheus-sizing/metrics.yaml
+++ b/workloads/prometheus-sizing/metrics.yaml
@@ -1,0 +1,47 @@
+metrics:
+  - query: sum(irate(container_cpu_usage_seconds_total{name!="",namespace="openshift-monitoring"}[2m]) * 100) by (pod, namespace, node)
+    metricName: podCPU
+
+  - query: sum(container_memory_rss{name!="",namespace="openshift-monitoring"}) by (pod, namespace, node)
+    metricName: podMemory
+
+  - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance)  and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: nodeCPU
+
+  - query: (avg(node_memory_MemAvailable_bytes) by (instance)  and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: nodeMemoryAvailable
+
+  - query: (avg(node_memory_Active_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: nodeMemoryActive
+
+  - query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+    metricName: nodeMemoryCached+nodeMemoryBuffers
+
+  - query: (irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: rxNetworkBytes
+
+  - query: (irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: txNetworkBytes
+
+  - query: (rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: nodeDiskWrittenBytes
+
+  - query: (rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+    metricName: nodeDiskReadBytes
+
+  - query: sum(kube_pod_status_phase{}) by (phase)
+    metricName: podStatusCount
+
+  - query: kube_node_role
+    metricName: nodeRoles
+    instant: true
+
+  - query: sum(kube_node_status_condition{status="true"}) by (condition)
+    metricName: nodeStatus
+
+  - query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="infra"}) > 0
+    metricName: containerDiskUsage
+
+  - query: cluster_version{type="completed"}
+    metricName: clusterVersion
+    instant: true

--- a/workloads/prometheus-sizing/prometheus-sizing-churning.sh
+++ b/workloads/prometheus-sizing/prometheus-sizing-churning.sh
@@ -2,13 +2,6 @@
 set -e
 
 source common.sh
-# How many pods to create in each node
-export PODS_PER_NODE=50
-# How often pod churning happens
-export POD_CHURNING_PERIOD=15m
-# Number of namespaces
-export NUMBER_OF_NS=8
-export JOB_PAUSE=${JOB_PAUSE:-125m}
 
 get_number_of_pods
 get_pods_per_namespace

--- a/workloads/prometheus-sizing/prometheus-sizing-churning.sh
+++ b/workloads/prometheus-sizing/prometheus-sizing-churning.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -e
+
+source common.sh
+# How many pods to create in each node
+export PODS_PER_NODE=50
+# How often pod churning happens
+export POD_CHURNING_PERIOD=15m
+# Number of namespaces
+export NUMBER_OF_NS=8
+export JOB_PAUSE=${JOB_PAUSE:-125m}
+
+get_number_of_pods
+get_pods_per_namespace
+run_test prometheus-sizing-churning.yml

--- a/workloads/prometheus-sizing/prometheus-sizing-churning.yml
+++ b/workloads/prometheus-sizing/prometheus-sizing-churning.yml
@@ -2,7 +2,7 @@
 global:
   writeToFile: false
   indexerConfig:
-    enabled: true
+    enabled: {{ .ENABLE_INDEXING }}
     esServers: [{{ .ES_SERVER }}]
     insecureSkipVerify: true
     defaultIndex: {{ .ES_INDEX }}
@@ -12,7 +12,7 @@ jobs:
     namespacedIterations: true
     namespace: prometheus-sizing-churning
     jobIterations: {{ .NUMBER_OF_NS }}
-    waitWhenFinished: true
+    waitWhenFinished: false
     cleanup: true
     qps: {{ .QPS }}
     burst: {{ .BURST }}
@@ -33,7 +33,7 @@ jobs:
   - name: prometheus-sizing-churning-churn-{{ $val }}
     namespacedIterations: false
     namespace: prometheus-sizing-churning-churn-{{ $val }}
-    waitWhenFinished: true
+    waitWhenFinished: false
     jobIterations: 1
     qps: {{ $.QPS }}
     burst: {{ $.BURST }}

--- a/workloads/prometheus-sizing/prometheus-sizing-churning.yml
+++ b/workloads/prometheus-sizing/prometheus-sizing-churning.yml
@@ -1,0 +1,46 @@
+---
+global:
+  writeToFile: false
+  indexerConfig:
+    enabled: true
+    esServers: [{{ .ES_SERVER }}]
+    insecureSkipVerify: true
+    defaultIndex: {{ .ES_INDEX }}
+    type: elastic
+jobs:
+  - name: prometheus-sizing-churning
+    namespacedIterations: true
+    namespace: prometheus-sizing-churning
+    jobIterations: {{ .NUMBER_OF_NS }}
+    waitWhenFinished: true
+    cleanup: true
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
+    jobPause: {{ .POD_CHURNING_PERIOD }}
+    objects:
+      - objectTemplate: templates/pod.yml
+        replicas: {{ .PODS_PER_NS }}
+        inputVars:
+          containerImage: gcr.io/google_containers/pause-amd64:3.0
+{{ range $pos, $val := sequence 1 .NUMBER_OF_NS }}
+  - name: prometheus-sizing-churning-delete-{{ $val }}
+    jobType: delete
+    waitForDeletion: false
+    objects:
+    - kind: Namespace
+      labelSelector: {name: prometheus-sizing-churning-{{ $val }}}
+
+  - name: prometheus-sizing-churning-churn-{{ $val }}
+    namespacedIterations: false
+    namespace: prometheus-sizing-churning-churn-{{ $val }}
+    waitWhenFinished: true
+    jobIterations: 1
+    qps: {{ $.QPS }}
+    burst: {{ $.BURST }}
+    jobPause: {{ $.POD_CHURNING_PERIOD }}
+    objects:
+      - objectTemplate: templates/pod.yml
+        replicas: {{ $.PODS_PER_NS }}
+        inputVars:
+          containerImage: gcr.io/google_containers/pause-amd64:3.0
+{{ end }}

--- a/workloads/prometheus-sizing/prometheus-sizing-static.sh
+++ b/workloads/prometheus-sizing/prometheus-sizing-static.sh
@@ -2,7 +2,6 @@
 set -e
 
 source common.sh
-export JOB_PAUSE=${JOB_PAUSE:-125m}
 
 get_number_of_pods
 run_test prometheus-sizing-static.yml

--- a/workloads/prometheus-sizing/prometheus-sizing-static.sh
+++ b/workloads/prometheus-sizing/prometheus-sizing-static.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+source common.sh
+export JOB_PAUSE=${JOB_PAUSE:-125m}
+
+get_number_of_pods
+run_test prometheus-sizing-static.yml

--- a/workloads/prometheus-sizing/prometheus-sizing-static.yml
+++ b/workloads/prometheus-sizing/prometheus-sizing-static.yml
@@ -2,7 +2,7 @@
 global:
   writeToFile: false
   indexerConfig:
-    enabled: true
+    enabled: {{ .ENABLE_INDEXING }}
     esServers: [{{.ES_SERVER}}]
     insecureSkipVerify: true
     defaultIndex: {{.ES_INDEX}}
@@ -11,15 +11,15 @@ jobs:
   - name: prometheus-sizing-static
     jobIterations: 1
     cleanup: true
-    qps: {{.QPS}}
-    burst: {{.BURST}}
+    qps: {{ .QPS }}
+    burst: {{ .BURST }}
     namespacedIterations: false
     namespace: prometheus-sizing-static
     waitWhenFinished: true
-    jobPause: {{.JOB_PAUSE}}
+    jobPause: {{ .JOB_PAUSE }}
     objects:
       - objectTemplate: templates/pod.yml
-        replicas: {{.POD_REPLICAS}}
+        replicas: {{ .POD_REPLICAS }}
         inputVars:
           containerImage: gcr.io/google_containers/pause-amd64:3.0
 

--- a/workloads/prometheus-sizing/prometheus-sizing-static.yml
+++ b/workloads/prometheus-sizing/prometheus-sizing-static.yml
@@ -1,0 +1,32 @@
+---
+global:
+  writeToFile: false
+  indexerConfig:
+    enabled: true
+    esServers: [{{.ES_SERVER}}]
+    insecureSkipVerify: true
+    defaultIndex: {{.ES_INDEX}}
+    type: elastic
+jobs:
+  - name: prometheus-sizing-static
+    jobIterations: 1
+    cleanup: true
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    namespace: prometheus-sizing-static
+    waitWhenFinished: true
+    jobPause: {{.JOB_PAUSE}}
+    objects:
+      - objectTemplate: templates/pod.yml
+        replicas: {{.POD_REPLICAS}}
+        inputVars:
+          containerImage: gcr.io/google_containers/pause-amd64:3.0
+
+  - name: delete-prometheus-sizing-static
+    waitForDeletion: true
+    jobType: delete
+    objects:
+      - kind: Namespace
+        labelSelector: {kube-burner-job: prometheus-sizing-static}
+

--- a/workloads/prometheus-sizing/templates/pod.yml
+++ b/workloads/prometheus-sizing/templates/pod.yml
@@ -1,0 +1,18 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: prometheus-sizing-{{.Replica}}
+  labels:
+    name: prometheus-sizing
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  containers:
+  - name: prometheus-sizing
+    image: {{.containerImage}}
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: false


### PR DESCRIPTION
### Description

New prometheus sizing workload. Two variants:

- Static: "Fills" worker nodes with 250 pods and waits 125 minutes before collecting metrics
- Churning: Creates 50 pods per node by default, divided in 8 namespaces by default, and rotates (Deletes that namespace and creates a new one) one these namespace each 15 minutes (by default as well).

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>