### PR TITLE
Increse default step size

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -33,7 +33,7 @@ All scripts can be tweaked with the following environment variables:
 | **WAIT_FOR**         | Wait for the resources of this list to be ready | [] (empty means all of them) |
 | **VERIFY_OBJECTS**   | Verify objects created by kube-burner | true |
 | **ERROR_ON_VERIFY**  | Make kube-burner pod to hang when verification fails | true |
-| **STEP_SIZE**        | Prometheus step size, useful for long benchmarks | 30s|
+| **STEP_SIZE**        | Prometheus step size, useful for long benchmarks | 2m|
 | **LOG_STREAMING**    | Enable log streaming of kube-burner pod | true |
 | **CLEANUP**          | Delete old namespaces for the selected workload before starting benchmark | false |
 | **CLEANUP_WHEN_FINISH** | Delete workload's namespaces after running it | false |

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -9,7 +9,7 @@ export POD_READY_TIMEOUT=${POD_READY_TIMEOUT:-180}
 export INDEXING=${INDEXING:-true}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
-export STEP_SIZE=${STEP_SIZE:-30s}
+export STEP_SIZE=${STEP_SIZE:-2m}
 export METADATA_COLLECTION=${METADATA_COLLECTION:-true}
 export PROM_URL=${PROM_URL:-https://prometheus-k8s.openshift-monitoring.svc.cluster.local:9091}
 


### PR DESCRIPTION
### Description

We index too many documents in most of our tests, this should help us to reduce that number by 4 in detriment of 30 seconds granularity (which we don't need in the majority of cases)

### Fixes
