### PR TITLE
update conditional to count lines instead of words

### DIFF
--- a/workloads/logging/common.sh
+++ b/workloads/logging/common.sh
@@ -157,7 +157,7 @@ wait_for_benchmark() {
   done
   log "Waiting for log-generator pods to start"
   suuid=$(oc get benchmark -n my-ripsaw log-generator -o jsonpath="{.status.suuid}")
-  until [[ $(oc get pod -n my-ripsaw -l job-name=log-generator-${suuid} --ignore-not-found -o jsonpath="{.items[*].status.phase}" | grep Running | wc -w) -eq $POD_COUNT ]]; do
+  until [[ $(oc get pod -n my-ripsaw -l job-name=log-generator-${suuid} --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l) -eq $POD_COUNT ]]; do
     sleep 1
     if [[ $(date +%s) -gt ${timeout} ]]; then
       log "Timeout waiting for all pods to be running"


### PR DESCRIPTION
With the current configuration, the grep do not act over the words on a line, it will be valid when there is at least one pod running, and will include any other status on the count, because wc -w will only count words, not words validated by the grep.

Actual result during the process:

```
$ oc get pod -n my-ripsaw -l job-name=log-generator-f9981cc5 --ignore-not-found -o jsonpath="{.items[*].status.phase}" | grep Running
Pending Pending Pending Running Pending Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Pending Pending Pending Running Pending Running Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Running Pending Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Running Running Pending Pending Running Running Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Running Running Pending Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Running Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Running Pending Pending Pending Pending Running Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Pending Running Pending Pending
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-f9981cc5 --ignore-not-found -o jsonpath="{.items[*].status.phase}" | grep Running | wc -w
250
```

New result:

```
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
108
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
113
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
136
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
166
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
182
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
202
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
218
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
232
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
249
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
250
[morenod@morenod-laptop ~]$ oc get pod -n my-ripsaw -l job-name=log-generator-fe788c3e --ignore-not-found -o go-template='{{ range .items}}{{.status.phase}}{{"\n"}}{{end}}' | grep Running | wc -l
250
```

