### PR TITLE
Adding concurrent builds test for benchmark operator

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -12,6 +12,7 @@ In order to kick off one of these benchmarks you must use the run.sh script. The
 - **`pod-density`**: `WORKLOAD=pod-density ./run.sh`
 - **`pod-density-heavy`**: `WORKLOAD=pod-density-heavy ./run.sh`
 - **`custom`**: `WORKLOAD=custom ./run.sh`
+- **`concurrent-builds`**: `WORKLOAD=concurrent-builds ./run.sh`
 
 ## Environment variables
 
@@ -140,6 +141,18 @@ $ INDEXING=false WORKLOAD_TEMPLATE=my-config/kube-burner.cfg METRICS_PROFILE=my-
 
 will launch a pod running a kube-burner process that will use the configuration file defined at https://raw.githubusercontent.com/cloud-bulldozer/cluster-perf-ci/master/configmap-scale.yml
 
+### Concurrent Builds
+
+Creates a buildconfig and imagestream for a specified application(s) (defined in **APP_LIST** env variable). **This
+ will create as many namespaces with these objects as the configured job_iterations**.
+After the initial creation of the objects the script will concurrently build different numbers (defined by
+ **BUILD_LIST**) of the builds and output the average times. 
+To edit any of the build information edit the bash script correlating with the application of interest under the
+ [builds](./builds) folder
+
+**NOTE**: Do not edit parameters other than BUILD_LIST and APP_LIST in env variables file. They will be overwritten
+ be the data in builds folder. If you need to make updates to application data, edit environment variables under
+  builds/<application_name>.sh
 
 ### Snappy integration configurations
 

--- a/workloads/kube-burner/build_helper.sh
+++ b/workloads/kube-burner/build_helper.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/bash
+
+function prepare_builds_file()
+{
+  project_name=`oc get project --no-headers | grep -m 1 conc-b | awk {'print $1'}`
+  bc_name=`oc get bc -n $project_name --no-headers | awk {'print $1'}`
+  running_build_file="running-builds.json"
+  # generate running-builds.json on the fly
+  printf '%s\n' "[" > "${running_build_file}"
+  proj_substring=${project_name::${#project_name}-1}
+  for (( c=1; c<"${MAX_CONC_BUILDS}"; c++ ))
+  do
+    if [[ "$c" == $((MAX_CONC_BUILDS - 1)) ]]; then
+      printf '%s\n' "{\"namespace\":\"$proj_substring${c}\", \"name\":\"$bc_name\"}" >> "${running_build_file}"
+    else
+      printf '%s\n' "{\"namespace\":\"$proj_substring${c}\", \"name\":\"$bc_name\"}," >> "${running_build_file}"
+    fi
+  done
+  printf '%s' "]" >> "${running_build_file}"
+}
+
+
+function install_svt_repo() {
+  rm -rf svt
+  git clone --single-branch --branch ${build_test_branch} ${build_test_repo} --depth 1
+  curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
+  python2 --version
+
+  python2 get-pip.py
+  python2 -m pip install futures pytimeparse logging
+  python2 -m pip install futures pytimeparse logging
+}
+
+function run_builds() {
+  for i in "${build_array[@]}"
+  do
+    log "running $i $1 concurrent builds"
+    fileName="conc_builds_$1.out"
+    python2 svt/openshift_performance/ose3_perf/scripts/build_test.py -z -a -n 2 -r $i -f running-builds.json > $fileName 2>&1
+    sleep 10
+  done
+}
+
+function wait_for_running_builds() {
+  running=`oc get pods -A --no-headers | grep svt-$1 | grep Running | wc -l`
+  while [ $running -ne 0 ]; do
+    sleep 15
+    running=`oc get pods -A | grep svt-$1 | grep Running | wc -l`
+    log "$running pods are still running"
+  done
+
+}
+
+function run_build_workload() {
+  app=$1
+  export APP_SUBNAME=$app
+  rm -rf conc_builds_$app.out
+  . ./builds/$app.sh
+
+  run_workload kube-burner-crd.yaml
+  sleep 15
+  wait_for_running_builds $app
+  sleep 10
+
+  prepare_builds_file conc_builds_$app.out
+  run_builds $app
+  proj=$app
+
+  echo "================ Average times for $proj app =================" >> conc_builds_results.out
+  grep "Average build time, all good builds" conc_builds_$proj.out >> conc_builds_results.out
+  grep "Average push time, all good builds" conc_builds_$proj.out >> conc_builds_results.out
+  grep "Good builds included in stats" conc_builds_$proj.out >> conc_builds_results.out
+  echo "==============================================================" >> conc_builds_results.out
+  # have to clean up to be able to run with new configmap/kube-burner with same uuid
+  cleanup
+
+}

--- a/workloads/kube-burner/builds/cakephp.sh
+++ b/workloads/kube-burner/builds/cakephp.sh
@@ -1,0 +1,13 @@
+export APP=cakephp
+# Concurrent Build Specific
+export BUILD_IMAGE_STREAM=cakephp-mysql-example
+
+export SOURCE_STRAT_ENV=COMPOSER_MIRROR
+export SOURCE_STRAT_FROM_VERSION=latest
+
+export SOURCE_STRAT_FROM=php
+export POST_COMMIT_SCRIPT=./vendor/bin/phpunit
+
+
+export BUILD_IMAGE=image-registry.openshift-image-registry.svc:5000/svt-${app}/${BUILD_IMAGE_STREAM}
+export GIT_URL=https://github.com/sclorg/cakephp-ex.git

--- a/workloads/kube-burner/builds/django.sh
+++ b/workloads/kube-burner/builds/django.sh
@@ -1,0 +1,12 @@
+export APP=django
+# Concurrent Build Specific
+export BUILD_IMAGE_STREAM=django-psql-example
+
+export SOURCE_STRAT_ENV=PIP_INDEX_URL
+export SOURCE_STRAT_FROM_VERSION=latest
+export SOURCE_STRAT_FROM=python
+export POST_COMMIT_SCRIPT="./manage.py test"
+
+
+export BUILD_IMAGE=image-registry.openshift-image-registry.svc:5000/svt-${app}/${BUILD_IMAGE_STREAM}
+export GIT_URL=https://github.com/sclorg/django-ex.git

--- a/workloads/kube-burner/builds/eap.sh
+++ b/workloads/kube-burner/builds/eap.sh
@@ -1,0 +1,10 @@
+export APP=eap-app
+# Concurrent Build Specific
+export BUILD_IMAGE_STREAM=jboss-eap64-openshift
+export SOURCE_STRAT_ENV="''"
+export SOURCE_STRAT_FROM_VERSION=latest
+export SOURCE_STRAT_FROM=jboss-eap64-openshift
+export POST_COMMIT_SCRIPT="''"
+
+export BUILD_IMAGE=image-registry.openshift-image-registry.svc:5000/svt-${app}/${BUILD_IMAGE_STREAM}
+export GIT_URL=https://github.com/jboss-openshift/openshift-quickstarts

--- a/workloads/kube-burner/builds/nodejs.sh
+++ b/workloads/kube-burner/builds/nodejs.sh
@@ -1,0 +1,12 @@
+export APP=nodejs-mongodb-example
+# Concurrent Build Specific
+export BUILD_IMAGE_STREAM=nodejs-mongodb-example
+
+export SOURCE_STRAT_ENV="''"
+export SOURCE_STRAT_FROM_VERSION=latest
+export SOURCE_STRAT_FROM=nodejs
+export POST_COMMIT_SCRIPT="''"
+
+
+export BUILD_IMAGE=image-registry.openshift-image-registry.svc:5000/svt-${app}/${BUILD_IMAGE_STREAM}
+export GIT_URL=https://github.com/openshift/nodejs-ex.git

--- a/workloads/kube-burner/builds/rails.sh
+++ b/workloads/kube-burner/builds/rails.sh
@@ -1,0 +1,12 @@
+export APP=rails-postgresql-example
+# Concurrent Build Specific
+export BUILD_IMAGE_STREAM=rails-postgresql-example
+
+export SOURCE_STRAT_ENV=RUBYGEM_MIRROR
+export SOURCE_STRAT_FROM_VERSION=latest
+export SOURCE_STRAT_FROM=ruby
+export POST_COMMIT_SCRIPT="bundle exec rake test"
+
+
+export BUILD_IMAGE=image-registry.openshift-image-registry.svc:5000/svt-${app}/${BUILD_IMAGE_STREAM}
+export GIT_URL=https://github.com/sclorg/rails-ex.git

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Benchark-operator
+# Benchmark-operator
 export OPERATOR_REPO=${OPERATOR_REPO:-https://github.com/cloud-bulldozer/benchmark-operator.git}
 export OPERATOR_BRANCH=${OPERATOR_BRANCH:-master}
 export POD_READY_TIMEOUT=${POD_READY_TIMEOUT:-180}
@@ -50,6 +50,22 @@ export HYPERSHIFT=${HYPERSHIFT:-false}
 export MGMT_CLUSTER_NAME=${MGMT_CLUSTER_NAME:-perf-management-cluster}
 export HOSTED_CLUSTER_NS=${HOSTED_CLUSTER_NS:-clusters-perf-hosted-1}
 export THANOS_RECEIVER_URL=${THANOS_RECEIVER_URL:-http://thanos.apps.cluster.devcluster/api/v1/receive}
+
+# # Concurrent Builds variables
+# Space seperated list of build numbers and build app types
+export BUILD_LIST=${BUILD_LIST:-"1 8 15 30 45 60 75"}
+export APP_LIST=${APP_LIST:-'cakephp eap django nodejs'}
+
+# Concurrent Build Specific
+export APP_SUBNAME=""
+export APP=""
+export BUILD_IMAGE_STREAM=""
+export SOURCE_STRAT_ENV=""
+export SOURCE_STRAT_FROM=""
+export POST_COMMIT_SCRIPT=""
+export SOURCE_STRAT_FROM_VERSION=""
+export BUILD_IMAGE=""
+export GIT_URL=""
 
 # Thresholds
 export POD_READY_THRESHOLD=${POD_READY_THRESHOLD:-5000ms}

--- a/workloads/kube-burner/workloads/concurrent-builds/buildconfig_trigger.yml
+++ b/workloads/kube-burner/workloads/concurrent-builds/buildconfig_trigger.yml
@@ -1,0 +1,36 @@
+---
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+metadata:
+  name: {{.JobName}}-{{.Replica}}
+spec:
+  nodeSelector: {{.nodeSelector}}
+  triggers:
+  - type: GitHub
+    github:
+      secret: {{.JobName}}-{{.Replica}}
+  - type: ImageChange
+  - type: ConfigChange
+  source:
+    git:
+      uri: {{.gitUri}}
+    type: Git
+  strategy:
+    type: Source
+    sourceStrategy:
+{{ if index . "sourceStratEnv" }}
+      env:
+        - name: {{.sourceStratEnv}}
+{{ end }}
+      from:
+        kind: ImageStreamTag
+        name: {{.fromSource}}:{{.fromSourceVersion}}
+        namespace: 'openshift'
+{{ if index . "postCommitScript" }}
+  postCommit:
+    script: {{.postCommitScript}}
+{{ end }}
+  output:
+    to:
+      kind: ImageStreamTag
+      name: {{.imageStream}}-{{.Replica}}:latest

--- a/workloads/kube-burner/workloads/concurrent-builds/concurrent-builds.yml
+++ b/workloads/kube-burner/workloads/concurrent-builds/concurrent-builds.yml
@@ -1,0 +1,86 @@
+---
+global:
+  writeToFile: false
+  indexerConfig:
+    enabled: ${INDEXING}
+    esServers: ["${ES_SERVER}"]
+    insecureSkipVerify: true
+    defaultIndex: ${ES_INDEX}
+    type: elastic
+  measurements:
+    - name: podLatency
+      esIndex: ${ES_INDEX}
+{{ if eq .PPROF_COLLECTION "True" }}
+    - name: pprof
+      pprofInterval: {{ .PPROF_COLLECTION_INTERVAL }}
+      pprofDirectory: /tmp/pprof-data
+      pprofTargets:
+
+      - name: kube-apiserver-cpu
+        namespace: "openshift-kube-apiserver"
+        labelSelector: {app: openshift-kube-apiserver}
+        bearerToken: {{ .BEARER_TOKEN }}
+        url: https://localhost:6443/debug/pprof/profile?timeout=30
+
+      - name: kube-apiserver-heap
+        namespace: "openshift-kube-apiserver"
+        labelSelector: {app: openshift-kube-apiserver}
+        bearerToken: {{ .BEARER_TOKEN }}
+        url: https://localhost:6443/debug/pprof/heap
+
+      - name: kube-controller-manager-heap
+        namespace: "openshift-kube-controller-manager"
+        labelSelector: {app: kube-controller-manager}
+        bearerToken: {{ .BEARER_TOKEN }}
+        url: https://localhost:10257/debug/pprof/heap
+
+      - name: kube-controller-manager-cpu
+        namespace: "openshift-kube-controller-manager"
+        labelSelector: {app: kube-controller-manager}
+        bearerToken: {{ .BEARER_TOKEN }}
+        url: https://localhost:10257/debug/pprof/profile?timeout=30
+
+      - name: etcd-heap
+        namespace: "openshift-etcd"
+        labelSelector: {app: etcd}
+        cert: {{ .CERTIFICATE }}
+        key: {{ .PRIVATE_KEY }}
+        url: https://localhost:2379/debug/pprof/heap
+
+      - name: etcd-cpu
+        namespace: "openshift-etcd"
+        labelSelector: {app: etcd}
+        cert: {{ .CERTIFICATE }}
+        key: {{ .PRIVATE_KEY }}
+        url: https://localhost:2379/debug/pprof/profile?timeout=30
+{{ end }}
+jobs:
+  - name: concurrent-builds
+    jobIterations: ${TEST_JOB_ITERATIONS}
+    qps: ${QPS}
+    burst: ${BURST}
+    namespacedIterations: true
+    namespace: conc-b-${UUID}
+    podWait: ${POD_WAIT}
+    cleanup: ${CLEANUP}
+    waitFor: ${WAIT_FOR}
+    waitWhenFinished: ${WAIT_WHEN_FINISHED}
+    verifyObjects: ${VERIFY_OBJECTS}
+    errorOnVerify: ${ERROR_ON_VERIFY}
+    maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
+    objects:
+      - objectTemplate: imagestream.yml
+        replicas: 1
+        inputVars:
+          prefix: ${BUILD_IMAGE_STREAM}
+          image: ${BUILD_IMAGE}
+      - objectTemplate: buildconfig_trigger.yml
+        replicas: 1
+        inputVars:
+          imageStream: ${BUILD_IMAGE_STREAM}
+          gitUri: ${GIT_URL}
+          sourceStratEnv: ${SOURCE_STRAT_ENV}
+          fromSource: ${SOURCE_STRAT_FROM}
+          fromSourceVersion: ${SOURCE_STRAT_FROM_VERSION}
+          postCommitScript: ${POST_COMMIT_SCRIPT}
+          nodeSelector: "${POD_NODE_SELECTOR}"

--- a/workloads/kube-burner/workloads/concurrent-builds/configmap.yml
+++ b/workloads/kube-burner/workloads/concurrent-builds/configmap.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{.JobName}}-{{.Replica}}
+data:
+  key1: "{{rand 4}}"
+  key2: "{{rand 10}}"

--- a/workloads/kube-burner/workloads/concurrent-builds/imagestream.yml
+++ b/workloads/kube-burner/workloads/concurrent-builds/imagestream.yml
@@ -1,0 +1,9 @@
+---
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+metadata:
+  name: {{.prefix}}-{{.Replica}}
+spec:
+{{ if index . "image" }}
+  dockerImageRepository: {{.image}}
+{{ end }}


### PR DESCRIPTION
### Description
This (with addition of benchmark-operator [PR](https://github.com/cloud-bulldozer/benchmark-operator/pull/566)) will add and run the concurrent builds test case 

This is a little different from some of the other scripts in kube-burner because of the need to start **x** number of builds concurrently and get the build and push times. 
Benchmark-operator creates the builds that we can then use to create/start new builds concurrently to get the data for. The benchmark operator makes 1 more namespace then set in the build array to make sure that we can run enough concurrent builds as specified in the build array parameter. 

The results will be outputted into a file named "conc_builds_results.out" and printed out at the end of the run