### PR TITLE
Modifying the default restricted SCC is not required

### DIFF
--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -117,7 +117,6 @@ deploy_operator() {
   kubectl apply -f benchmark-operator/resources/backpack_role.yaml
   oc adm policy -n benchmark-operator add-scc-to-user privileged -z benchmark-operator
   oc adm policy -n benchmark-operator add-scc-to-user privileged -z backpack-view
-  oc patch scc restricted --type=merge -p '{"allowHostNetwork": true}'
 }
 
 run_workload() {


### PR DESCRIPTION
The Job to create server/client use the benchmark-operator scc
that has priveleged access. Moreover this command fails on Managed
Services clusters since you cannot change an existing SCC there.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
