### PR TITLE
Remove extra / which is causing errors on reencrypt route tests

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -177,7 +177,7 @@ test_routes(){
       local scheme="http://"
     fi
     for host in $(oc get route -n http-scale-${termination} --no-headers -o custom-columns="route:.spec.host"); do
-      curl --retry 3 --connect-timeout 5 -sSk ${scheme}${host}/${URL_PATH} -o /dev/null
+      curl --retry 3 --connect-timeout 5 -sSk ${scheme}${host}${URL_PATH} -o /dev/null
     done
   done
 }


### PR DESCRIPTION
Router test is failing on Airflow executions for ROSA because of this function:


```
[2021-11-16, 16:53:41 CET] {subprocess.py:89} INFO - /home/airflow/workspace/e2e-benchmarking/workloads/router-perf-v2
[2021-11-16, 16:53:41 CET] {subprocess.py:89} INFO - [1mTue Nov 16 15:53:41 UTC 2021 Testing all routes before triggering the workload[0m
[2021-11-16, 16:59:08 CET] {subprocess.py:89} INFO - curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
```

Route checked is: https://http-perf-reencrypt-1-http-scale-reencrypt.apps.airflow-49-e51a.dny1.s1.devshift.org//1024.html

The double slash is making curl fails:

```
$ curl -k https://http-perf-reencrypt-1-http-scale-reencrypt.apps.airflow-49-e51a.dny1.s1.devshift.org//1024.html
curl: (92) HTTP/2 stream 0 was not closed cleanly: PROTOCOL_ERROR (err 1)
```


Removing it, everything works:

```
$ curl -k https://http-perf-reencrypt-1-http-scale-reencrypt.apps.airflow-49-e51a.dny1.s1.devshift.org/1024.html
<!DOCTYPE html>
<html>
<head>
<title>Welcome 1024B</title>
</head>
<body>
<h1>Welcome 1024B</h1>

<pre>
1234567891123456789212345678931234567894123456789512345678961234567897123456789812345678991234567890123456789112345678921234567
1234567891123456789212345678931234567894123456789512345678961234567897123456789812345678991234567890123456789112345678921234567
1234567891123456789212345678931234567894123456789512345678961234567897123456789812345678991234567890123456789112345678921234567
1234567891123456789212345678931234567894123456789512345678961234567897123456789812345678991234567890123456789112345678921234567
1234567891123456789212345678931234567894123456789512345678961234567897123456789812345678991234567890123456789112345678921234567
1234567891123456789212345678931234567894123456789512345678961234567897123456789812345678991234567890123456789112345678921234567
1234567891123456789212345678931234567894123456789512345678961234567897123456789812345678991234567890123456789112345678921234567
</pre>

</body>
</html>

```

