### PR TITLE
Sleep 10s before next run

### DIFF
--- a/workloads/scale-perf/README.md
+++ b/workloads/scale-perf/README.md
@@ -41,7 +41,7 @@ Timeout value (in minutes) for each scale event
 
 ### RUNS
 Default: 3
-How many times to run the scale up. It will scale down to the original size before running the next itteration
+How many times to run the scale up. It will scale down to the original size before running the next iteration
 
 ### ES_SERVER
 Default: `https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443`

--- a/workloads/scale-perf/run_scale_fromgit.sh
+++ b/workloads/scale-perf/run_scale_fromgit.sh
@@ -113,8 +113,8 @@ EOF
       fi
       
     fi
-    oc delete pod $scale_pod -n benchmark-operator --ignore-not-found --wait
     oc -n benchmark-operator delete benchmark/scale --ignore-not-found --wait
+    sleep 10
   done
 done
 


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

We're creating a new benchmark with the same uuid just after deleting the previous one, benchmark-operator goes crazy and marks the new one as completed w/o doing nothing.



