### PR TITLE
making e2e scripts use manual uuid if given

### DIFF
--- a/indexing/jenkins/index.sh
+++ b/indexing/jenkins/index.sh
@@ -33,7 +33,7 @@ if [[ -z $JENKINS_USER ]] || [[ -z $JENKINS_API_TOKEN ]]; then
 fi
 
 # Generate a uuid
-export UUID=$(uuidgen)
+export UUID=${UUID:-$(uuidgen)}
 
 # Timestamp
 timestamp=`date +"%Y-%m-%dT%T.%3N"`

--- a/workloads/baseline-performance/common.sh
+++ b/workloads/baseline-performance/common.sh
@@ -15,7 +15,7 @@ export WRITE_TO_FILE=${WRITE_TO_FILE:-false}
 export WATCH_TIME=${WATCH_TIME:-30}
 
 
-export UUID=$(uuidgen)
+export UUID=${UUID:-$(uuidgen)}
 
 export PROM_URL=https://$(oc get route -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")
 export PROM_TOKEN=$(oc -n openshift-monitoring sa get-token prometheus-k8s)

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -10,7 +10,7 @@ else
   export PROM_TOKEN=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
 fi
 export TOLERATIONS="[{key: role, value: workload, effect: NoSchedule}]"
-export UUID=$(uuidgen)
+export UUID=${UUID:-$(uuidgen)}
 
 log() {
   echo -e "\033[1m$(date "+%d-%m-%YT%H:%M:%S") ${@}\033[0m"

--- a/workloads/network-perf/env.sh
+++ b/workloads/network-perf/env.sh
@@ -1,3 +1,4 @@
+export UUID=${UUID:-$(uuidgen)}
 export ES_SERVER=
 export METADATA_COLLECTION=true
 export COMPARE=false

--- a/workloads/network-perf/ripsaw-uperf-crd.yaml
+++ b/workloads/network-perf/ripsaw-uperf-crd.yaml
@@ -6,6 +6,7 @@ metadata:
   name: uperf-benchmark-${WORKLOAD}-network-${pairs}
   namespace: benchmark-operator
 spec:
+  uuid: ${UUID}
   elasticsearch:
     url: $_es
   clustername: $cloud_name

--- a/workloads/prometheus-sizing/common.sh
+++ b/workloads/prometheus-sizing/common.sh
@@ -1,6 +1,6 @@
 source env.sh
 
-export UUID=$(uuidgen)
+export UUID=${UUID:-$(uuidgen)}
 export PROM_URL=https://$(oc get route -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")
 export PROM_TOKEN=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
 

--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -1,6 +1,6 @@
 # General
 export KUBECONFIG=${KUBECONFIG:-~/.kube/config}
-export UUID=$(uuidgen)
+export UUID=${UUID:-$(uuidgen)}
 
 # ES configuration
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}


### PR DESCRIPTION
Ensures e2e checks for the UUID env var before generating a random uuid. If that environment variable exists, it'll use that instead.