### PR TITLE
Fixing run compare.sh to be able to find correct configs

### DIFF
--- a/utils/touchstone-compare/run_compare.sh
+++ b/utils/touchstone-compare/run_compare.sh
@@ -6,7 +6,12 @@ tool=${1}
 
 python3 -m venv ./venv
 source ./venv/bin/activate
-pip3 install git+https://github.com/cloud-bulldozer/benchmark-comparison
+set -x
+git clone https://github.com/cloud-bulldozer/benchmark-comparison
+ln -s benchmark-comparison/config config
+ln -s benchmark-comparison/tolerancy-configs tolerancy-configs
+set +x
+pip3 install benchmark-comparison/.
 
 if [[ $? -ne 0 ]] ; then
   echo "Unable to execute compare - Failed to install touchstone"
@@ -23,4 +28,4 @@ if [[ $? -ne 0 ]] ; then
 fi
 
 deactivate
-rm -rf venv
+rm -rf venv benchmark-comparison config tolerancy-configs


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description
I saw recently all of my jobs running into error: 
![image](https://user-images.githubusercontent.com/8180469/116302183-dfeca080-a76e-11eb-9ec7-0d8436acae38.png)

### Fixes

This PR fixes the error by cloning github repo, creating soft-links to config dirs. 

cc @chaitanyaenr @mffiedler @mohit-sheth 
