### PR TITLE
add infra!= to zones selector as rosa infra nodes as labeled as infra,worker

### DIFF
--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -43,7 +43,7 @@ export_defaults() {
   export pin=true
   export networkpolicy=${NETWORK_POLICY:=false}
   export multi_az=${MULTI_AZ:=true}
-  zones=($(oc get nodes -l node-role.kubernetes.io/workload!=,node-role.kubernetes.io/worker -o go-template='{{ range .items }}{{ index .metadata.labels "topology.kubernetes.io/zone" }}{{ "\n" }}{{ end }}' | uniq))
+  zones=($(oc get nodes -l node-role.kubernetes.io/workload!=,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/worker -o go-template='{{ range .items }}{{ index .metadata.labels "topology.kubernetes.io/zone" }}{{ "\n" }}{{ end }}' | uniq))
   platform=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.type}' | tr '[:upper:]' '[:lower:]')
   log "Platform is found to be : ${platform} "
   # If multi_az we use one node from the two first AZs


### PR DESCRIPTION
Zones search is failing on rosa clusters because nodes are labeled on a different way:

$ oc get nodes
NAME                                         STATUS   ROLES          AGE   VERSION
ip-10-0-133-190.us-west-2.compute.internal   Ready    worker         75m   v1.21.1+9807387
ip-10-0-135-251.us-west-2.compute.internal   Ready    infra,worker   51m   v1.21.1+9807387
ip-10-0-141-182.us-west-2.compute.internal   Ready    master         82m   v1.21.1+9807387
ip-10-0-164-185.us-west-2.compute.internal   Ready    worker         73m   v1.21.1+9807387
ip-10-0-166-165.us-west-2.compute.internal   Ready    infra,worker   51m   v1.21.1+9807387
ip-10-0-170-115.us-west-2.compute.internal   Ready    master         82m   v1.21.1+9807387
ip-10-0-194-87.us-west-2.compute.internal    Ready    infra,worker   50m   v1.21.1+9807387
ip-10-0-206-22.us-west-2.compute.internal    Ready    worker         75m   v1.21.1+9807387
ip-10-0-216-216.us-west-2.compute.internal   Ready    master         81m   v1.21.1+9807387

