### PR TITLE
Replace uuid variable that was empty with one with the actual UUID

### DIFF
--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -144,7 +144,7 @@ run_workload() {
 }
 
 assign_uuid() {
-  compare_uperf_uuid=${benchmark_uuid}
+  compare_uperf_uuid=${UUID}
   if [ ${WORKLOAD} == "hostnet" ] ; then
     baseline_uperf_uuid=${_baseline_hostnet_uuid}
   elif [ ${WORKLOAD} == "service" ] ; then


### PR DESCRIPTION
### Description
The benchmark_uuid was not in use anywhere and never set by the test so when it would go to compare the uuid of the running test would be empty. Replaced this with the UUID set for the run.

### Fixes
