### PR TITLE
Run hostNetwork with only 1 pair

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -34,7 +34,7 @@ The run.sh script can be tweaked with the following environment variables
 | **SERVICE_ETP**         | To mention the type of `ExternalTrafficPolicy` of a service, supported option `Cluster` or `Local` | Cluster |
 | **SAMPLES**             | How many times to run the tests | 3 |
 | **MULTI_AZ**            | If true, uperf client and server pods will be colocated in different topology zones or AZs (`topology.kubernetes.io/zone` in k8s terminology). 2 worker nodes in differet topology zones are required to enable this flag.  If false, uperf client and server pods will be colocated in the same topology zone | true |
-| **PAIRS**               | List with the number of pairs the test will be triggered | 1 2 4 |
+| **PAIRS**               | List with the number of pairs the test will be triggered (hostnet variant is executed w/ 1 pair only) | 1 2 4 |
 | **TEST_TIMEOUT**        | Benchmark timeout, in seconds | 7200 (2 hours) |
 | **TEST_CLEANUP**        | Remove benchmark CR at the end | true |
 

--- a/workloads/network-perf/run.sh
+++ b/workloads/network-perf/run.sh
@@ -41,6 +41,9 @@ for pairs in ${PAIRS}; do
   if ! run_workload ${CR}; then
     exit 1
   fi
+  if [[ ${WORKLOAD} == "hostnet" ]]; then
+    break
+  fi
 done
 
 BASELINE_UUID=${BASELINE_POD_UUID}


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Host Network tests were originally executed with only 1 pair to prevent uperf server port collision.

Fixes: https://github.com/cloud-bulldozer/e2e-benchmarking/issues/328
