### PR TITLE
Adding safe_create to retry pulling repo if it goes missing

### DIFF
--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -160,6 +160,11 @@ if [ ! -z "$client_pod" ]; then
     log "Encountered CRITICAL condition more than 3 times in uperf-client logs"
     log "Log dump of uperf-client pod"
     oc logs $client_pod -n my-ripsaw
+    log "Following Server pods were present"
+    server_pod=$(oc get pods -n my-ripsaw --no-headers | awk '{print $1}' | grep uperf-server | awk 'NR==1{print $1}')
+    oc logs $server_pod -n my-ripsaw
+    log "Following services were also present before calling delete_benchmark due to failure"
+    oc describe svc -n my-ripsaw
     delete_benchmark
     exit 1
   fi


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description

While running multiple jobs on a shared jenkins agent, all jobs were cloning into `/tmp/benchmark-operator` but what happened is the `init_cleanup` call caused the repo to be removed from `/tmp` before `oc apply -f` in `deploy_operator` could actually create resources. This PR fixes that race condition.

### Fixes
The way it does that is by calling `safe_create` that wraps the `oc apply -f ` command in a `while` loop, which will try to re-clone the missing repo(if it goes missing due to another parallel run, or for any other reason) . It will exit the loop when the resource gets created. 


Additionally adding some more debug logging for errors I am seeing in the runs lately. Having server pod and service info will help.

**NOTE:** Another way to fix this problem would be to create unique directories for each job in the `/tmp/` or change the path to something that user can input. Please let me know if you prefer that. I didn't want to inject any jenkins variables like `$WORKSPACE` in the script so I didn't go that route. We can also consider adding a random hash to the path where `benchmark-operator` is cloned. 

CC: @mffiedler @chaitanyaenr @mohit-sheth 