### PR TITLE
remove ERROR lines from touchstone output

### DIFF
--- a/utils/touchstone-compare/run_compare.sh
+++ b/utils/touchstone-compare/run_compare.sh
@@ -19,7 +19,7 @@ if [[ $? -ne 0 ]] ; then
 fi
 
 set -x
-  touchstone_compare --database elasticsearch -url $_es $_es_baseline -u ${2} ${3} -o yaml --config config/${tool}.json --tolerancy-rules tolerancy-configs/${tool}.yaml | tee compare_output_${!#}.yaml
+  touchstone_compare --database elasticsearch -url $_es $_es_baseline -u ${2} ${3} -o yaml --config config/${tool}.json --tolerancy-rules tolerancy-configs/${tool}.yaml | grep -v "ERROR"| tee compare_output_${!#}.yaml
 set +x
 
 if [[ $? -ne 0 ]] ; then


### PR DESCRIPTION
### Description
Removes ERROR lines in the compare.yaml files so that csv_gen.py can parse the yaml file to create a csv