### PR TITLE
Bump default KUBE_BURNER_IMAGE for kube-burner workload

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -38,7 +38,7 @@ All scripts can be tweaked with the following environment variables:
 | **LOG_STREAMING**    | Enable log streaming of kube-burner pod | true |
 | **CLEANUP**          | Delete old namespaces for the selected workload before starting benchmark | false |
 | **CLEANUP_WHEN_FINISH** | Delete workload's namespaces after running it | false |
-| **KUBE_BURNER_IMAGE** | Kube-burner container image | quay.io/cloud-bulldozer/kube-burner:v0.13 |
+| **KUBE_BURNER_IMAGE** | Kube-burner container image | quay.io/cloud-bulldozer/kube-burner:v0.14.3 |
 | **LOG_LEVEL**        | Kube-burner log level | info |
 | **PPROF_COLLECTION** | Collect and store pprof data locally | false |
 | **PPROF_COLLECTION_INTERVAL** | Intervals for which pprof data will be collected | 5m | 
@@ -145,4 +145,5 @@ Password for the Snappy data-server.
 
 **`SNAPPY_USER_FOLDER`**
 Default: 'perf-ci'
-To store the data for a specific user
+To store the data for a specific user.
+

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -30,7 +30,7 @@ export REMOTE_METRIC_PROFILE=${REMOTE_METRIC_PROFILE}
 export REMOTE_ALERT_PROFILE=${REMOTE_ALERT_PROFILE}
 
 # Kube-burner job
-export KUBE_BURNER_IMAGE=${KUBE_BURNER_IMAGE:-quay.io/cloud-bulldozer/kube-burner:v0.14.1}
+export KUBE_BURNER_IMAGE=${KUBE_BURNER_IMAGE:-quay.io/cloud-bulldozer/kube-burner:v0.14.3}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-14400}
 export LOG_STREAMING=${LOG_STREAMING:-true}


### PR DESCRIPTION
### Description
Interim solution as we should try to replace the hard coded version with a `stable` tag.

### Fixes
- `kube-burner` bug fixes around Elasticsearch (https://github.com/cloud-bulldozer/kube-burner/releases/tag/v0.14.3)