### PR TITLE
Pin scripts to pull from v0.1 release of benchmark-operator

### DIFF
--- a/workloads/etcd-perf/run_etcd_tests_fromgit.sh
+++ b/workloads/etcd-perf/run_etcd_tests_fromgit.sh
@@ -27,7 +27,7 @@ rm -rf /tmp/benchmark-operator
 oc create ns my-ripsaw
 oc create ns backpack
 
-git clone http://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator --depth 1
+git clone -b v0.1 http://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator --depth 1
 oc apply -f /tmp/benchmark-operator/deploy
 oc apply -f /tmp/benchmark-operator/resources/backpack_role.yaml
 oc apply -f /tmp/benchmark-operator/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -1,7 +1,7 @@
 
 # Common
 export OPERATOR_REPO=${OPERATOR_REPO:-https://github.com/cloud-bulldozer/benchmark-operator.git}
-export OPERATOR_BRANCH=${OPERATOR_BRANCH:-master}
+export OPERATOR_BRANCH=${OPERATOR_BRANCH:-v0.1}
 export QPS=${QPS:-20}
 export BURST=${BURST:-20}
 export POD_READY_TIMEOUT=${POD_READY_TIMEOUT:-1200}

--- a/workloads/logging/common.sh
+++ b/workloads/logging/common.sh
@@ -29,7 +29,7 @@ export UUID=${UUID:-`uuidgen`}
 
 # Operator
 operator_repo=${OPERATOR_REPO:-https://github.com/cloud-bulldozer/benchmark-operator.git}
-operator_branch=${OPERATOR_BRANCH:-master}
+operator_branch=${OPERATOR_BRANCH:-v0.1}
 timestamp=`date "+%d-%m-%YT%H:%M:%S"`
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 export METADATA_COLLECTION=${METADATA_COLLECTION:-false}

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -28,7 +28,7 @@ check_cluster_health() {
 
 export_defaults() {
   operator_repo=${OPERATOR_REPO:=https://github.com/cloud-bulldozer/benchmark-operator.git}
-  operator_branch=${OPERATOR_BRANCH:=master}
+  operator_branch=${OPERATOR_BRANCH:=v0.1}
   CRD=${CRD:-ripsaw-uperf-crd.yaml}
   export _es=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
   _es_baseline=${ES_SERVER_BASELINE:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}

--- a/workloads/scale-perf/common.sh
+++ b/workloads/scale-perf/common.sh
@@ -12,7 +12,7 @@ fi
 
 
 operator_repo=${OPERATOR_REPO:=https://github.com/cloud-bulldozer/benchmark-operator.git}
-operator_branch=${OPERATOR_BRANCH:=master}
+operator_branch=${OPERATOR_BRANCH:=v0.1}
 _es=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 _es_baseline=${ES_SERVER_BASELINE:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 _metadata_collection=${METADATA_COLLECTION:=false}

--- a/workloads/storage-perf/run_storage_tests_fromgit.sh
+++ b/workloads/storage-perf/run_storage_tests_fromgit.sh
@@ -22,7 +22,7 @@ rm -rf /tmp/benchmark-operator
 
 oc create ns my-ripsaw
 
-git clone http://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
+git clone -b v0.1 http://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator
 oc apply -f /tmp/benchmark-operator/deploy
 oc apply -f /tmp/benchmark-operator/resources/backpack_role.yaml
 oc apply -f /tmp/benchmark-operator/resources/crds/ripsaw_v1alpha1_ripsaw_crd.yaml


### PR DESCRIPTION
This should allow us to merge https://github.com/cloud-bulldozer/benchmark-operator/pull/598 without breaking e2e
