### PR TITLE
fix snappy error due to grep/pipe 

### DIFF
--- a/utils/snappy-move-results/common.sh
+++ b/utils/snappy-move-results/common.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -xeEo pipefail
+#set -xeEo pipefail
+set -x
 
 # Get OpenShift cluster details
 export cluster_name=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')


### PR DESCRIPTION
### Description
snappy part in uperf scripts are failing on airflow, due to error in grep/pipe
disabling -o pipefail should solve this issue by not terminating immediately and return 0 
This error does not occur when a uperf script runs individually, but is seen on airflow dags when run after the control plane tests , 
only the infra lines fail
infra=`oc get nodes -l node-role.kubernetes.io/infra | grep -v NAME -m 1 | awk '{print $1}'`
INFRA_NODE_TYPE=`oc describe node $infra | grep "node.kubernetes.io/instance-type" | grep -oE "[^=]+$"`
possible theories are grep takes too long to find or multiple pipes cause a timeout.  

