### PR TITLE
remove unused fi

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -209,4 +209,4 @@ snappy_backup() {
  ../../utils/snappy-move-results/run_snappy.sh metadata.json $snappy_path
  store_on_elastic
  rm -rf files_list
-fi
+}


### PR DESCRIPTION
Router test failing on airflow because this fi

[2021-10-26 20:16:43,111] {subprocess.py:78} INFO - ./common.sh: line 212: syntax error near unexpected token `fi'
[2021-10-26 20:16:43,112] {subprocess.py:78} INFO - 4bc2b05f-511d-462f-b852-adf0dafad2fb
[2021-10-26 20:16:43,112] {subprocess.py:82} INFO - Command exited with return code 2
