### PR TITLE
add error handling to gsheet creation

### DIFF
--- a/workloads/network-perf/csv_gen.py
+++ b/workloads/network-perf/csv_gen.py
@@ -201,6 +201,10 @@ parser.add_argument(
 params = parser.parse_args()
 generate_csv(params.yaml_files, f"{params.sheetname}.csv")
 if "EMAIL_ID_FOR_RESULTS_SHEET" in os.environ and "GSHEET_KEY_LOCATION" in os.environ:
-    push_to_gsheet(
-        f"{params.sheetname}.csv", os.environ["GSHEET_KEY_LOCATION"], os.environ["EMAIL_ID_FOR_RESULTS_SHEET"],
-    )
+    try:
+        push_to_gsheet(
+            f"{params.sheetname}.csv", os.environ["GSHEET_KEY_LOCATION"], os.environ["EMAIL_ID_FOR_RESULTS_SHEET"],
+        )
+    except Exception as e:
+        print("Error while generating gsheet: ")
+        print(e)

--- a/workloads/router-perf-v2/csv_gen.py
+++ b/workloads/router-perf-v2/csv_gen.py
@@ -256,8 +256,12 @@ if len(params.uuids) > 2:
     exit(1)
 generate_csv(params, f"{params.sheetname}.csv")
 if "EMAIL_ID_FOR_RESULTS_SHEET" and "GSHEET_KEY_LOCATION" in os.environ:
-    push_to_gsheet(
-        f"{params.sheetname}.csv",
-        os.environ["GSHEET_KEY_LOCATION"],
-        os.environ["EMAIL_ID_FOR_RESULTS_SHEET"],
-    )
+    try:
+        push_to_gsheet(
+            f"{params.sheetname}.csv",
+            os.environ["GSHEET_KEY_LOCATION"],
+            os.environ["EMAIL_ID_FOR_RESULTS_SHEET"],
+        )
+    except Exception as e:
+        print("Error while generating gsheet: ")
+        print(e)


### PR DESCRIPTION
### Description
At present router and network test are marked as failed, if there are some issues with google sheet API's which should not be the case.
Recently came across a DAG run where EMAIL_ID var was not even exported but still it tried to send gsheet email to NULL address, which returned error and test was marked failed. 
