### PR TITLE
Expose the number of samples as an option for network workloads

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -32,6 +32,20 @@ Elasticsearch server to index the results of the current run. Use the notation `
 Default: `true`   
 Enable/Disable collection of metadata
 
+## Workload
+
+### HOSTNETWORK
+Default: `false` 
+If enabled will test the performance of the node the pod will run on
+
+### SERVICEIP
+Default: `false`
+This option (if enabled) will place the uperf server behind a K8s Service
+
+### SAMPLES
+Default: `3`
+How many times to run the tests
+
 ## Comparison
 
 ### COMPARE_WITH_GOLD

--- a/workloads/network-perf/env.sh
+++ b/workloads/network-perf/env.sh
@@ -15,6 +15,7 @@ export MULTI_AZ=${MULTI_AZ:=true}
 export HOSTNETWORK=false
 export SERVICEIP=false
 export TEST_TIMEOUT=${TEST_TIMEOUT:-7200}
+export SAMPLES=${SAMPLES:-3}
 
 # Comparison and csv generation
 BASELINE_HOSTNET_UUID=${BASELINE_HOSTNET_UUID}

--- a/workloads/network-perf/ripsaw-uperf-crd.yaml
+++ b/workloads/network-perf/ripsaw-uperf-crd.yaml
@@ -27,7 +27,7 @@ spec:
       pin_client: "$client"
       multus:
         enabled: false
-      samples: 3
+      samples: ${SAMPLES}
       pair: ${pairs}
       nthrs:
         - 1


### PR DESCRIPTION
### Description
In bare metal environments the oscillation between test runs is less significant compared with shared cloud ones.
Exposing the number of samples as an option will allow to run faster tests in bare metal scenarios.

### Fixes
