### PR TITLE
CPU and memory by node role plus failed pods breakdown

### DIFF
--- a/workloads/kube-burner/metrics-profiles/metrics-aggregated.yml
+++ b/workloads/kube-burner/metrics-profiles/metrics-aggregated.yml
@@ -78,15 +78,6 @@
   metricName: nodeMemoryTotal-AggregatedInfra
   instant: true
 
-- query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeMemoryCached+nodeMemoryBuffers-Masters
-
-- query: avg(node_memory_Cached_bytes + node_memory_Buffers_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
-  metricName: nodeMemoryCached+nodeMemoryBuffers-AggregatedWorkers
-
-- query: avg(node_memory_Cached_bytes + node_memory_Buffers_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
-  metricName: nodeMemoryCached+nodeMemoryBuffers-AggregatedInfra
-
 - query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
   metricName: rxNetworkBytes-Masters
 
@@ -167,6 +158,9 @@
 
 - query: sum(kube_pod_status_phase{}) by (phase)
   metricName: podStatusCount
+
+- query: kube_pod_status_phase{phase="Failed"} > 0
+  metricName: failedPods
 
 - query: count(kube_secret_info{})
   metricName: secretCount

--- a/workloads/kube-burner/metrics-profiles/metrics.yml
+++ b/workloads/kube-burner/metrics-profiles/metrics.yml
@@ -52,18 +52,35 @@
   metricName: containerNetworkSetupOverallLatency
 
 # Node metrics
-- query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0
-  metricName: nodeCPU
+- query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0  and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
+  metricName: nodeCPU-workers
 
-- query: avg(node_memory_MemAvailable_bytes) by (instance)
-  metricName: nodeMemoryAvailable
+- query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0  and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
+  metricName: nodeCPU-masters
 
-- query: avg(node_memory_MemTotal_bytes) by (instance)
-  metricName: nodeMemoryTotal
+- query: sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) > 0  and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
+  metricName: nodeCPU-infra
+
+- query: avg(node_memory_MemAvailable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryAvailable-Masters
+
+- query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryAvailable-AggregatedWorkers
+
+- query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryAvailable-AggregatedInfra
+
+- query: avg(node_memory_MemTotal_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryTotal-Masters
   instant: true
 
-- query: avg(node_memory_Cached_bytes) by (instance) + avg(node_memory_Buffers_bytes) by (instance)
-  metricName: nodeMemoryCached+nodeMemoryBuffers
+- query: avg(node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryTotal-AggregatedWorkers
+  instant: true
+
+- query: avg(node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
+  metricName: nodeMemoryTotal-AggregatedInfra
+  instant: true
 
 - query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
   metricName: rxNetworkBytes
@@ -112,6 +129,9 @@
 
 - query: sum(kube_pod_status_phase{}) by (phase)
   metricName: podStatusCount
+
+- query: kube_pod_status_phase{phase="Failed"} > 0
+  metricName: failedPods
 
 - query: count(kube_secret_info{})
   metricName: secretCount


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
Add per node role memory/cpu metrics, also adding failed pod metrics to ease debugging.
Remove buffers + cached memory (usually useless)


### Fixes
