### PR TITLE
Fix run comapre dot sh

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -63,7 +63,7 @@ get_scenario(){
 deploy_infra(){
   log "Deploying benchmark infrastructure"
   WORKLOAD_NODE_SELECTOR=$(echo ${NODE_SELECTOR} | tr -d {:} | tr -d " ") # Remove braces and spaces
-  if [[ $(oc get node --show-labels -l ${WORKLOAD_NODE_SELECTOR} --no-headers | grep node-role.kubernetes.io/workload -c) -eq 0 ]]; then
+  if [[ $(oc get node --show-labels -l ${WORKLOAD_NODE_SELECTOR} --no-headers | grep ${WORKLOAD_NODE_SELECTOR} -c) -eq 0 ]]; then
     log "No nodes with label ${WORKLOAD_NODE_SELECTOR} found, proceeding to label a worker node at random."
     SELECTED_NODE=$(oc get nodes -l "node-role.kubernetes.io/worker=" -o custom-columns=:.metadata.name | tail -n1)
     log "Selected ${SELECTED_NODE} to label as ${WORKLOAD_NODE_SELECTOR}"

--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -95,6 +95,7 @@ tune_liveness_probe(){
 }
 
 tune_workload_node(){
+  TUNED_SELECTOR=$(echo ${NODE_SELECTOR} | tr -d {:})
   log "${1} tuned profile for node labeled with ${TUNED_SELECTOR}"
   sed "s#TUNED_SELECTOR#${TUNED_SELECTOR}#g" tuned-profile.yml | oc ${1} -f -
 }


### PR DESCRIPTION
### Description
Follow up to #171 as that PR added the labels, but too late for the run to succeed. `http-scale-client` deployment waits for the node with correct label and the run fails. 

### Fixes
This PR moves the labeling logic up in the chain so the deployment can succeed.

@mffiedler @mohit-sheth @chaitanyaenr 