### PR TITLE
Adjust NUM_NODES command in router test to account for managed services

### DIFF
--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -7,7 +7,7 @@ export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4b
 export ES_INDEX=${ES_INDEX:-router-test-results}
 
 # Environment setup
-NUM_NODES=$(oc get node -l node-role.kubernetes.io/worker --no-headers | grep -cw Ready)
+NUM_NODES=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!=,node-role.kubernetes.io/infra!= --no-headers | grep -cw Ready)
 ENGINE=${ENGINE:-podman}
 KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.11/kube-burner-0.11-Linux-x86_64.tar.gz}
 KUBE_BURNER_IMAGE=quay.io/cloud-bulldozer/kube-burner:latest


### PR DESCRIPTION
### Description
The way NUM_NODES is calculated currently doesn't account for clusters that tag workload and infra nodes as worker nodes as well. This would result in a miscalculation of workers.

### Fixes
Fix NUM_NODES calculation to account for managed services