### PR TITLE
Adding missing env variable to env.sh and README

### DIFF
--- a/workloads/router-perf-v2/README.md
+++ b/workloads/router-perf-v2/README.md
@@ -61,6 +61,7 @@ It's possible to tune the default configuration through environment variables. T
 | ES_SERVER             | Elasticsearch endpoint to send metrics | `https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443` |
 | ES_SERVER_BASELINE    | Elasticsearch endpoint used to fetch baseline results | "" |
 | ES_INDEX              | Elasticsearch index | `router-test-results` |
+| COMPARE               | Should we compare the gathered data to the baseline small/large scale UUIDs if provided | "false" |
 | SMALL_SCALE_BASELINE_UUID | Baseline UUID to compare small scale results with (optional) | "" |
 | LARGE_SCALE_BASELINE_UUID | Baseline UUID to compare large scale results with (optional) | "" |
 | PREFIX                | Test name prefix (optional) | Result of `oc get clusterversion version -o jsonpath="{.status.desired.version}"` |

--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -35,6 +35,7 @@ QUIET_PERIOD=${QUIET_PERIOD:-60s}
 KEEPALIVE_REQUESTS=${KEEPALIVE_REQUESTS:-"0 1 50"}
 
 # Comparison and csv generation
+export COMPARE="false"
 THROUGHPUT_TOLERANCE=${THROUGHPUT_TOLERANCE:-5}
 LATENCY_TOLERANCE=${LATENCY_TOLERANCE:-5}
 PREFIX=${PREFIX:-$(oc get clusterversion version -o jsonpath="{.status.desired.version}")}


### PR DESCRIPTION
### Description
The COMPARE env variable was being used in utils/touchstone_compare/run_compare.sh but was not in the router env.sh or README. If this is not set and the user wants to compare data without the GOLD UUID no comparison is produced.

### Fixes
