### PR TITLE
Adjusting comparison to key on BASELINE_UUID being set

### DIFF
--- a/workloads/router-perf-v2/ingress-performance.sh
+++ b/workloads/router-perf-v2/ingress-performance.sh
@@ -32,7 +32,7 @@ oc rsync -n http-scale-client $(oc get pod -l app=http-scale-client -n http-scal
 tune_workload_node delete
 cleanup_infra
 if [[ -n ${ES_SERVER} ]]; then
-  if [[ ${COMPARE_WITH_GOLD} == "true" ]]; then 
+  if [[ ${BASELINE_UUID} != "" ]]; then 
     log "Generating results in compare.yaml"
     ../../utils/touchstone-compare/run_compare.sh mb ${BASELINE_UUID} ${UUID} ${NUM_NODES}
     python3 -m venv ./venv


### PR DESCRIPTION
### Description
Changing comparison to key on BASELINE_UUID being set instead of COMPARE_WITH_GOLD

### Fixes
If a user sets the large or small scale uuid to compare to and sets compate with gold to false (since they do not want to fetch the data from ES) the comparison was being skipped. Keying off BASELINE_UUID being set allows for either situation to work as well as the user not setting any comparison.