### PR TITLE
Added Baseline Performance Workload

### DIFF
--- a/workloads/baseline-performance/README.md
+++ b/workloads/baseline-performance/README.md
@@ -1,0 +1,18 @@
+ # Baseline Cluster Performance benchmark
+
+The baseline performance benchmark is used to measure the performance metrics of the cluster when there are no resources loaded on the cluster. Helps in understanding the baseline performance of the control plane components, nodes, etcd, kubelet etc of Openshift. The baseline workload will sleep for ${WATCH_TIME} minutes and call kube-burner indexer to collect the metrics without loading the cluster.
+
+
+
+## Common variables
+
+These environment variables can be customized 
+
+| Variable         | Description                         | Default |
+|------------------|-------------------------------------|---------|
+| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz` |
+| **WATCH_TIME**              | Sleep duration for which metrics will be collected in minutes| 15 |
+| **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
+| **ES_SERVER**        | ElasticSearch endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|
+| **ES_INDEX**         | ElasticSearch index            | ripsaw-kube-burner |
+| **WRITE_TO_FILE**     | Dump collected metrics to files  locally  | false |

--- a/workloads/baseline-performance/README.md
+++ b/workloads/baseline-performance/README.md
@@ -11,7 +11,7 @@ These environment variables can be customized
 | Variable         | Description                         | Default |
 |------------------|-------------------------------------|---------|
 | **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz` |
-| **WATCH_TIME**              | Sleep duration for which metrics will be collected in minutes| 15 |
+| **WATCH_TIME**              | Sleep duration for which metrics will be collected in minutes| 30 |
 | **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
 | **ES_SERVER**        | ElasticSearch endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|
 | **ES_INDEX**         | ElasticSearch index            | ripsaw-kube-burner |

--- a/workloads/baseline-performance/baseline_perf.sh
+++ b/workloads/baseline-performance/baseline_perf.sh
@@ -6,7 +6,7 @@ source ./common.sh
 start_time=`date +%s`
 log "Sleeping for ${WATCH_TIME}M "
 sleep ${WATCH_TIME}m 
-end_time='date +%s'
+end_time=`date +%s`
 log "Running kube-burner index to measure  the performance of the cluster over the past ${WATCH_TIME}M"
   
 curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz

--- a/workloads/baseline-performance/baseline_perf.sh
+++ b/workloads/baseline-performance/baseline_perf.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+source ./common.sh
+
+start_time=`date +%s`
+log "Sleeping for ${WATCH_TIME}M "
+sleep ${WATCH_TIME}m 
+end_time='date +%s'
+log "Running kube-burner index to measure  the performance of the cluster over the past ${WATCH_TIME}M"
+  
+curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz
+
+./kube-burner index -c baseline_perf.yml --uuid=${UUID} -u=${PROM_URL} --token=${PROM_TOKEN} -m=metrics.yaml --start ${start_time} --end ${end_time}
+
+log "Metrics stored at elasticsearch server $ES_SERVER on index $ES_INDEX with UUID $UUID"

--- a/workloads/baseline-performance/baseline_perf.yml
+++ b/workloads/baseline-performance/baseline_perf.yml
@@ -1,0 +1,9 @@
+---
+global:
+  writeToFile: {{ .WRITE_TO_FILE }}
+  indexerConfig:
+    enabled: {{ .ENABLE_INDEXING }}
+    esServers: [{{.ES_SERVER}}]
+    insecureSkipVerify: true
+    defaultIndex: {{.ES_INDEX}}
+    type: elastic

--- a/workloads/baseline-performance/common.sh
+++ b/workloads/baseline-performance/common.sh
@@ -1,3 +1,9 @@
+# Check for kubeconfig
+if [[ -z $KUBECONFIG ]] && [[ ! -s $HOME/.kube/config ]]; then
+    echo "KUBECONFIG var is not defined and cannot find kube config in the home directory, please check"
+    exit 1
+fi
+
 export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz}
 
 export ENABLE_INDEXING=${ENABLE_INDEXING:-true}

--- a/workloads/baseline-performance/common.sh
+++ b/workloads/baseline-performance/common.sh
@@ -12,7 +12,7 @@ export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
 export WRITE_TO_FILE=${WRITE_TO_FILE:-false}
 
 # Time duration for which kube-burner will collect metrics
-export WATCH_TIME=${WATCH_TIME:-15}
+export WATCH_TIME=${WATCH_TIME:-30}
 
 
 export UUID=$(uuidgen)

--- a/workloads/baseline-performance/common.sh
+++ b/workloads/baseline-performance/common.sh
@@ -1,0 +1,20 @@
+export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz}
+
+export ENABLE_INDEXING=${ENABLE_INDEXING:-true}
+export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
+export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
+export WRITE_TO_FILE=${WRITE_TO_FILE:-false}
+
+# Time duration for which kube-burner will collect metrics
+export WATCH_TIME=${WATCH_TIME:-15}
+
+
+export UUID=$(uuidgen)
+
+export PROM_URL=https://$(oc get route -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")
+export PROM_TOKEN=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+
+log(){
+  echo -e "\033[1m$(date "+%d-%m-%YT%H:%M:%S") ${@}\033[0m"
+}
+

--- a/workloads/baseline-performance/metrics.yaml
+++ b/workloads/baseline-performance/metrics.yaml
@@ -1,0 +1,117 @@
+metrics:
+# API server
+  - query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!~"WATCH", subresource!="log"}[2m])) by (verb,resource,subresource,instance,le)) > 0
+    metricName: API99thLatency
+
+  - query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH",subresource!="log"}[2m])) by (verb,instance,resource,code) > 0
+    metricName: APIRequestRate
+
+  - query: sum(apiserver_current_inflight_requests{}) by (request_kind) > 0
+    metricName: APIInflightRequests
+
+# Containers & pod metrics
+  - query: sum(irate(container_cpu_usage_seconds_total{name!="",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|monitoring|logging|image-registry)"}[2m]) * 100) by (pod, namespace, node)
+    metricName: podCPU
+
+  - query: sum(container_memory_rss{name!="",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|monitoring|logging|image-registry)"}) by (pod, namespace, node)
+    metricName: podMemory
+
+  - query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
+    metricName: containerDiskUsage
+
+# Kubelet & CRI-O metrics
+  - query: sum(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+    metricName: kubeletCPU
+
+  - query: sum(process_resident_memory_bytes{service="kubelet",job="kubelet"}) by (node) and on (node) kube_node_role{role="worker"}
+    metricName: kubeletMemory
+
+  - query: sum(irate(process_cpu_seconds_total{service="kubelet",job="crio"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+    metricName: crioCPU
+
+  - query: sum(process_resident_memory_bytes{service="kubelet",job="crio"}) by (node) and on (node) kube_node_role{role="worker"}
+    metricName: crioMemory
+
+# Node metrics
+  - query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
+    metricName: nodeCPU
+
+  - query: avg(node_memory_MemAvailable_bytes) by (instance)
+    metricName: nodeMemoryAvailable
+
+  - query: avg(node_memory_Active_bytes) by (instance)
+    metricName: nodeMemoryActive
+
+  - query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance)
+    metricName: nodeMemoryCached+nodeMemoryBuffers
+
+  - query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
+    metricName: rxNetworkBytes
+
+  - query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
+    metricName: txNetworkBytes
+
+  - query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m])
+    metricName: nodeDiskWrittenBytes
+
+  - query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m])
+    metricName: nodeDiskReadBytes
+
+  - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
+    metricName: etcdLeaderChangesRate
+
+# Etcd metrics
+  - query: etcd_server_is_leader > 0
+    metricName: etcdServerIsLeader
+
+  - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
+    metricName: 99thEtcdDiskBackendCommitDurationSeconds
+
+  - query: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))
+    metricName: 99thEtcdDiskWalFsyncDurationSeconds
+
+  - query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))
+    metricName: 99thEtcdRoundTripTimeSeconds
+
+  - query: etcd_mvcc_db_total_size_in_bytes
+    metricName: etcdDBPhysicalSizeBytes
+
+  - query: etcd_mvcc_db_total_size_in_use_in_bytes
+    metricName: etcdDBLogicalSizeBytes
+
+  - query: sum(rate(etcd_object_counts{}[5m])) by (resource) > 0
+    metricName: etcdObjectCount
+
+  - query: sum by (cluster_version)(etcd_cluster_version)
+    metricName: etcdVersion
+    instant: true
+
+# Cluster metrics
+  - query: count(kube_namespace_created)
+    metricName: namespaceCount
+
+  - query: sum(kube_pod_status_phase{}) by (phase)
+    metricName: podStatusCount
+
+  - query: count(kube_secret_info{})
+    metricName: secretCount
+
+  - query: count(kube_deployment_labels{})
+    metricName: deploymentCount
+
+  - query: count(kube_configmap_info{})
+    metricName: configmapCount
+
+  - query: count(kube_service_info{})
+    metricName: serviceCount
+
+  - query: kube_node_role
+    metricName: nodeRoles
+    instant: true
+
+  - query: sum(kube_node_status_condition{status="true"}) by (condition)
+    metricName: nodeStatus
+
+  - query: cluster_version{type="completed"}
+    metricName: clusterVersion
+    instant: true


### PR DESCRIPTION
### Description
The baseline performance benchmark is used to measure the performance metrics of the cluster when there are no resources loaded on the cluster. Helps in understanding the baseline performance of the control plane components, nodes, etcd, kubelet etc of Openshift. This way we can identify the bottlenecks in case of regression with respect to minor as well as major releases. The baseline workload will sleep for ${WATCH_TIME} minutes and call kube-burner indexer to collect the metrics without loading the cluster.
#### referencing issue:
https://issues.redhat.com/browse/PERFSCALE-1120