### PR TITLE
fix venv deactivate conflict

### DIFF
--- a/utils/common.sh
+++ b/utils/common.sh
@@ -80,7 +80,7 @@ gen_spreadsheet_helper() {
 
 gen_spreadsheet() {
   log "Installing requirements to generate spreadsheet"
-  if [[ "$VIRTUAL_ENV" != "" ]]; then
+  if [[ "${VIRTUAL_ENV}" != "" ]]; then
     gen_spreadsheet_helper ${1} ${2} ${3} ${4}
   else
     csv_tmp=$(mktemp -d)

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -81,12 +81,12 @@ gen_spreadsheet_helper() {
 gen_spreadsheet() {
   log "Installing requirements to generate spreadsheet"
   if [[ "$VIRTUAL_ENV" != "" ]]; then
-    gen_spreadsheet_helper
+    gen_spreadsheet_helper ${1} ${2} ${3} ${4}
   else
     csv_tmp=$(mktemp -d)
     python -m venv ${csv_tmp}
     source ${csv_tmp}/bin/activate
-    gen_spreadsheet_helper
+    gen_spreadsheet_helper ${1} ${2} ${3} ${4}
     deactivate
     rm -rf ${csv_tmp}
   fi

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -74,11 +74,7 @@ log() {
 ##############################################################################
 gen_spreadsheet() {
   log "Installing requirements to generate spreadsheet"
-  csv_tmp=$(mktemp -d)
-  python -m venv ${csv_tmp}
-  source ${csv_tmp}/bin/activate
   pip install oauth2client>=4.1.3 gspread
   python3 ../../utils/csv_gen.py --sheetname ${1}-$(date "+%Y-%m-%dT%H:%M:%S") -c ${2} --email ${3} --service-account ${4}
-  rm -rf ${csv_tmp}
 }
 

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -72,9 +72,22 @@ log() {
 #   Gmail email address
 #   Service account file
 ##############################################################################
-gen_spreadsheet() {
-  log "Installing requirements to generate spreadsheet"
+
+gen_spreadsheet_helper() {
   pip install oauth2client>=4.1.3 gspread
-  python3 ../../utils/csv_gen.py --sheetname ${1}-$(date "+%Y-%m-%dT%H:%M:%S") -c ${2} --email ${3} --service-account ${4}
+  python3 $(dirname $(realpath ${BASH_SOURCE[0]}))/csv_gen.py --sheetname ${1}-$(date "+%Y-%m-%dT%H:%M:%S") -c ${2} --email ${3} --service-account ${4}
 }
 
+gen_spreadsheet() {
+  log "Installing requirements to generate spreadsheet"
+  if [[ "$VIRTUAL_ENV" != "" ]]; then
+    gen_spreadsheet_helper
+  else
+    csv_tmp=$(mktemp -d)
+    python -m venv ${csv_tmp}
+    source ${csv_tmp}/bin/activate
+    gen_spreadsheet_helper
+    deactivate
+    rm -rf ${csv_tmp}
+  fi
+}

--- a/utils/common.sh
+++ b/utils/common.sh
@@ -79,7 +79,6 @@ gen_spreadsheet() {
   source ${csv_tmp}/bin/activate
   pip install oauth2client>=4.1.3 gspread
   python3 ../../utils/csv_gen.py --sheetname ${1}-$(date "+%Y-%m-%dT%H:%M:%S") -c ${2} --email ${3} --service-account ${4}
-  deactivate
   rm -rf ${csv_tmp}
 }
 

--- a/utils/compare.sh
+++ b/utils/compare.sh
@@ -11,7 +11,9 @@ install_touchstone() {
 }
 
 remove_touchstone() {
-  deactivate
+  if [[ -z ${GSHEET_KEY_LOCATION} ]]; then
+    deactivate
+  fi
   rm -rf "${touchstone_tmp}"
 }
 

--- a/utils/compare.sh
+++ b/utils/compare.sh
@@ -11,9 +11,7 @@ install_touchstone() {
 }
 
 remove_touchstone() {
-  if [[ -z ${GSHEET_KEY_LOCATION} ]]; then
-    deactivate
-  fi
+  deactivate
   rm -rf "${touchstone_tmp}"
 }
 


### PR DESCRIPTION
### Description
error: `[2021-11-29, 20:38:02 UTC] {subprocess.py:89} INFO - ../../utils/compare.sh: line 14: deactivate: command not found`. 
This error occurs since we're trying to deactivate venv when it's already been deactivated. This happens because we're creating a virtualenv inside an already existing venv and when we try to deactivate the inner venv, both venv's get deactivated. The second venv is created in generate google spreadsheet function. 
first venv: https://github.com/cloud-bulldozer/e2e-benchmarking/blob/dc5b31b5119605579ccbd1c6eaf6bf4a2f81dc2c/utils/compare.sh#L8 
second venv: https://github.com/cloud-bulldozer/e2e-benchmarking/blob/dc5b31b5119605579ccbd1c6eaf6bf4a2f81dc2c/utils/common.sh#L78 
So a solution is to ignore the first venv's deactivate command if deactivate from the google spreadsheet fn is called. This can be done by checking if gsheet_key_location var is set , if not set we can let the deactivate command of the first venv execute.  
### Fixes
https://github.com/cloud-bulldozer/e2e-benchmarking/issues/290 