### PR TITLE
New Pod density heavy workload

### DIFF
--- a/workloads/kube-burner/run_poddensity-heavy_test_fromgit.sh
+++ b/workloads/kube-burner/run_poddensity-heavy_test_fromgit.sh
@@ -4,7 +4,7 @@ set -e
 
 export WORKLOAD=pod-density
 export TEST_JOB_ITERATIONS=${PODS:-1000}
-export REMOTE_CONFIG=${REMOTE_CONFIG:-https://raw.githubusercontent.com/Harshith-umesh/e2e-benchmarking/master/workloads/kube-burner/workloads/node-pod-density/pod-density-heavy.yml}
+export REMOTE_CONFIG=${REMOTE_CONFIG:-https://raw.githubusercontent.com/Harshith-umesh/e2e-benchmarking/master/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml}
 export REMOTE_METRIC_PROFILE=${REMOTE_METRIC_PROFILE:-https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/metrics-profiles/metrics.yml}
 
 . common.sh

--- a/workloads/kube-burner/run_poddensity-heavy_test_fromgit.sh
+++ b/workloads/kube-burner/run_poddensity-heavy_test_fromgit.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/bash -e
+
+set -e
+
+export WORKLOAD=pod-density
+export TEST_JOB_ITERATIONS=${PODS:-1000}
+export REMOTE_CONFIG=${REMOTE_CONFIG:-https://raw.githubusercontent.com/Harshith-umesh/e2e-benchmarking/master/workloads/kube-burner/workloads/node-pod-density/pod-density-heavy.yml}
+export REMOTE_METRIC_PROFILE=${REMOTE_METRIC_PROFILE:-https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/metrics-profiles/metrics.yml}
+
+. common.sh
+
+deploy_operator
+check_running_benchmarks
+deploy_workload
+wait_for_benchmark ${WORKLOAD}
+rm -rf benchmark-operator
+if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then
+  cleanup
+fi
+exit ${rc}

--- a/workloads/kube-burner/run_poddensity-heavy_test_fromgit.sh
+++ b/workloads/kube-burner/run_poddensity-heavy_test_fromgit.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export WORKLOAD=pod-density
+export WORKLOAD=pod-density-heavy
 export TEST_JOB_ITERATIONS=${PODS:-1000}
 export REMOTE_CONFIG=${REMOTE_CONFIG:-https://raw.githubusercontent.com/Harshith-umesh/e2e-benchmarking/master/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml}
 export REMOTE_METRIC_PROFILE=${REMOTE_METRIC_PROFILE:-https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/metrics-profiles/metrics.yml}

--- a/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
+++ b/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
@@ -11,12 +11,12 @@ global:
     - name: podLatency
       esIndex: {{.ES_INDEX}}
 jobs:
-  - name: node-density
+  - name: pod-density-heavy
     jobIterations: {{.JOB_ITERATIONS}}
     qps: {{.QPS}}
     burst: {{.BURST}}
     namespacedIterations: false
-    namespace: node-density-{{.UUID}}
+    namespace: pod-density-heavy-{{.UUID}}
     podWait: {{.POD_WAIT}}
     cleanup: {{.CLEANUP}}
     waitFor: {{.WAIT_FOR}}
@@ -31,3 +31,5 @@ jobs:
         inputVars:
           containerImage: quay.io/cloud-bulldozer/hello-openshift:latest
           nodeSelector: "{{.POD_NODE_SELECTOR}}"
+          readinessPeriod: 10
+          livenessPeriod: 10

--- a/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
+++ b/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
@@ -1,0 +1,33 @@
+---
+global:
+  writeToFile: false
+  indexerConfig:
+    enabled: {{.INDEXING}}
+    esServers: ["{{.ES_SERVER}}"]
+    insecureSkipVerify: true
+    defaultIndex: {{.ES_INDEX}}
+    type: elastic
+  measurements:
+    - name: podLatency
+      esIndex: {{.ES_INDEX}}
+jobs:
+  - name: node-density
+    jobIterations: {{.JOB_ITERATIONS}}
+    qps: {{.QPS}}
+    burst: {{.BURST}}
+    namespacedIterations: false
+    namespace: node-density-{{.UUID}}
+    podWait: {{.POD_WAIT}}
+    cleanup: {{.CLEANUP}}
+    waitFor: {{.WAIT_FOR}}
+    waitWhenFinished: {{.WAIT_WHEN_FINISHED}}
+    verifyObjects: {{.VERIFY_OBJECTS}}
+    errorOnVerify: {{.ERROR_ON_VERIFY}}
+    maxWaitTimeout: {{.MAX_WAIT_TIMEOUT}}
+    objects:
+
+      - objectTemplate: https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/workloads/node-pod-density/templates/pod.yml
+        replicas: 1
+        inputVars:
+          containerImage: gcr.io/google_containers/pause-amd64:3.0
+          nodeSelector: "{{.POD_NODE_SELECTOR}}"

--- a/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
+++ b/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
@@ -29,5 +29,5 @@ jobs:
       - objectTemplate: https://raw.githubusercontent.com/cloud-bulldozer/e2e-benchmarking/master/workloads/kube-burner/workloads/node-pod-density/templates/pod.yml
         replicas: 1
         inputVars:
-          containerImage: gcr.io/google_containers/pause-amd64:3.0
+          containerImage: quay.io/cloud-bulldozer/hello-openshift:latest
           nodeSelector: "{{.POD_NODE_SELECTOR}}"

--- a/workloads/kube-burner/workloads/pod-density-heavy/templates/pod.yml
+++ b/workloads/kube-burner/workloads/pod-density-heavy/templates/pod.yml
@@ -1,0 +1,17 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: {{.JobName}}-{{.Iteration}}
+  labels:
+    name: {{.JobName}}
+spec:
+  nodeSelector: {{.nodeSelector}}
+  containers:
+  - name: node-density
+    image: {{.containerImage}}
+    ports:
+    - containerPort: 8080
+      protocol: TCP
+    imagePullPolicy: IfNotPresent
+    securityContext:
+      privileged: false

--- a/workloads/kube-burner/workloads/pod-density-heavy/templates/pod.yml
+++ b/workloads/kube-burner/workloads/pod-density-heavy/templates/pod.yml
@@ -7,11 +7,27 @@ metadata:
 spec:
   nodeSelector: {{.nodeSelector}}
   containers:
-  - name: node-density
+  - name: pod-density-heavy
     image: {{.containerImage}}
     ports:
     - containerPort: 8080
       protocol: TCP
     imagePullPolicy: IfNotPresent
+    readinessProbe:
+      httpGet:
+        path: /
+        port: 8080
+      periodSeconds: {{ .readinessPeriod }}
+      failureThreshold: 1
+      timeoutSeconds: 60
+      initialDelaySeconds: 30
+    livenessProbe:
+      httpGet:
+        path: /
+        port: 8080
+      periodSeconds: {{ .livenessPeriod }}
+      failureThreshold: 1
+      timeoutSeconds: 15
+      initialDelaySeconds: 30
     securityContext:
       privileged: false


### PR DESCRIPTION
### Description
A new workload in kube-burner i.e. a heavier version of pod density , the current implementation of pod density only creates sleep pods and not a heavy application which can push the cluster to its maximum. The new workload uses readiness and liveness probes as well which generate load on the worker nodes. Container image used in this new workload is hello-openshift (quay.io/cloud-bulldozer/hello-openshift:latest) which sets an HTTP response "hello openshift" on port 8080.

### Fixes
https://github.com/cloud-bulldozer/e2e-benchmarking/issues/184 