### PR TITLE
Cluster Density Needs Config map to have quotes

### DIFF
--- a/workloads/kube-burner/workloads/cluster-density/templates/configmap.yml
+++ b/workloads/kube-burner/workloads/cluster-density/templates/configmap.yml
@@ -4,5 +4,5 @@ kind: ConfigMap
 metadata:
   name: {{.JobName}}-{{.Replica}}
 data:
-  key1: {{rand 4}}
-  key2: {{rand 10}}
+  key1: "{{rand 4}}"
+  key2: "{{rand 10}}"


### PR DESCRIPTION
### Description
Adding in quotes around key1 and key2 that are randomly generated strings

Tested out and successfully created a configmap that had value: **key1: 0483** 

### Fixes
https://github.com/cloud-bulldozer/e2e-benchmarking/issues/231
