### PR TITLE
clear temp/ripsaw directory before running ci tests

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -26,12 +26,10 @@ Workload                | Test                           | Result | Runtime  |
 ------------------------|--------------------------------|--------|----------|
 EOF
 
-# Clear the /tmp/ripsaw* directory to avoid pip version conflicts due to existing temp files.
-rm -rf /tmp/ripsaw*
-
 test_rc=0
 for test in ${test_list}; do            
-
+  # Clear the /tmp/ripsaw-cli directory to avoid pip version conflicts due to existing temp files.
+  rm -rf /tmp/ripsaw-cli
   start_time=`date`
 
   command=${test##*:}                                     #to extract the shell script name to run

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -26,6 +26,9 @@ Workload                | Test                           | Result | Runtime  |
 ------------------------|--------------------------------|--------|----------|
 EOF
 
+# Clear the /tmp/ripsaw* directory to avoid pip version conflicts due to existing temp files.
+rm -rf /tmp/ripsaw*
+
 test_rc=0
 for test in ${test_list}; do            
 


### PR DESCRIPTION
### Description
CI fails when we update any dependency library version in ripsaw because of the existing old installed ripsaw in the CI node.

Adding clean steps before running any ci test to make sure that we do not have any temp ripsaw files from previous runs.