### PR TITLE
print scale up/down timings on stdout

### DIFF
--- a/workloads/scale-perf/run_scale_fromgit.sh
+++ b/workloads/scale-perf/run_scale_fromgit.sh
@@ -4,6 +4,7 @@ source ./common.sh
 source ../../utils/common.sh
 
 log "Starting test for cloud: ${CLOUD_NAME}"
+start_time=`date`
 deploy_operator
 
 # Get initial worker count
@@ -38,3 +39,6 @@ for x in $(seq 1 ${RUNS}); do
     fi
   done
 done
+end_time=`date`
+duration=`date -ud@$(($(date -ud"$end_time" +%s)-$(date -ud"$start_time" +%s))) +%T`
+log "Duration of execution: ${duration} for number of scale runs: ${RUNS}"


### PR DESCRIPTION
### Fixes
https://github.com/cloud-bulldozer/e2e-benchmarking/issues/79