### PR TITLE
export SERVICEIP within hostnetwork script

### DIFF
--- a/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
+++ b/workloads/network-perf/run_hostnetwork_network_test_fromgit.sh
@@ -3,6 +3,7 @@
 source ./common.sh
 export WORKLOAD=hostnet
 export HOSTNETWORK=true
+export SERVICEIP=false
 export pairs=1
 export UUID=$(uuidgen)
 


### PR DESCRIPTION
Accidentally setting SERVICEUP to true for hostnetwork
test sresults in pods not starting. Since there is no concept
of servceip for host network tests, makes sense to override that
in the script.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
