### PR TITLE
Fix in maxnamespaces and maxservices kube-burner workloads

### DIFF
--- a/workloads/kube-burner/run_maxnamespaces_test_fromgit.sh
+++ b/workloads/kube-burner/run_maxnamespaces_test_fromgit.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TEST_JOB_ITERATIONS=${NAMESPACE_COUNT:-1000}
+export TEST_JOB_ITERATIONS=${NAMESPACE_COUNT:-1000}
 export WORKLOAD=max-namespaces
 export REMOTE_CONFIG=${REMOTE_CONFIG:-https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/workloads/max-namespaces/max-namespaces.yml}
 export REMOTE_METRIC_PROFILE=${REMOTE_METRIC_PROFILE:-https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/metrics-profiles/metrics-aggregated.yml}

--- a/workloads/kube-burner/run_maxservices_test_fromgit.sh
+++ b/workloads/kube-burner/run_maxservices_test_fromgit.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-TEST_JOB_ITERATIONS=${SERVICE_COUNT:-1000}
+export TEST_JOB_ITERATIONS=${SERVICE_COUNT:-1000}
 export WORKLOAD=max-services
 export REMOTE_CONFIG=https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/workloads/max-services/max-services.yml
 export REMOTE_METRIC_PROFILE=${REMOTE_METRIC_PROFILE:-https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/metrics-profiles/metrics-aggregated.yml}


### PR DESCRIPTION
### Description
This PR closes #235, where job iterations for the maxservices and maxnamespaces kube-burner
workloads were being set to 0.

### Fixes
Closes #235 
