### PR TITLE
Kube burner metrics refactor

### DIFF
--- a/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
@@ -37,9 +37,6 @@
 - query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring|image-registry)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
   metricName: containerMemory-Infra
 
-- query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
-  metricName: containerDiskUsage
-
 # Node metrics: CPU & Memory
 
 - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
@@ -72,7 +69,6 @@
 
 - query: avg(node_memory_MemTotal_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryTotal-Infra
-  instant: true
 
 - query: irate(container_runtime_crio_operations_latency_microseconds{operation_type="network_setup_pod"}[2m]) > 0
   metricName: containerNetworkSetupLatency

--- a/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
@@ -1,10 +1,13 @@
 # API server
 
-- query: irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[2m]
-  metricName: SchedulingThroughput
+- query: irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[2m]) > 0
+  metricName: schedulingThroughput
 
-- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!="WATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))
-  metricName: APICallsLatency
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"LIST|GET", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))
+  metricName: readOnlyAPICallsLatency
+
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"POST|PUT|DELETE|PATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))
+  metricName: mutatingAPICallsLatency
 
 - query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH"}[2m])) by (verb,resource,code) > 0
   metricName: APIRequestRate
@@ -15,25 +18,30 @@
   metricName: kubeproxyP99ProgrammingLatency
 
 # Containers & pod metrics
+
 - query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|sdn|ovn-kubernetes|.*apiserver|authentication|.*controller-manager|.*scheduler|image-registry|operator-lifecycle-manager)"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
   metricName: containerCPU-Masters
 
-- query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"}[2m]) * 100 and on (node) kube_node_role{role="worker"}) by (namespace, container)) > 0
+- query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"}[2m]) * 100 and on (node) kube_node_role{role="worker"}) by (namespace, pod, container)) > 0
   metricName: containerCPU-AggregatedWorkers
 
-- query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring|image-registry|operator-lifecycle-manager)"}[2m]) * 100 and on (node) kube_node_role{role="infra"}) by (namespace, container)) > 0
+- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(monitoring|sdn|ovn-kubernetes|ingress)"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
   metricName: containerCPU-Infra
 
 - query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|image-registry|operator-lifecycle-manager)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
   metricName: containerMemory-Masters
 
-- query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"} and on (node) kube_node_role{role="worker"}) by (container, namespace)
+- query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"} and on (node) kube_node_role{role="worker"}) by (pod, container, namespace)
   metricName: containerMemory-AggregatedWorkers
 
-- query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|image-registry|operator-lifecycle-manager)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
+- query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring|image-registry)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
   metricName: containerMemory-Infra
 
-# Node metrics
+- query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
+  metricName: containerDiskUsage
+
+# Node metrics: CPU & Memory
+
 - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
   metricName: nodeCPU-Masters
 
@@ -97,14 +105,12 @@
   metricName: P99APIEtcdRequestLatency
 
 # Cluster metrics
+
 - query: sum(kube_namespace_status_phase) by (phase) > 0
   metricName: namespaceCount
 
 - query: sum(kube_pod_status_phase{}) by (phase)
   metricName: podStatusCount
-
-- query: kube_pod_status_phase{phase="Failed"} > 0
-  metricName: failedPods
 
 - query: count(kube_secret_info{})
   metricName: secretCount
@@ -127,9 +133,6 @@
 
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
-
-- query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
-  metricName: containerDiskUsage
 
 - query: cluster_version{type="completed"}
   metricName: clusterVersion

--- a/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
@@ -1,51 +1,37 @@
 # API server
-- query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!~"WATCH", subresource!="log"}[2m])) by (verb,resource,subresource,instance,le)) > 0
-  metricName: API99thLatency
 
-- query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH",subresource!="log"}[2m])) by (verb,instance,resource,code) > 0
+- query: irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[2m]
+  metricName: SchedulingThroughput
+
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!="WATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))
+  metricName: APICallsLatency
+
+- query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH"}[2m])) by (verb,resource,code) > 0
   metricName: APIRequestRate
 
-# P&F
-- query: rate(apiserver_flowcontrol_dispatched_requests_total[2m]) > 0
-  metricName: APIFlowControlDispatchedRequests
+# Kubeproxy - (SDN only)
 
-- query: sum(apiserver_flowcontrol_current_executing_requests) by (instance, priority_level,flow_schema) > 0
-  metricName: APIFlowControlCurrentExecutingRequests
-
-- query: rate(apiserver_flowcontrol_rejected_requests_total[2m]) > 0
-  metricName: APIFlowControlRejectedRequests
-
-- query: sum(apiserver_flowcontrol_current_inqueue_requests) by (instance, flow_schema, priority_level) > 0
-  metricName: APIFlowControlInqueueRequests
-
-- query: avg(apiserver_flowcontrol_request_concurrency_limit{}) by (priority_level)
-  metricName: APIFlowControlRequestConcurrencyLimit
-  instant: true
+- query: histogram_quantile(0.99, rate(kubeproxy_network_programming_duration_seconds_bucket[2m]))
+  metricName: kubeproxyP99ProgrammingLatency
 
 # Containers & pod metrics
-- query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|image-registry|operator-lifecycle-manager)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
-  metricName: containerMemory-Masters
-
 - query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|sdn|ovn-kubernetes|.*apiserver|authentication|.*controller-manager|.*scheduler|image-registry|operator-lifecycle-manager)"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
   metricName: containerCPU-Masters
-
-- query: (sum(irate(container_cpu_usage_seconds_total{pod!="",container="prometheus",namespace="openshift-monitoring"}[2m]) * 100) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
-  metricName: containerCPU-Prometheus
 
 - query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"}[2m]) * 100 and on (node) kube_node_role{role="worker"}) by (namespace, container)) > 0
   metricName: containerCPU-AggregatedWorkers
 
 - query: (avg(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring|image-registry|operator-lifecycle-manager)"}[2m]) * 100 and on (node) kube_node_role{role="infra"}) by (namespace, container)) > 0
-  metricName: containerCPU-AggregatedInfra
+  metricName: containerCPU-Infra
 
-- query: (sum(container_memory_rss{pod!="",namespace="openshift-monitoring",name!="",container="prometheus"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
-  metricName: containerMemory-Prometheus
+- query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|image-registry|operator-lifecycle-manager)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="master"}) > 0
+  metricName: containerMemory-Masters
 
 - query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress)"} and on (node) kube_node_role{role="worker"}) by (container, namespace)
   metricName: containerMemory-AggregatedWorkers
 
-- query: avg(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(sdn|ovn-kubernetes|ingress|monitoring|image-registry|operator-lifecycle-manager)"} and on (node) kube_node_role{role="infra"}) by (container, namespace)
-  metricName: containerMemory-AggregatedInfra
+- query: (sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|image-registry|operator-lifecycle-manager)"}) by (container, pod, namespace, node) and on (node) kube_node_role{role="infra"}) > 0
+  metricName: containerMemory-Infra
 
 # Node metrics
 - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
@@ -54,17 +40,14 @@
 - query: (avg((sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
   metricName: nodeCPU-AggregatedWorkers
 
-- query: (avg((sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
-  metricName: nodeCPU-AggregatedInfra
-
 - query: avg(node_memory_MemAvailable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryAvailable-Masters
 
 - query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
   metricName: nodeMemoryAvailable-AggregatedWorkers
 
-- query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
-  metricName: nodeMemoryAvailable-AggregatedInfra
+- query: avg(node_memory_MemAvailable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryAvailable-Infra
 
 - query: avg(node_memory_MemTotal_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryTotal-Masters
@@ -74,45 +57,9 @@
   metricName: nodeMemoryTotal-AggregatedWorkers
   instant: true
 
-- query: avg(node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)"))
-  metricName: nodeMemoryTotal-AggregatedInfra
+- query: avg(node_memory_MemTotal_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryTotal-Infra
   instant: true
-
-- query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: rxNetworkBytes-Masters
-
-- query: avg(irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
-  metricName: rxNetworkBytes-AggregatedWorkers
-
-- query: avg(irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
-  metricName: rxNetworkBytes-AggregatedInfra
-
-- query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: txNetworkBytes-Masters
-
-- query: avg(irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
-  metricName: txNetworkBytes-AggregatedWorkers
-
-- query: avg(irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
-  metricName: txNetworkBytes-AggregatedInfra
-
-- query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeDiskWrittenBytes-Masters
-
-- query: avg(rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
-  metricName: nodeDiskWrittenBytes-AggregatedWorkers
-
-- query: avg(rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
-  metricName: nodeDiskWrittenBytes-AggregatedInfra
-
-- query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeDiskReadBytes-Masters
-
-- query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (device)
-  metricName: nodeDiskReadBytes-AggregatedWorkers
-
-- query: avg(rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m]) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) by (device)
-  metricName: nodeDiskReadBytes-AggregatedInfra
 
 - query: irate(container_runtime_crio_operations_latency_microseconds{operation_type="network_setup_pod"}[2m]) > 0
   metricName: containerNetworkSetupLatency
@@ -145,9 +92,6 @@
 - query: sum by (cluster_version)(etcd_cluster_version)
   metricName: etcdVersion
   instant: true
-
-- query: sum(rate(etcd_object_counts{}[5m])) by (resource) > 0
-  metricName: etcdObjectCount
 
 - query: histogram_quantile(0.99,sum(rate(etcd_request_duration_seconds_bucket[2m])) by (le,operation,apiserver)) > 0
   metricName: P99APIEtcdRequestLatency
@@ -190,17 +134,3 @@
 - query: cluster_version{type="completed"}
   metricName: clusterVersion
   instant: true
-
-# Golang metrics
-
-- query: go_memstats_heap_alloc_bytes{job=~"apiserver|api|etcd"}
-  metricName: goHeapAllocBytes
-
-- query: go_memstats_heap_inuse_bytes{job=~"apiserver|api|etcd"}
-  metricName: goHeapInuseBytes
-
-- query: go_gc_duration_seconds{job=~"apiserver|api|etcd",quantile="1"}
-  metricName: goGCDurationSeconds
-
-- query: topk(10,ALERTS{severity!="none"})
-  metricName: alerts

--- a/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
@@ -79,9 +79,6 @@
 - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
   metricName: etcdLeaderChangesRate
 
-- query: etcd_server_is_leader > 0
-  metricName: etcdServerIsLeader
-
 - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
   metricName: 99thEtcdDiskBackendCommitDurationSeconds
 
@@ -90,12 +87,6 @@
 
 - query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))
   metricName: 99thEtcdRoundTripTimeSeconds
-
-- query: etcd_mvcc_db_total_size_in_bytes
-  metricName: etcdDBPhysicalSizeBytes
-
-- query: etcd_mvcc_db_total_size_in_use_in_bytes
-  metricName: etcdDBLogicalSizeBytes
 
 - query: sum by (cluster_version)(etcd_cluster_version)
   metricName: etcdVersion

--- a/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
@@ -48,18 +48,23 @@
 - query: (avg((sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))) by (mode)) > 0
   metricName: nodeCPU-AggregatedWorkers
 
-- query: avg(node_memory_MemAvailable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+- query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPU-Infra
+
+- query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryAvailable-Masters
 
 - query: avg(node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
   metricName: nodeMemoryAvailable-AggregatedWorkers
 
-- query: avg(node_memory_MemAvailable_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+- query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryAvailable-Infra
 
-- query: avg(node_memory_MemTotal_bytes) by (instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+- query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryTotal-Masters
-  instant: true
+
+- query: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryUtilization-Masters
 
 - query: avg(node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
   metricName: nodeMemoryTotal-AggregatedWorkers

--- a/workloads/kube-burner/metrics-profiles/metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics.yaml
@@ -1,10 +1,13 @@
 # API server
 
-- query: irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[2m]
-  metricName: SchedulingThroughput
+- query: irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[2m]) > 0
+  metricName: schedulingThroughput
 
-- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!="WATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))
-  metricName: APICallsLatency
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"LIST|GET", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))
+  metricName: readOnlyAPICallsLatency
+
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb=~"POST|PUT|DELETE|PATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))
+  metricName: mutatingAPICallsLatency
 
 - query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH"}[2m])) by (verb,resource,code) > 0
   metricName: APIRequestRate
@@ -15,16 +18,18 @@
   metricName: kubeproxyP99ProgrammingLatency
 
 # Containers & pod metrics
-- query: sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|sdn|ingress|.*controller-manager|.*scheduler|monitoring|image-registry)"}[2m]) * 100) by (container, pod, namespace, node)
+
+- query: (sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|sdn|ingress|.*controller-manager|.*scheduler|image-registry)"}[2m]) * 100) by (container, pod, namespace, node)) > 0
   metricName: containerCPU
 
-- query: sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|sdn|ingress|.*controller-manager|.*scheduler|monitoring)"}) by (container, pod, namespace, node)
+- query: sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|sdn|ingress|.*controller-manager|.*scheduler)"}) by (container, pod, namespace, node)
   metricName: containerMemory
 
 - query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
   metricName: containerDiskUsage
 
-# Kubelet & CRI-O metrics
+# Kubelet & CRI-O runtime metrics
+
 - query: sum(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
   metricName: kubeletCPU
 
@@ -43,26 +48,42 @@
 - query: irate(container_runtime_crio_operations_latency_microseconds{operation_type="network_setup_overall"}[2m]) > 0
   metricName: containerNetworkSetupOverallLatency
 
-# Node metrics
+# Node metrics: CPU & Memory
+
 - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
-  metricName: nodeCPU-workers
+  metricName: nodeCPU-Workers
 
 - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
-  metricName: nodeCPU-masters
+  metricName: nodeCPU-Masters
 
 - query: (sum(irate(node_cpu_seconds_total[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
-  metricName: nodeCPU-infra
+  metricName: nodeCPU-Infra
 
 - query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeMemoryAvailable
+  metricName: nodeMemoryAvailable-Masters
+
+- query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryAvailable-Workers
+
+- query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryAvailable-Infra
 
 - query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeMemoryTotal
+  metricName: nodeMemoryTotal-Masters
+  instant: true
+
+- query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryTotal-Workers
+  instant: true
+
+- query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryTotal-Infra
   instant: true
 
 # Etcd metrics
+
 - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
- metricName: etcdLeaderChangesRate
+  metricName: etcdLeaderChangesRate
 
 - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
   metricName: 99thEtcdDiskBackendCommitDurationSeconds
@@ -87,6 +108,7 @@
   metricName: P99APIEtcdRequestLatency
 
 # Cluster metrics
+
 - query: sum(kube_namespace_status_phase) by (phase) > 0
   metricName: namespaceCount
 

--- a/workloads/kube-burner/metrics-profiles/metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics.yaml
@@ -1,32 +1,24 @@
 # API server
-- query: histogram_quantile(0.99, sum(rate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!~"WATCH", subresource!="log"}[2m])) by (verb,resource,subresource,instance,le)) > 0
-  metricName: API99thLatency
 
-- query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH",subresource!="log"}[2m])) by (verb,instance,resource,code) > 0
+- query: irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[2m]
+  metricName: SchedulingThroughput
+
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{apiserver="kube-apiserver", verb!="WATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope))
+  metricName: APICallsLatency
+
+- query: sum(irate(apiserver_request_total{apiserver="kube-apiserver",verb!="WATCH"}[2m])) by (verb,resource,code) > 0
   metricName: APIRequestRate
 
-# P&F
-- query: rate(apiserver_flowcontrol_dispatched_requests_total[2m]) > 0
-  metricName: APIFlowControlDispatchedRequests
+# Kubeproxy - (SDN only)
 
-- query: sum(apiserver_flowcontrol_current_executing_requests) by (instance, priority_level,flow_schema) > 0
-  metricName: APIFlowControlCurrentExecutingRequests
-
-- query: rate(apiserver_flowcontrol_rejected_requests_total[2m]) > 0
-  metricName: APIFlowControlRejectedRequests
-
-- query: sum(apiserver_flowcontrol_current_inqueue_requests) by (instance, flow_schema, priority_level) > 0
-  metricName: APIFlowControlInqueueRequests
-
-- query: avg(apiserver_flowcontrol_request_concurrency_limit{}) by (priority_level)
-  metricName: APIFlowControlRequestConcurrencyLimit
-  instant: true
+- query: histogram_quantile(0.99, rate(kubeproxy_network_programming_duration_seconds_bucket[2m]))
+  metricName: kubeproxyP99ProgrammingLatency
 
 # Containers & pod metrics
-- query: sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|monitoring|image-registry|operator-lifecycle-manager)"}[2m]) * 100) by (container, pod, namespace, node)
+- query: sum(irate(container_cpu_usage_seconds_total{name!="",container!="POD",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|sdn|ingress|.*controller-manager|.*scheduler|monitoring|image-registry)"}[2m]) * 100) by (container, pod, namespace, node)
   metricName: containerCPU
 
-- query: sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|oauth-apiserver|.*apiserver|ovn-kubernetes|sdn|ingress|authentication|.*controller-manager|.*scheduler|monitoring|image-registry|operator-lifecycle-manager)"}) by (container, pod, namespace, node)
+- query: sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|sdn|ingress|.*controller-manager|.*scheduler|monitoring)"}) by (container, pod, namespace, node)
   metricName: containerMemory
 
 - query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
@@ -62,44 +54,15 @@
   metricName: nodeCPU-infra
 
 - query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeMemoryAvailable-Masters
-
-- query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeMemoryAvailable-Workers
-
-- query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeMemoryAvailable-AggregatedInfra
+  metricName: nodeMemoryAvailable
 
 - query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeMemoryTotal-Masters
+  metricName: nodeMemoryTotal
   instant: true
-
-- query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeMemoryTotal-Workers
-  instant: true
-
-- query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
-  metricName: nodeMemoryTotal-Infra
-  instant: true
-
-- query: irate(node_network_receive_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
-  metricName: rxNetworkBytes
-
-- query: irate(node_network_transmit_bytes_total{device=~"^(ens|eth|bond|team).*"}[2m])
-  metricName: txNetworkBytes
-
-- query: rate(node_disk_written_bytes_total{device!~"^(dm|rb).*"}[2m])
-  metricName: nodeDiskWrittenBytes
-
-- query: rate(node_disk_read_bytes_total{device!~"^(dm|rb).*"}[2m])
-  metricName: nodeDiskReadBytes
 
 # Etcd metrics
 - query: sum(rate(etcd_server_leader_changes_seen_total[2m]))
-  metricName: etcdLeaderChangesRate
-
-- query: etcd_server_is_leader > 0
-  metricName: etcdServerIsLeader
+ metricName: etcdLeaderChangesRate
 
 - query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))
   metricName: 99thEtcdDiskBackendCommitDurationSeconds
@@ -116,12 +79,12 @@
 - query: etcd_mvcc_db_total_size_in_use_in_bytes
   metricName: etcdDBLogicalSizeBytes
 
-- query: sum(rate(etcd_object_counts{}[5m])) by (resource) > 0
-  metricName: etcdObjectCount
-
 - query: sum by (cluster_version)(etcd_cluster_version)
   metricName: etcdVersion
   instant: true
+
+- query: histogram_quantile(0.99,sum(rate(etcd_request_duration_seconds_bucket[2m])) by (le,operation,apiserver)) > 0
+  metricName: P99APIEtcdRequestLatency
 
 # Cluster metrics
 - query: sum(kube_namespace_status_phase) by (phase) > 0
@@ -129,9 +92,6 @@
 
 - query: sum(kube_pod_status_phase{}) by (phase)
   metricName: podStatusCount
-
-- query: kube_pod_status_phase{phase="Failed"} > 0
-  metricName: failedPods
 
 - query: count(kube_secret_info{})
   metricName: secretCount
@@ -158,6 +118,3 @@
 - query: cluster_version{type="completed"}
   metricName: clusterVersion
   instant: true
-
-- query: topk(10,ALERTS{severity!="none"})
-  metricName: alerts

--- a/workloads/kube-burner/metrics-profiles/metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics.yaml
@@ -25,9 +25,6 @@
 - query: sum(container_memory_rss{name!="",container!="POD",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|sdn|ingress|.*controller-manager|.*scheduler)"}) by (container, pod, namespace, node)
   metricName: containerMemory
 
-- query: (sum(rate(container_fs_writes_bytes_total{container!="",device!~".+dm.+"}[5m])) by (device, container, node) and on (node) kube_node_role{role="master"}) > 0
-  metricName: containerDiskUsage
-
 # Kubelet & CRI-O runtime metrics
 
 - query: sum(irate(process_cpu_seconds_total{service="kubelet",job="kubelet"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}

--- a/workloads/kube-burner/metrics-profiles/metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics.yaml
@@ -65,20 +65,21 @@
 - query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryAvailable-Workers
 
+# We compute memory utilization by substrating available memory to the total
+- query: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryUtilization-Workers
+
 - query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryAvailable-Infra
 
 - query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryTotal-Masters
-  instant: true
 
 - query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryTotal-Workers
-  instant: true
 
 - query: node_memory_MemTotal_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryTotal-Infra
-  instant: true
 
 # Etcd metrics
 

--- a/workloads/kube-burner/metrics-profiles/metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics.yaml
@@ -94,12 +94,6 @@
 - query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket[5m]))
   metricName: 99thEtcdRoundTripTimeSeconds
 
-- query: etcd_mvcc_db_total_size_in_bytes
-  metricName: etcdDBPhysicalSizeBytes
-
-- query: etcd_mvcc_db_total_size_in_use_in_bytes
-  metricName: etcdDBLogicalSizeBytes
-
 - query: sum by (cluster_version)(etcd_cluster_version)
   metricName: etcdVersion
   instant: true


### PR DESCRIPTION
### Description

Get rid of metrics not useful (or too granular) for release reporting (we should use Dittybopper or Thanos for cluster debugging and long term storage of this kind of metrics) , hence reducing the number of indexed documents. and add some of the upstream SLI metrics (https://github.com/kubernetes/community/blob/master/sig-scalability/slos/slos.md#steady-state-slisslos) such as:

- Pod Ready latency
- Network programming latency
- ReadOnly API requests
- Mutating API requests
- Etcd Fsync latency (This is a OpenShift SLI)


Dashboard refactor is also ready: http://grafana.apps.observability.perfscale.devcluster.openshift.com/d/n8_lX3-nk/kube-burner-report-v2?orgId=1&from=1644849374037&to=1644856446517&var-Datasource=Observability%20-%20ripsaw-kube-burner&var-sdn=openshift-sdn&var-job=cluster-density&var-uuid=287e8000-8677-45-cluster-density-20220214&var-master=ip-10-0-129-75.us-west-2.compute.internal&var-worker=ip-10-0-130-220.us-west-2.compute.internal&var-infra=ip-10-0-153-10.us-west-2.compute.internal&var-namespace=All&var-latencyPercentile=P99