### PR TITLE
fix issue of 'oauth2client' not found in csv_gen.py for router-perf-v2

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -220,3 +220,6 @@ test_routes(){
     done <<< $(oc get route -n http-scale-${termination} --no-headers | awk '{print $2}')
   done
 }
+
+python3 -m pip install -r requirements.txt | grep -v 'already satisfied'
+


### PR DESCRIPTION
### Description
In router perf test, I got the following error in log.
```
07-09 15:02:22.377  09-07-2021T07:02:20 Generating CSV results
07-09 15:02:22.377  Traceback (most recent call last):
07-09 15:02:22.377    File "./csv_gen.py", line 9, in <module>
07-09 15:02:22.377      from oauth2client.service_account import ServiceAccountCredentials
07-09 15:02:22.377  ModuleNotFoundError: No module named 'oauth2client'
```

### Fixes
Install requirements in common.sh.
