### PR TITLE
Remove workload name prefix from namespace expression

### DIFF
--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -131,14 +131,14 @@ cleanup() {
   if [[ ! "$WORKLOAD" =~ cluster ]]; then
     # Force delete individual pods
     for cleanup in $(oc get pods -n $(oc get ns -l kube-burner-uuid=${UUID} -o custom-columns=name:{.metadata.name} --no-headers) --no-headers -o custom-columns=name:{.metadata.name}); do
-      oc delete -n $(oc get ns -l kube-burner-uuid=${UUID} -o custom-columns=name:{.metadata.name} --no-headers) pod/$cleanup --force;
+      oc delete -n $(oc get ns -l kube-burner-uuid=${UUID} -o custom-columns=name:{.metadata.name} --no-headers) pod/${cleanup} --force
     done
   fi
 
   # Force delete the remaining namespaces
-  for ns in $(oc get ns | grep $WORKLOAD | awk '{print $1}'); do
-    oc delete --all pods -n $ns --force --grace-period=0 --ignore-not-found --wait;
-    oc delete namespace $ns --ignore-not-found
+  for ns in $(oc get ns -l kube-burner-uuid=${UUID} -o custom-columns=name:{.metadata.name} --no-headers); do
+    oc delete --all pods -n ${ns} --force --grace-period=0 --ignore-not-found --wait
+    oc delete namespace ${ns} --ignore-not-found
   done
 }
 

--- a/workloads/kube-burner/workloads/cluster-density/cluster-density.yml
+++ b/workloads/kube-burner/workloads/cluster-density/cluster-density.yml
@@ -60,7 +60,7 @@ jobs:
     qps: ${QPS}
     burst: ${BURST}
     namespacedIterations: true
-    namespace: cluster-density-${UUID}
+    namespace: ${UUID}
     podWait: ${POD_WAIT}
     cleanup: ${CLEANUP}
     waitFor: ${WAIT_FOR}

--- a/workloads/kube-burner/workloads/max-namespaces/max-namespaces.yml
+++ b/workloads/kube-burner/workloads/max-namespaces/max-namespaces.yml
@@ -60,7 +60,7 @@ jobs:
     qps: ${QPS}
     burst: ${BURST}
     namespacedIterations: true
-    namespace: max-namespaces-${UUID}
+    namespace: ${UUID}
     podWait: ${POD_WAIT}
     cleanup: ${CLEANUP}
     waitFor: ${WAIT_FOR}

--- a/workloads/kube-burner/workloads/max-services/max-services.yml
+++ b/workloads/kube-burner/workloads/max-services/max-services.yml
@@ -55,12 +55,12 @@ global:
         url: https://localhost:2379/debug/pprof/profile?timeout=30
 {{ end }}
 jobs:
-  - name: max-serv
+  - name: max-services
     jobIterations: ${TEST_JOB_ITERATIONS}
     qps: ${QPS}
     burst: ${BURST}
     namespacedIterations: false
-    namespace: max-serv-${UUID}
+    namespace: ${UUID}
     podWait: ${POD_WAIT}
     cleanup: ${CLEANUP}
     waitFor: ${WAIT_FOR}

--- a/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
@@ -60,7 +60,7 @@ jobs:
     qps: ${QPS}
     burst: ${BURST}
     namespacedIterations: false
-    namespace: node-density-heavy-${UUID}
+    namespace: ${UUID}
     podWait: ${POD_WAIT}
     cleanup: ${CLEANUP}
     waitFor: ${WAIT_FOR}

--- a/workloads/kube-burner/workloads/node-pod-density/node-pod-density.yml
+++ b/workloads/kube-burner/workloads/node-pod-density/node-pod-density.yml
@@ -57,7 +57,7 @@ jobs:
     qps: ${QPS}
     burst: ${BURST}
     namespacedIterations: false
-    namespace: node-density-${UUID}
+    namespace: ${UUID}
     podWait: ${POD_WAIT}
     cleanup: ${CLEANUP}
     waitFor: ${WAIT_FOR}

--- a/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
+++ b/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
@@ -60,7 +60,7 @@ jobs:
     qps: ${QPS}
     burst: ${BURST}
     namespacedIterations: false
-    namespace: pod-density-heavy-${UUID}
+    namespace: ${UUID}
     podWait: ${POD_WAIT}
     cleanup: ${CLEANUP}
     waitFor: ${WAIT_FOR}


### PR DESCRIPTION


Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
Remove workload name prefix from namespace expression

### Fixes
So that:
```
time="2022-01-18 11:36:00" level=error msg="Unexpected error creating
namespace
cluster-density-8d06dda5-ae61-4a-cluster-density-1k-20220118-206:
Namespace
\"cluster-density-8d06dda5-ae61-4a-cluster-density-1k-20220118-206\" is
invalid: [metadata.name: Invalid value:
\"cluster-density-8d06dda5-ae61-4a-cluster-density-1k-20220118-206\":
must be no more than 63 characters, metadata.labels: Invalid value:
\"cluster-density-8d06dda5-ae61-4a-cluster-density-1k-20220118-206\":
must be no more than 63 characters]"```

does not happen anymore.