### PR TITLE
Add worker node selection for labeling workload nodes

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -89,6 +89,11 @@ tune_liveness_probe(){
 
 tune_workload_node(){
   TUNED_SELECTOR=$(echo ${NODE_SELECTOR} | tr -d {:})
+  NUM_WORKLOAD_NODES=$(oc get node --show-labels -l ${TUNED_SELECTOR} --no-headers | grep node-role.kubernetes.io/workload -c)
+  if [[ $NUM_WORKLOAD_NODES -le 0 ]]; then
+    log "No nodes with label ${TUNED_SELECTOR} found, proceeding to label a worker node at random."
+    oc label node $(oc get nodes -l "node-role.kubernetes.io/worker=" -o custom-columns=:.metadata.name | shuf -n 1) ${TUNED_SELECTOR}=""
+  fi
   log "${1} tuned profile for node labeled with ${TUNED_SELECTOR}"
   sed "s#TUNED_SELECTOR#${TUNED_SELECTOR}#g" tuned-profile.yml | oc ${1} -f -
 }


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description

During execution of Router ingress perf testing, we found that if we no nodes are labeled as `workload`, we run into failure.

### Fixes

It fixes above issue by selecting one worker node at random and label it as a `workload` node. It is not the ideal solution for all usecases, but in our case all our worker nodes are of same instance type and in that case it would make sense to label any node at random.

cc: @chaitanyaenr @mohit-sheth @mffiedler  