### PR TITLE
Baremetal update

### DIFF
--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -49,8 +49,10 @@ export_defaults() {
   #If using baremetal we use different query to find worker nodes
   if [ "$baremetal" != "No resources found in openshift-machine-api namespace." ]; then
   log "Colocating uperf pods for baremetal"
-  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}')
-  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $2}')
+  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}')[0]
+  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}')[1]
+  echo $server
+  echo $client
   
   else
     # If multi_az we use one node from the two first AZs

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -224,12 +224,16 @@ assign_uuid() {
 }
 
 run_benchmark_comparison() {
+  log "Begining benchamrk comparison"
   ../../utils/touchstone-compare/run_compare.sh uperf ${baseline_uperf_uuid} ${compare_uperf_uuid} ${pairs}
   pairs_array=( "${pairs_array[@]}" "compare_output_${pairs}.yaml" )
+  log "Finished benchmark comparison"
 }
 
 generate_csv() {
+  log "Generating CSV"
   python3 csv_gen.py --files $(echo "${pairs_array[@]}") --latency_tolerance=$latency_tolerance --throughput_tolerance=$throughput_tolerance  
+  log "Finished generating CSV"
 }
 
 init_cleanup() {
@@ -252,6 +256,7 @@ update() {
 }
 
 print_uuid() {
+  log "Logging uuid.txt"
   cat uuid.txt
 }
 

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -52,7 +52,7 @@ export_defaults() {
   export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}')
   export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $2}')
   
-  elif [ "$baremetal" == "No resources found in openshift-machine-api namespace." ]; then
+  else
     # If multi_az we use one node from the two first AZs
     if [[ ${multi_az} == "true" ]]; then
       # Get AZs from worker nodes

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -47,12 +47,12 @@ export_defaults() {
   zones=($(oc get nodes -l node-role.kubernetes.io/workload!=,node-role.kubernetes.io/worker -o go-template='{{ range .items }}{{ index .metadata.labels "topology.kubernetes.io/zone" }}{{ "\n" }}{{ end }}' | uniq))
 
   #If using baremetal we use different query to find worker nodes
-  if [[ {$baremetal} != "No resources found openshift-machine-api namespace"]]; then
+  if [[ {$baremetal} != "No resources found openshift-machine-api namespace" ]]; then
   log "Colocating uperf pods for baremetal"
   export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}')
   export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $2}')
   
-  elif [[ {$baremetal} == "No resources found openshift-machine-api namespace"; then
+  elif [[ {$baremetal} == "No resources found openshift-machine-api namespace" ]]; then
   # If multi_az we use one node from the two first AZs
     if [[ ${multi_az} == "true" ]]; then
       # Get AZs from worker nodes

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -49,8 +49,8 @@ export_defaults() {
   #If using baremetal we use different query to find worker nodes
   if [ "$baremetal" != "No resources found in openshift-machine-api namespace." ]; then
   log "Colocating uperf pods for baremetal"
-  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==0{print $1}')
-  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==1{print $1}')
+  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==1{print $1}')
+  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==2{print $1}')
   
   else
     # If multi_az we use one node from the two first AZs

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -48,9 +48,15 @@ export_defaults() {
 
   #If using baremetal we use different query to find worker nodes
   if [[ "${baremetalCheck}" == '"BareMetal"' ]]; then
-  log "Colocating uperf pods for baremetal"
-  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==1{print $1}')
-  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==2{print $1}')
+    log "Colocating uperf pods for baremetal"
+    nodeCount=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | wc -l)
+    if [[ ${nodeCount} -ge 2 ]]; then
+      export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==1{print $1}')
+      export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==2{print $1}')
+    else
+      log "At least 2 worker nodes are required"
+      exit 1
+    fi  
   
   else
     # If multi_az we use one node from the two first AZs

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -49,10 +49,8 @@ export_defaults() {
   #If using baremetal we use different query to find worker nodes
   if [ "$baremetal" != "No resources found in openshift-machine-api namespace." ]; then
   log "Colocating uperf pods for baremetal"
-  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}')[0]
-  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}')[1]
-  echo $server
-  echo $client
+  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}'[0])
+  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}'[1])
   
   else
     # If multi_az we use one node from the two first AZs

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -47,13 +47,13 @@ export_defaults() {
   zones=($(oc get nodes -l node-role.kubernetes.io/workload!=,node-role.kubernetes.io/worker -o go-template='{{ range .items }}{{ index .metadata.labels "topology.kubernetes.io/zone" }}{{ "\n" }}{{ end }}' | uniq))
 
   #If using baremetal we use different query to find worker nodes
-  if [[ {$baremetal} != "No resources found openshift-machine-api namespace" ]]; then
+  if [ "$baremetal" != "No resources found in openshift-machine-api namespace." ]; then
   log "Colocating uperf pods for baremetal"
   export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}')
   export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $2}')
   
-  elif [[ {$baremetal} == "No resources found openshift-machine-api namespace" ]]; then
-  # If multi_az we use one node from the two first AZs
+  elif [ "$baremetal" == "No resources found in openshift-machine-api namespace." ]; then
+    # If multi_az we use one node from the two first AZs
     if [[ ${multi_az} == "true" ]]; then
       # Get AZs from worker nodes
       log "Colocating uperf pods in different AZs"

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -47,7 +47,7 @@ export_defaults() {
   zones=($(oc get nodes -l node-role.kubernetes.io/workload!=,node-role.kubernetes.io/worker -o go-template='{{ range .items }}{{ index .metadata.labels "topology.kubernetes.io/zone" }}{{ "\n" }}{{ end }}' | uniq))
 
   #If using baremetal we use different query to find worker nodes
-  if [[ ${baremetalCheck} == "BareMetal" ]]; then
+  if [[ "${baremetalCheck}" == '"BareMetal"' ]]; then
   log "Colocating uperf pods for baremetal"
   export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==1{print $1}')
   export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==2{print $1}')

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -43,11 +43,11 @@ export_defaults() {
   export pin=true
   export networkpolicy=${NETWORK_POLICY:=false}
   export multi_az=${MULTI_AZ:=true}
-  export baremetalCheck=$(oc get bmh -n openshift-machine-api)
+  export baremetalCheck=$(oc get infrastructure cluster -o json | jq .spec.platformSpec.type)
   zones=($(oc get nodes -l node-role.kubernetes.io/workload!=,node-role.kubernetes.io/worker -o go-template='{{ range .items }}{{ index .metadata.labels "topology.kubernetes.io/zone" }}{{ "\n" }}{{ end }}' | uniq))
 
   #If using baremetal we use different query to find worker nodes
-  if [ "$baremetal" != "No resources found in openshift-machine-api namespace." ]; then
+  if [[ ${baremetalCheck} == "BareMetal" ]]; then
   log "Colocating uperf pods for baremetal"
   export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==1{print $1}')
   export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==2{print $1}')

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -49,8 +49,8 @@ export_defaults() {
   #If using baremetal we use different query to find worker nodes
   if [ "$baremetal" != "No resources found in openshift-machine-api namespace." ]; then
   log "Colocating uperf pods for baremetal"
-  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}[0]')
-  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}[1]')
+  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==1{print $1}')
+  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==2{print $1}')
   
   else
     # If multi_az we use one node from the two first AZs

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -49,8 +49,8 @@ export_defaults() {
   #If using baremetal we use different query to find worker nodes
   if [ "$baremetal" != "No resources found in openshift-machine-api namespace." ]; then
   log "Colocating uperf pods for baremetal"
-  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==1{print $1}')
-  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==2{print $1}')
+  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==0{print $1}')
+  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR==1{print $1}')
   
   else
     # If multi_az we use one node from the two first AZs

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -43,29 +43,39 @@ export_defaults() {
   export pin=true
   export networkpolicy=${NETWORK_POLICY:=false}
   export multi_az=${MULTI_AZ:=true}
+  export baremetalCheck=$(oc get bmh -n openshift-machine-api)
   zones=($(oc get nodes -l node-role.kubernetes.io/workload!=,node-role.kubernetes.io/worker -o go-template='{{ range .items }}{{ index .metadata.labels "topology.kubernetes.io/zone" }}{{ "\n" }}{{ end }}' | uniq))
 
+  #If using baremetal we use different query to find worker nodes
+  if [[ {$baremetal} != "No resources found openshift-machine-api namespace"]]; then
+  log "Colocating uperf pods for baremetal"
+  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}')
+  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $2}')
+  
+  elif [[ {$baremetal} == "No resources found openshift-machine-api namespace"; then
   # If multi_az we use one node from the two first AZs
-  if [[ ${multi_az} == "true" ]]; then
-    # Get AZs from worker nodes
-    log "Colocating uperf pods in different AZs"
-    if [[ ${#zones[@]} -gt 1 ]]; then
-      export server=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",topology.kubernetes.io/zone=${zones[0]} -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}' | head -n1)
-      export client=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",topology.kubernetes.io/zone=${zones[1]} -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}' | tail -n1)
+    if [[ ${multi_az} == "true" ]]; then
+      # Get AZs from worker nodes
+      log "Colocating uperf pods in different AZs"
+      if [[ ${#zones[@]} -gt 1 ]]; then
+        export server=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",topology.kubernetes.io/zone=${zones[0]} -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}' | head -n1)
+        export client=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",topology.kubernetes.io/zone=${zones[1]} -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}' | tail -n1)
+      else
+        log "At least 2 worker nodes placed in different topology zones are required"
+        exit 1
+      fi
+    # If multi_az is disabled we use the two first nodes from the first AZ
     else
-      log "At least 2 worker nodes placed in different topology zones are required"
-      exit 1
+      nodes=($(oc get nodes -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",topology.kubernetes.io/zone=${zones[0]} -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}'))
+      if [[ ${#nodes[@]} -lt 2 ]]; then
+        log "At least 2 worker nodes placed in the topology zone ${zones[0]} are required"
+        exit 1
+      fi
+      log "Colocating uperf pods in the same AZ"
+      export server=${nodes[0]}
+      export client=${nodes[1]}
     fi
-  # If multi_az is disabled we use the two first nodes from the first AZ
-  else
-    nodes=($(oc get nodes -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",topology.kubernetes.io/zone=${zones[0]} -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}'))
-    if [[ ${#nodes[@]} -lt 2 ]]; then
-      log "At least 2 worker nodes placed in the topology zone ${zones[0]} are required"
-      exit 1
-    fi
-    log "Colocating uperf pods in the same AZ"
-    export server=${nodes[0]}
-    export client=${nodes[1]}
+    log "Finished assigning server and client nodes"
   fi
 
   if [ ${WORKLOAD} == "hostnet" ]

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -49,8 +49,8 @@ export_defaults() {
   #If using baremetal we use different query to find worker nodes
   if [ "$baremetal" != "No resources found in openshift-machine-api namespace." ]; then
   log "Colocating uperf pods for baremetal"
-  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}'[0])
-  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}'[1])
+  export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}[0]')
+  export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk '{print $1}[1]')
   
   else
     # If multi_az we use one node from the two first AZs

--- a/workloads/network-perf/requirements.txt
+++ b/workloads/network-perf/requirements.txt
@@ -2,3 +2,4 @@ gspread
 gspread-formatting
 oauth2client
 PyYAML>=5.4.1
+make

--- a/workloads/network-perf/requirements.txt
+++ b/workloads/network-perf/requirements.txt
@@ -1,4 +1,4 @@
 gspread
 gspread-formatting
 oauth2client
-pyyaml
+PyYAML>=5.4.1

--- a/workloads/upgrade-perf/common.sh
+++ b/workloads/upgrade-perf/common.sh
@@ -55,7 +55,7 @@ rm -rf /tmp/snafu upgrade
 
 git clone https://github.com/cloud-bulldozer/benchmark-wrapper.git /tmp/snafu
 
-python3 -m venv upgrade
+python3.8 -m venv upgrade
 source upgrade/bin/activate
 pip3 install -e /tmp/snafu
 


### PR DESCRIPTION
### Description
First attempt to have network-perf tests check infrastructure type for BareMetal. 
### Fixes
Once BareMetal is detected as the infrastructure type, separate code is used to assign client and server worker nodes for the benchmark tests. Currently, it only assigns the first two worker nodes that are returned. The current code fails to assign the env vars as it is written for aws.
Secondly, I had to update PyYAML version as currently it seems to use a deprecated version that `yaml.FullLoader` does not exist and will cause the code to fail.