### PR TITLE
Scale ingress controller down to 0 before setting liveness probe

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -58,6 +58,7 @@ tune_liveness_probe(){
   oc scale --replicas=0 -n openshift-cluster-version deploy/cluster-version-operator
   oc scale --replicas=0 -n openshift-ingress-operator deploy/ingress-operator
   log "Increasing ingress controller liveness probe period to $((RUNTIME * 2))s"
+  oc scale --replicas=0 -n openshift-ingress deploy/router-default
   oc set probe -n openshift-ingress --liveness --period-seconds=$((RUNTIME * 2)) deploy/router-default
   log "Scaling number of routers to ${NUMBER_OF_ROUTERS}"
   oc scale --replicas=${NUMBER_OF_ROUTERS} -n openshift-ingress deploy/router-default


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
In single node deployments we need to scale the number of ingress controllers to zero before setting liveness probe due to the anti-affinity rules of this deployment  and the deployment rollout policy (maxUnavailable is 50%)

### Fixes
- Fixes #220 