### PR TITLE
remove set

### DIFF
--- a/utils/snappy-move-results/common.sh
+++ b/utils/snappy-move-results/common.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 #set -xeEo pipefail
-set -x
 
 # Get OpenShift cluster details
 export cluster_name=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')


### PR DESCRIPTION
using `set -x` messes up the last output line of Airflow benchmarks, preventing the uuid from being passed and subsequently indexed. That breaks report functionality