### PR TITLE
Fix benchmark comparison in uperf tests

### DIFF
--- a/utils/touchstone-compare/run_compare.sh
+++ b/utils/touchstone-compare/run_compare.sh
@@ -21,6 +21,7 @@ fi
 set -x
 if [[ ${COMPARE_WITH_GOLD} == "true" ]] || [[ ${COMPARE} == "true" ]]; then
   echo "Comparing"
+  echo "baseline gold uuid: ${2} current run uuid: ${3}"
   touchstone_compare --database elasticsearch -url $_es_baseline $_es -u ${2} ${3} -o yaml --config config/${tool}.json --tolerancy-rules tolerancy-configs/${tool}.yaml | grep -v "ERROR"| tee compare_output_${!#}.yaml
 else
   touchstone_compare --database elasticsearch -url $_es -u ${2} -o yaml --config config/${tool}.json --tolerancy-rules tolerancy-configs/${tool}.yaml | grep -v "ERROR"| tee compare_output_${!#}.yaml

--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -45,10 +45,6 @@ Note: Make sure that elasticsearch baseline uuid (example: BASELINE_POD_1P_UUID,
 Default: `openshiftsdn`   
 Compares the current run with gold-index with the sdn type of GOLD_SDN. Options: `openshiftsdn` and `ovnkubernetes`
 
-### GOLD_OCP_VERSION
-Default: ``     
-The openshift version you want to compare the current run to
-
 ### ES_GOLD
 Default: ``     
 The ES server that houses gold-index. Format `http(s)://[username]:[password]@[address]:[port]`

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -95,7 +95,7 @@ export_defaults() {
      export GSHEET_KEY_LOCATION=$HOME/.secrets/gsheet_key.json
   fi
 
-  if [[ ${COMPARE} = "true" ]] && [[ ${COMPARE_WITH_GOLD} == "true" ]]; then
+  if [[ ${COMPARE} == "true" ]] && [[ ${COMPARE_WITH_GOLD} == "true" ]]; then
     gold_index=$(curl -X GET   "${ES_GOLD}/openshift-gold-${platform}-results/_search" -H 'Content-Type: application/json' -d ' {"query": {"term": {"version": '\"${GOLD_OCP_VERSION}\"'}}}')
     BASELINE_HOSTNET_UUID=$(echo $gold_index | jq -r '."hits".hits[0]."_source"."uperf-benchmark".'\"$gold_sdn\"'."network_type"."hostnetwork"."num_pairs"."1"."uuid"')
     BASELINE_POD_1P_UUID=$(echo $gold_index | jq -r '."hits".hits[0]."_source"."uperf-benchmark".'\"$gold_sdn\"'."network_type"."podnetwork"."num_pairs"."1"."uuid"')
@@ -248,6 +248,11 @@ update() {
   benchmark_state=$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-${WORKLOAD}-network-${pairs} -n benchmark-operator -o jsonpath='{.status.state}')
   benchmark_uuid=$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-${WORKLOAD}-network-${pairs} -n benchmark-operator -o jsonpath='{.status.uuid}')
   benchmark_current_pair=$(oc get benchmarks.ripsaw.cloudbulldozer.io/uperf-benchmark-${WORKLOAD}-network-${pairs} -n benchmark-operator -o jsonpath='{.spec.workload.args.pair}')
+}
+
+get_gold_ocp_version(){
+  current_version=`oc get clusterversion | grep -o [0-9.]* | head -1 | cut -c 1-3`
+  export GOLD_OCP_VERSION=$( bc <<< "$current_version - 0.1" )
 }
 
 print_uuid() {

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -96,6 +96,7 @@ export_defaults() {
   fi
 
   if [[ ${COMPARE} == "true" ]] && [[ ${COMPARE_WITH_GOLD} == "true" ]]; then
+    get_gold_ocp_version
     gold_index=$(curl -X GET   "${ES_GOLD}/openshift-gold-${platform}-results/_search" -H 'Content-Type: application/json' -d ' {"query": {"term": {"version": '\"${GOLD_OCP_VERSION}\"'}}}')
     BASELINE_HOSTNET_UUID=$(echo $gold_index | jq -r '."hits".hits[0]."_source"."uperf-benchmark".'\"$gold_sdn\"'."network_type"."hostnetwork"."num_pairs"."1"."uuid"')
     BASELINE_POD_1P_UUID=$(echo $gold_index | jq -r '."hits".hits[0]."_source"."uperf-benchmark".'\"$gold_sdn\"'."network_type"."podnetwork"."num_pairs"."1"."uuid"')


### PR DESCRIPTION
### Description
fixes benchmark comparison in uperf 
adds new function get_gold_ocp_version to automatically get the cluster version to compare with existing ocp version
### Fixes
Fixes failing airflow uperf runs 