### PR TITLE
initialized pod_count

### DIFF
--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -89,6 +89,7 @@ label_nodes() {
     log "Not enough worker nodes to label"
     exit 1
   fi
+  pod_count=0
   for n in ${nodes}; do
     pods=$(oc describe ${n} | awk '/Non-terminated/{print $3}' | sed "s/(//g")
     pod_count=$((pods + pod_count))


### PR DESCRIPTION
### Description
pod_count is not initialized at the beginning, hence there is wrong calculation of already running pods.

### Fixes
