### PR TITLE
Exit on benchmark error

### DIFF
--- a/utils/benchmark-operator.sh
+++ b/utils/benchmark-operator.sh
@@ -48,6 +48,8 @@ remove_benchmark_operator() {
 ############################################################################
 run_benchmark() {
   source ${ripsaw_tmp}/bin/activate
+  set -e
   ripsaw benchmark run -f ${1} -t ${2}
+  set +e
   deactivate
 }


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

The benchmarks using ripsaw-cli are not currently exiting 1 when hitting an error (Workload failure and/or timeout).

### Fixes
