### PR TITLE
Rename VERSION parameter to prevent conflict with benchmark-operator…

### DIFF
--- a/ci/env.sh
+++ b/ci/env.sh
@@ -17,7 +17,7 @@ export NODE_COUNT=1
 export PODS_PER_NODE=100
 
 #for upgrade perf
-export VERSION=`oc get clusterversion | grep -o [0-9.]* | head -1`
+export TOVERSION=`oc get clusterversion | grep -o [0-9.]* | head -1`
 
 # For router perf v2
 export RUNTIME=5

--- a/workloads/scale-perf/common.sh
+++ b/workloads/scale-perf/common.sh
@@ -66,9 +66,9 @@ fi
 
 echo "Starting test for cloud: $cloud_name"
 
-log "Removing benchmark-operator namespace, if it already exists"
+echo "Removing benchmark-operator namespace, if it already exists"
 oc delete namespace benchmark-operator --ignore-not-found
-log "Cloning benchmark-operator from branch ${operator_branch} of ${operator_repo}"
+echo "Cloning benchmark-operator from branch ${operator_branch} of ${operator_repo}"
 rm -rf benchmark-operator
 git clone --single-branch --branch ${operator_branch} ${operator_repo} --depth 1
 (cd benchmark-operator && make deploy)

--- a/workloads/upgrade-perf/README.md
+++ b/workloads/upgrade-perf/README.md
@@ -11,7 +11,7 @@ $ ./run_<test-name>_fromgit.sh
 
 ## Environment variables
 
-### VERSION
+### TOVERSION
 Default: ''
 The version to upgrade to. The version must be on the list of previous or available updates.
 
@@ -78,7 +78,6 @@ export BASELINE_CLOUD_NAME=
 export ES_SERVER_BASELINE=
 export ES_PORT_BASELINE=
 export BASELINE_UUID=
-export VERSION=
 export TOVERSION=
 export POLL_INTERVAL=
 export TIMEOUT=

--- a/workloads/upgrade-perf/common.sh
+++ b/workloads/upgrade-perf/common.sh
@@ -70,8 +70,8 @@ echo "Current version $_init_version"
 echo "UUID: $_uuid"
 
 # fail if the version to upgrade to is not set
-if [[ -z $TOIMAGE ]] && [[ -z $LATEST ]] && [[ -z $VERSION ]]; then
-  echo "Looks like the version to upgrade to is not set, please set either TOIMAGE, LATEST or VERSION environment vars"
+if [[ -z $TOIMAGE ]] && [[ -z $LATEST ]] && [[ -z $TOVERSION ]]; then
+  echo "Looks like the version to upgrade to is not set, please set either TOIMAGE, LATEST or TOVERSION environment vars"
   exit 1
 fi
 

--- a/workloads/upgrade-perf/run_upgrade_fromgit.sh
+++ b/workloads/upgrade-perf/run_upgrade_fromgit.sh
@@ -19,8 +19,8 @@ if [[ -n $TOIMAGE ]]; then
   run_snafu --tool upgrade -u ${_uuid} --toimage ${TOIMAGE} --timeout ${_timeout} --poll_interval ${_poll_interval}
 elif [[ -n $LATEST ]]; then
   run_snafu --tool upgrade -u ${_uuid} --latest ${LATEST} --timeout ${_timeout} --poll_interval ${_poll_interval}
-elif [[ -n $VERSION ]]; then
-  run_snafu --tool upgrade -u ${_uuid} --version ${VERSION} --timeout ${_timeout} --poll_interval ${_poll_interval}
+elif [[ -n $TOVERSION ]]; then
+  run_snafu --tool upgrade -u ${_uuid} --version ${TOVERSION} --timeout ${_timeout} --poll_interval ${_poll_interval}
 fi
 
 _snafu_rc=$?


### PR DESCRIPTION
…s VERSION

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Benchmark-operator's makefile uses VERSION as parameter, the upgrade workload is breaking CI.

### Fixes
