### PR TITLE
Have uperf tests only use a single UUID instead of 1 per pair

### DIFF
--- a/workloads/network-perf/run_pod_network_policy_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_policy_test_fromgit.sh
@@ -4,15 +4,16 @@ source ./common.sh
 export WORKLOAD=pod
 export NETWORK_POLICY=true
 
+export UUID=$(uuidgen)
 for pairs in 1 2 4; do
-  export UUID=$(uuidgen)
   export pairs=${pairs}
   run_workload ripsaw-uperf-crd.yaml
   if [[ $? != 0 ]]; then
     exit 1
   fi
-  BASELINE_UUID=${BASELINE_POD_UUID[${i}]}
-  COMPARISON_OUTPUT="${PWD}/pod-networkpolicy-${pairs}-pairs.csv"
-  run_benchmark_comparison
 done
+BASELINE_UUID=${BASELINE_POD_UUID}
+COMPARISON_OUTPUT="${PWD}/pod-networkpolicy-all-pairs.csv"
+run_benchmark_comparison
+
 log "Finished workload ${0}"

--- a/workloads/network-perf/run_pod_network_test_fromgit.sh
+++ b/workloads/network-perf/run_pod_network_test_fromgit.sh
@@ -3,17 +3,17 @@
 source ./common.sh
 export WORKLOAD=pod
 
+export UUID=$(uuidgen)
 for pairs in 1 2 4; do
-  export UUID=$(uuidgen)
   export pairs
   run_workload ripsaw-uperf-crd.yaml
   if [[ $? != 0 ]]; then
     exit 1
   fi
-  BASELINE_UUID=${BASELINE_POD_UUID[${i}]}
-  COMPARISON_OUTPUT="${PWD}/pod-${pairs}-pairs.csv"
-  run_benchmark_comparison
 done
+BASELINE_UUID=${BASELINE_POD_UUID}
+COMPARISON_OUTPUT="${PWD}/pod-all-pairs.csv"
+run_benchmark_comparison
 
 if [[ ${ENABLE_SNAPPY_BACKUP} == "true" ]] ; then
   snappy_backup network_perf_pod_network_test

--- a/workloads/network-perf/run_serviceip_network_policy_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_policy_test_fromgit.sh
@@ -9,15 +9,16 @@ if [[ "${isBareMetal}" == "true" ]]; then
   export METADATA_TARGETED=true
 fi
 
+export UUID=$(uuidgen)
 for pairs in 1 2 4; do
-  export UUID=$(uuidgen)
   export pairs=${pairs}
-  COMPARISON_OUTPUT="${PWD}/service-networkpolicy-${pairs}-pairs.csv"
   run_workload ripsaw-uperf-crd.yaml
   if [[ $? != 0 ]]; then
     exit 1
   fi
-  BASELINE_UUID=${BASELINE_SVC_UUID[${i}]}
-  run_benchmark_comparison
 done
+BASELINE_UUID=${BASELINE_SVC_UUID}
+COMPARISON_OUTPUT="${PWD}/service-networkpolicy-all-pairs.csv"
+run_benchmark_comparison
+
 log "Finished workload ${0}"

--- a/workloads/network-perf/run_serviceip_network_test_fromgit.sh
+++ b/workloads/network-perf/run_serviceip_network_test_fromgit.sh
@@ -4,17 +4,18 @@ source ./common.sh
 export WORKLOAD=service
 export SERVICEIP=true
 
+export UUID=$(uuidgen)
 for pairs in 1 2 4; do
-  export UUID=$(uuidgen)
   export pairs
   run_workload ripsaw-uperf-crd.yaml
   if [[ $? != 0 ]]; then
     exit 1
   fi
-  BASELINE_UUID=${BASELINE_SVC_UUID[${i}]}
-  COMPARISON_OUTPUT="${PWD}/service-${pairs}-pairs.csv"
-  run_benchmark_comparison
 done
+BASELINE_UUID=${BASELINE_POD_UUID}
+COMPARISON_OUTPUT="${PWD}/service-all-pairs.csv"
+run_benchmark_comparison
+
 
 if [[ ${ENABLE_SNAPPY_BACKUP} == "true" ]] ; then
   snappy_backup network_perf_serviceip_network_test


### PR DESCRIPTION
### Description

Uperf testing was generating a UUID for each "Pair." This made viewing the data very cumbersome as you would have to track and stitch together multiple UUIDS. This PR simplifies it to have a single UUID for each execution of run_*test.sh

### Fixes
