### PR TITLE
Uperf single run

### DIFF
--- a/workloads/network-perf/run.sh
+++ b/workloads/network-perf/run.sh
@@ -3,11 +3,11 @@
 source ./common.sh
 export WORKLOAD=${WORKLOAD}
 
-  if [[ $WORKLOAD == "hostnet" ]]; then
+if [[ $WORKLOAD == "hostnet" ]]; then
     export HOSTNETWORK=true
-  elif [[ $WORKLOAD == "" ]]; then
+elif [[ $WORKLOAD == "service" ]]; then
     export SERVICEIP=true 
-  fi
+fi
 
 export pairs=${PAIRS:-1}
 export UUID=${UUID:-$(uuidgen)}

--- a/workloads/network-perf/run.sh
+++ b/workloads/network-perf/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+source ./common.sh
+export WORKLOAD=${WORKLOAD}
+
+  if [[ $WORKLOAD == "hostnet" ]]; then
+    export HOSTNETWORK=true
+  elif [[ $WORKLOAD == "" ]]; then
+    export SERVICEIP=true 
+  fi
+
+export pairs=${PAIRS:-1}
+export UUID=${UUID:-$(uuidgen)}
+
+run_workload ripsaw-uperf-crd.yaml
+if [[ $? != 0 ]]; then
+  exit 1
+fi
+
+log "Finished workload ${0}"


### PR DESCRIPTION
### Description

Current Uperf Scripts for pod and service network tests actually run three separate runs per script invocation (different number of pairs). In Airflow we assume 1 benchmark per task, so we want to run those three in separate tasks. 

This script `run.sh` will just run any generic uperf workload, and take in the necessary params to configure it. We can use this in our Airflow benchmark configs to split out the runs into separate tasks. 
