### PR TITLE
Fix threshold for network latency and throughput tolerance

### DIFF
--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -37,8 +37,8 @@ export_defaults() {
   export COMPARE=${COMPARE:=false}
   network_type=$(oc get network cluster  -o jsonpath='{.status.networkType}' | tr '[:upper:]' '[:lower:]')
   gold_sdn=${GOLD_SDN:=openshiftsdn}
-  throughput_tolerance=${THROUGHPUT_TOLERANCE:=5}
-  latency_tolerance=${LATENCY_TOLERANCE:=5}
+  throughput_tolerance=${THROUGHPUT_TOLERANCE:=10}
+  latency_tolerance=${LATENCY_TOLERANCE:=10}
   export client_server_pairs=(1 2 4)
   export pin=true
   export networkpolicy=${NETWORK_POLICY:=false}


### PR DESCRIPTION
Signed-off-by: Kedar Vijay Kulkarni <kkulkarni@redhat.com>

### Description
The README said default should be 10 but script was setting it to 5. 

### Fixes
Fix the defaults to match what README says it should be in https://github.com/cloud-bulldozer/e2e-benchmarking/blob/master/workloads/network-perf/README.md