### PR TITLE
Bump kube-burner v0.15.2

### DIFF
--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -32,7 +32,7 @@ export REMOTE_METRIC_PROFILE=${REMOTE_METRIC_PROFILE}
 export REMOTE_ALERT_PROFILE=${REMOTE_ALERT_PROFILE}
 
 # Kube-burner job
-export KUBE_BURNER_IMAGE=${KUBE_BURNER_IMAGE:-quay.io/cloud-bulldozer/kube-burner:v0.15.1}
+export KUBE_BURNER_IMAGE=${KUBE_BURNER_IMAGE:-quay.io/cloud-bulldozer/kube-burner:v0.15.2}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-14400}
 export LOG_STREAMING=${LOG_STREAMING:-true}


### PR DESCRIPTION
### Fixes

Includes fix for:

```
time="2022-02-22 10:45:41" level=error msg="Unexpected error creating namespace kube-burner: admission webhook \"namespace-validation.managed.openshift.io\" denied the request: Prevented from accessing Red Hat managed namespaces. Customer workloads should be placed in customer namespaces, and should not match an entry in this list of regular expressions: [^kube.* ^default$ ^redhat.* ^acm$ ^addon-dba-operator$ ^codeready-workspaces-operator$ ^codeready-workspaces-operator-qe$ ^openshift-logging$ ^openshift-storage$ ^prow$ ^redhat-addon-operator$ ^redhat-gpu-operator$ ^redhat-kas-fleetshard-operator$ ^redhat-kas-fleetshard-operator-qe$ ^redhat-managed-kafka-operator$ ^redhat-managed-kafka-operator-qe$ ^redhat-ocm-addon-test-operator$ ^redhat-ods-operator$ ^redhat-reference-addon$ ^redhat-rhmi-operator$ ^redhat-rhoam-operator$ ^redhat-rhoami-operator$ ^dedicated-admin$ ^openshift-aqua$ ^openshift-backplane$ ^openshift-backplane-cee$ ^openshift-backplane-managed-scripts$ ^openshift-backplane-srep$ ^openshift-build-test$ ^openshift-cloud-ingress-operator$ ^openshift-codeready-workspaces$ ^openshift-compliance$ ^openshift-custom-domains-operator$ ^openshift-customer-monitoring$ ^openshift-logging$ ^openshift-managed-upgrade-operator$ ^openshift-must-gather-operator$ ^openshift-operators-redhat$ ^openshift-osd-metrics$ ^openshift-rbac-permissions$ ^openshift-route-monitor-operator$ ^openshift-security$ ^openshift-splunk-forwarder-operator$ ^openshift-sre-pruning$ ^openshift-strimzi$ ^openshift-validation-webhook$ ^openshift-velero$ ^openshift-monitoring$ ^openshift$ ^openshift-apiserver$ ^openshift-apiserver-operator$ ^openshift-authentication$ ^openshift-authentication-operator$ ^openshift-cloud-controller-manager$ ^openshift-cloud-controller-manager-operator$ ^openshift-cloud-credential-operator$ ^openshift-cluster-csi-drivers$ ^openshift-cluster-machine-approver$ ^openshift-cluster-node-tuning-operator$ ^openshift-cluster-samples-operator$ ^openshift-cluster-storage-operator$ ^openshift-config$ ^openshift-config-managed$ ^openshift-config-operator$ ^openshift-console$ ^openshift-console-operator$ ^openshift-console-user-settings$ ^openshift-controller-manager$ ^openshift-controller-manager-operator$ ^openshift-dns$ ^openshift-dns-operator$ ^openshift-etcd$ ^openshift-etcd-operator$ ^openshift-host-network$ ^openshift-image-registry$ ^openshift-ingress$ ^openshift-ingress-canary$ ^openshift-ingress-operator$ ^openshift-insights$ ^openshift-kni-infra$ ^openshift-kube-apiserver$ ^openshift-kube-apiserver-operator$ ^openshift-kube-controller-manager$ ^openshift-kube-controller-manager-operator$ ^openshift-kube-scheduler$ ^openshift-kube-scheduler-operator$ ^openshift-kube-storage-version-migrator$ ^openshift-kube-storage-version-migrator-operator$ ^openshift-machine-api$ ^openshift-machine-config-operator$ ^openshift-marketplace$ ^openshift-monitoring$ ^openshift-multus$ ^openshift-network-diagnostics$ ^openshift-network-operator$ ^openshift-oauth-apiserver$ ^openshift-openstack-infra$ ^openshift-operator-lifecycle-manager$ ^openshift-operators$ ^openshift-ovirt-infra$ ^openshift-sdn$ ^openshift-service-ca$ ^openshift-service-ca-operator$ ^openshift-user-workload-monitoring$ ^openshift-vsphere-infra$]"
```

Caused by the preload mechanism recently added, since it tries to create a namespace called kube-burner



