### PR TITLE
Adding python3 specific version to touchstone installation

### DIFF
--- a/utils/compare.sh
+++ b/utils/compare.sh
@@ -5,7 +5,7 @@
 
 install_touchstone() {
   touchstone_tmp=$(mktemp -d)
-  python -m venv ${touchstone_tmp}
+  python3 -m venv ${touchstone_tmp}
   source ${touchstone_tmp}/bin/activate
   pip3 install git+https://github.com/cloud-bulldozer/benchmark-comparison.git
 }


### PR DESCRIPTION
### Description
In our test jenkins machines we have both python and python3 installed on our systems. Using python [here](https://github.com/cloud-bulldozer/e2e-benchmarking/blob/528eed64f791ae9856cde8bee082bcd998905c36/utils/compare.sh#L8) results in an error like the below. Are we able to add in python3 specifically here, so that we are able to properly create a python3 virtualenv? Thanks

### Fixes
01-10 15:23:41.990  Mon Jan 10 07:23:41 UTC 2022 Installing touchstone
01-10 15:23:41.990  /usr/bin/python: No module named venv