### PR TITLE
have UUID as local variable for networking tests

### DIFF
--- a/workloads/network-perf/env.sh
+++ b/workloads/network-perf/env.sh
@@ -1,6 +1,5 @@
 # Common
 TEST_CLEANUP=${TEST_CLEANUP:-true}
-export UUID=${UUID:-$(uuidgen)}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 export METADATA_COLLECTION=${METADATA_COLLECTION:-true}
 export METADATA_TARGETED=${METADATA_TARGETED:-true}

--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -4,6 +4,7 @@ export WORKLOAD=hostnet
 source ./common.sh
 export HOSTNETWORK=true
 export pairs=1
+export UUID=$(uuidgen)
 
 run_workload ripsaw-uperf-crd.yaml
 if [[ $? != 0 ]]; then

--- a/workloads/network-perf/run_pod_network_policy_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_policy_test_fromgit.sh
@@ -5,6 +5,7 @@ source ./common.sh
 export NETWORK_POLICY=true
 
 for pairs in 1 2 4; do
+  export UUID=$(uuidgen)
   export pairs=${pairs}
   run_workload ripsaw-uperf-crd.yaml
   if [[ $? != 0 ]]; then

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -4,6 +4,7 @@ export WORKLOAD=pod
 source ./common.sh
 
 for pairs in 1 2 4; do
+  export UUID=$(uuidgen)
   export pairs
   run_workload ripsaw-uperf-crd.yaml
   if [[ $? != 0 ]]; then

--- a/workloads/network-perf/run_serviceip_network_policy_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_policy_test_fromgit.sh
@@ -9,6 +9,7 @@ if [[ "${isBareMetal}" == "true" ]]; then
 fi
 
 for pairs in 1 2 4; do
+  export UUID=$(uuidgen)
   export pairs=${pairs}
   run_workload ripsaw-uperf-crd.yaml
   if [[ $? != 0 ]]; then

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -5,6 +5,7 @@ source ./common.sh
 export SERVICEIP=true
 
 for pairs in 1 2 4; do
+  export UUID=$(uuidgen)
   export pairs
   run_workload ripsaw-uperf-crd.yaml
   if [[ $? != 0 ]]; then

--- a/workloads/network-perf/smoke_test.sh
+++ b/workloads/network-perf/smoke_test.sh
@@ -3,6 +3,7 @@ export WORKLOAD=pod
 source ./common.sh
 
 for pairs in 1 2 4; do
+  export UUID=$(uuidgen)
   export pairs=${pairs}
   run_workload smoke-crd.yaml
   if [[ $? != 0 ]]; then


### PR DESCRIPTION
### Description
Uperf run from e2e requires 3 uuids (hn, p2p, p2s). When we set a uuid at a global level all the three test get the same uuid and it is impossible for benchmark-comparison to differentiate between them, for now at least. This commit should initialize different uuids for the 3 tests.