### PR TITLE
Fix cluster-density variables

### DIFF
--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -30,7 +30,7 @@ export REMOTE_METRIC_PROFILE=${REMOTE_METRIC_PROFILE}
 export REMOTE_ALERT_PROFILE=${REMOTE_ALERT_PROFILE}
 
 # Kube-burner job
-export KUBE_BURNER_IMAGE=${KUBE_BURNER_IMAGE:-quay.io/cloud-bulldozer/kube-burner:v0.13}
+export KUBE_BURNER_IMAGE=${KUBE_BURNER_IMAGE:-quay.io/cloud-bulldozer/kube-burner:v0.13.1}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-14400}
 export LOG_STREAMING=${LOG_STREAMING:-true}

--- a/workloads/kube-burner/workloads/cluster-density/cluster-density.yml
+++ b/workloads/kube-burner/workloads/cluster-density/cluster-density.yml
@@ -62,7 +62,6 @@ jobs:
         inputVars:
           podReplicas: 2
           name: deployment-2pod
-          envVar: {{rand 700}}
           nodeSelector: "{{.POD_NODE_SELECTOR}}"
 
       - objectTemplate: https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/workloads/cluster-density/templates/service.yml
@@ -75,7 +74,6 @@ jobs:
         inputVars:
           podReplicas: 1
           name: deployment-1pod
-          envVar: {{rand 700}}
           nodeSelector: "{{.POD_NODE_SELECTOR}}"
       
       - objectTemplate: https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/workloads/cluster-density/templates/service.yml

--- a/workloads/kube-burner/workloads/cluster-density/templates/configmap.yml
+++ b/workloads/kube-burner/workloads/cluster-density/templates/configmap.yml
@@ -4,5 +4,5 @@ kind: ConfigMap
 metadata:
   name: {{.JobName}}-{{.Replica}}
 data:
-  key1: {{rand 4}}
-  key2: {{rand 10}}
+  key1: "{{rand 4}}"
+  key2: "{{rand 10}}"

--- a/workloads/kube-burner/workloads/cluster-density/templates/deployment.yml
+++ b/workloads/kube-burner/workloads/cluster-density/templates/deployment.yml
@@ -35,13 +35,13 @@ spec:
         name: {{.name}}
         env:
         - name: ENVVAR1_{{.name}}
-          value: {{rand 250}}
+          value: "{{rand 250}}"
         - name: ENVVAR2_{{.name}}
-          value: {{rand 250}}
+          value: "{{rand 250}}"
         - name: ENVVAR3_{{.name}}
-          value: {{rand 250}}
+          value: "{{rand 250}}"
         - name: ENVVAR4_{{.name}}
-          value: {{rand 250}}
+          value: "{{rand 250}}"
       volumes:
       - name: secret-1
         secret:

--- a/workloads/kube-burner/workloads/cluster-density/templates/secret.yml
+++ b/workloads/kube-burner/workloads/cluster-density/templates/secret.yml
@@ -4,4 +4,4 @@ kind: Secret
 metadata:
   name: {{.JobName}}-{{.Replica}}
 data:
-  top-secret: {{rand 2048}}
+  top-secret: "{{rand 2048}}"


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Configmap and secret data must be strings, double quoting it to prevent issues like the following:
```
oc create -f - << EOF
apiVersion: v1
kind: ConfigMap
metadata:
  name: foo
data:
  key1: 4
EOF
Error from server (BadRequest): error when creating "STDIN": ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.ObjectMeta: v1.ObjectMeta.TypeMeta: Kind: Data: ReadString: expects " or n, but found 4, error found in #10 byte of ...|:{"key1":4},"kind":"|..., bigger context ...|{"apiVersion":"v1","data":{"key1":4},"kind":"ConfigMap","metadata":{"name":"temaller"|...
``` 

Where double quoted works like a charm
```
$ oc create -f - << EOF
apiVersion: v1                                    
kind: ConfigMap                                                                                                        
metadata:            
  name: foo              
data:                                                                                                                  
  key1: "4"                                                                                                            
EOF                                    
configmap/temaller created 
```

### Fixes

cluster-density randomly fails when the random generated character is a number.
