### PR TITLE
add retries to elastic indexing function for router-perf

### DIFF
--- a/workloads/router-perf-v2/workload.py
+++ b/workloads/router-perf-v2/workload.py
@@ -17,10 +17,17 @@ host_network = os.getenv("HOST_NETWORK", "")
 number_of_routers = os.getenv("NUMBER_OF_ROUTERS", "")
 
 
-def index_result(payload):
+def index_result(payload, retry_count=3):
     print(f"Indexing documents in {es_index}")
-    es = elasticsearch.Elasticsearch([es_server], send_get_body_as='POST')
-    es.index(index=es_index, body=payload)
+    while retry_count > 0:
+        try:
+            es = elasticsearch.Elasticsearch([es_server], send_get_body_as='POST')
+            es.index(index=es_index, body=payload)
+            retry_count = 0
+        except Exception as e:
+            print("Failed Indexing - \n" + str(e.message))
+            print("Retrying again to index...")
+            retry_count -= 1
 
 
 def run_mb(mb_config, runtime, output):


### PR DESCRIPTION
### Description
In some cases, elastic fails to index the data, throws an error, and fails the workload, which can be resolved on retry.

### Fixes
Added retries to index function to avoid flakiness.
More details on Issue - https://github.com/cloud-bulldozer/e2e-benchmarking/issues/269

closes #269 fixes #269 
