### PR TITLE
replace JOB_ITERATIONS with TEST_JOB_ITERATIONS in kube-burner-crd.yaml to avoid conflicts

### DIFF
--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -113,7 +113,7 @@ label_nodes() {
   if [[ ${1} == "heavy" ]]; then
     total_pod_count=$((total_pod_count / 2))
   fi
-  export JOB_ITERATIONS=${total_pod_count}
+  export TEST_JOB_ITERATIONS=${total_pod_count}
   log "Labeling ${NODE_COUNT} worker nodes with node-density=enabled"
   for n in ${nodes}; do
     oc label ${n} node-density=enabled --overwrite

--- a/workloads/kube-burner/kube-burner-crd.yaml
+++ b/workloads/kube-burner/kube-burner-crd.yaml
@@ -31,7 +31,7 @@ spec:
       # ES index name
       default_index: ${ES_INDEX}
       # Number of job iterations
-      job_iterations: ${JOB_ITERATIONS}
+      job_iterations: ${TEST_JOB_ITERATIONS}
       # Pin kube-burner to a node using the value of the label kubernetes.io/hostname
       pin_server: ${WORKLOAD_NODE}
       # Wait for pods to be runnig before finishing kube-burner workload

--- a/workloads/kube-burner/run_clusterdensity_test_fromgit.sh
+++ b/workloads/kube-burner/run_clusterdensity_test_fromgit.sh
@@ -4,7 +4,7 @@ set -e
 
 export WORKLOAD=cluster-density
 export METRICS_PROFILE=${METRICS_PROFILE:-metrics-aggregated.yaml}
-export JOB_ITERATIONS=${JOB_ITERATIONS:-1000}
+export TEST_JOB_ITERATIONS=${JOB_ITERATIONS:-1000}
 
 . common.sh
 

--- a/workloads/kube-burner/run_maxnamespaces_test_fromgit.sh
+++ b/workloads/kube-burner/run_maxnamespaces_test_fromgit.sh
@@ -4,7 +4,7 @@ set -e
 
 export WORKLOAD=max-namespaces
 export METRICS_PROFILE=${METRICS_PROFILE:-metrics-aggregated.yaml}
-export JOB_ITERATIONS=${NAMESPACE_COUNT:-1000}
+export TEST_JOB_ITERATIONS=${NAMESPACE_COUNT:-1000}
 
 . common.sh
 

--- a/workloads/kube-burner/run_maxservices_test_fromgit.sh
+++ b/workloads/kube-burner/run_maxservices_test_fromgit.sh
@@ -4,7 +4,7 @@ set -e
 
 export WORKLOAD=max-services
 export METRICS_PROFILE=${METRICS_PROFILE:-metrics-aggregated.yaml}
-export JOB_ITERATIONS=${SERVICE_COUNT:-1000}
+export TEST_JOB_ITERATIONS=${SERVICE_COUNT:-1000}
 
 . common.sh
 

--- a/workloads/kube-burner/run_poddensity_test_fromgit.sh
+++ b/workloads/kube-burner/run_poddensity_test_fromgit.sh
@@ -4,7 +4,7 @@ set -e
 
 export WORKLOAD=pod-density
 export METRICS_PROFILE=${METRICS_PROFILE:-metrics.yaml}
-export JOB_ITERATIONS=${PODS:-1000}
+export TEST_JOB_ITERATIONS=${PODS:-1000}
 
 . common.sh
 


### PR DESCRIPTION
### Description

The JOB_ITERATIONS variable in kube-burner is utilized twice. Once as an input from the user and again in the cr that is applied. This can cause confusion and conflicts when the user sets JOB_ITERATIONS in the env.sh file. This PR changes the variable used within the kube-burner scripts to TEST_JOB_ITERATIONS and applies that in the cr. This avoids reuse of the variable.

### Fixes
