### PR TITLE
New metric templates for Hypershift

### DIFF
--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -44,3 +44,10 @@ export LOG_LEVEL=${LOG_LEVEL:-info}
 # Pprof
 export PPROF_COLLECTION=${PPROF_COLLECTION:-false}
 export PPROF_COLLECTION_INTERVAL=${PPROF_COLLECTION_INTERVAL:-5m}
+
+# Hypershift vars
+export HYPERSHIFT=${HYPERSHIFT:-false}
+export HOSTED_CLUSTER_NAME=${HOSTED_CLUSTER_NAME:-perf-hosted-1}
+export MGMT_CLUSTER_NAME=${MGMT_CLUSTER_NAME:-perf-management-cluster}
+export HOSTED_CLUSTER_NS=${HOSTED_CLUSTER_NS:-clusters-perf-hosted-1}
+export THANOS_RECEIVER_URL=${THANOS_RECEIVER_URL:-http://thanos.apps.cluster.devcluster/api/v1/receive}

--- a/workloads/kube-burner/grafana-agent.yaml
+++ b/workloads/kube-burner/grafana-agent.yaml
@@ -1,0 +1,140 @@
+apiVersion: v1                                                                                                                                                                                                                               
+kind: Namespace                                                                                                                                                                                                                              
+metadata:                                                                                                                                                                                                                                                                                                                                                                                                                                         
+  name: grafana-agent 
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-agent
+  namespace: grafana-agent
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: grafana-agent
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - nodes/proxy
+  - services
+  - endpoints
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- nonResourceURLs:
+  - /metrics
+  - /federate
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: grafana-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: grafana-agent
+subjects:
+- kind: ServiceAccount
+  name: grafana-agent
+  namespace: grafana-agent
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-agent
+  namespace: grafana-agent
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: grafana-agent
+  template:
+    metadata:
+      labels:
+        name: grafana-agent
+    spec:
+      containers:
+      - args:
+        - --config.file=/etc/agent/agent.yaml
+        - --log.level=debug
+        command:
+        - /bin/agent
+        env:
+        - name: HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: grafana/agent:v0.20.0
+        imagePullPolicy: IfNotPresent
+        name: agent
+        ports:
+        - containerPort: 12345
+          name: http-metrics
+        volumeMounts:
+        - mountPath: /etc/agent
+          name: grafana-agent
+      serviceAccount: grafana-agent
+      volumes:
+      - configMap:
+          name: grafana-agent
+        name: grafana-agent
+---
+kind: ConfigMap
+metadata:
+  name: grafana-agent
+  namespace: grafana-agent
+apiVersion: v1
+data:
+  agent.yaml: |
+    server:
+      http_listen_port: 12345
+    prometheus:
+      wal_directory: /tmp/grafana-agent-wal
+      global:
+        scrape_interval: 15s
+        external_labels:
+          openshift_cluster_name: $CLUSTER_NAME
+          openshift_network_type: $NETWORK_TYPE
+          openshift_version: $OPENSHIFT_VERSION
+          openshift_platform: $PLATFORM
+          dag_id: $DAG_ID
+      configs:
+        - name: integrations
+          remote_write:
+            - url: "$THANOS_RECEIVER_URL"
+              queue_config:
+                max_samples_per_send: 1000
+                max_shards: 200
+                capacity: 2500
+          scrape_configs:
+            - job_name: cluster-monitoring
+              honor_labels: true
+              params:
+                'match[]': 
+                  - '{__name__=~".+"}'
+              scrape_interval: 30s
+              scrape_timeout: 30s
+              metrics_path: /federate
+              scheme: https
+              kubernetes_sd_configs:
+              - role: endpoints
+                namespaces:
+                  names:
+                  - openshift-monitoring
+                selectors:
+                  - role: endpoints 
+                    label: app.kubernetes.io/name=prometheus
+              authorization:
+                credentials_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+              tls_config:
+                insecure_skip_verify: true

--- a/workloads/kube-burner/metrics-profiles/hypershift-metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/hypershift-metrics.yaml
@@ -1,0 +1,118 @@
+# TODO API server
+
+# Kubeproxy - (SDN only)
+
+- query: histogram_quantile(0.99, rate(kubeproxy_network_programming_duration_seconds_bucket{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"}[2m]))
+  metricName: kubeproxyP99ProgrammingLatency
+
+# ControlPlane Containers & pod metrics
+
+- query: (sum((irate(container_cpu_usage_seconds_total{openshift_cluster_name=~"${MGMT_CLUSTER_NAME}",name!="",container!="POD",namespace=~"${HOSTED_CLUSTER_NS}"}[2m]) * 100) or (irate(container_cpu_usage_seconds_total{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}",name!="",container!="POD",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|sdn|ingress|.*controller-manager|.*scheduler|image-registry)"}[2m]) * 100))  by (container, pod, namespace, node, openshift_cluster_name)) > 0
+  metricName: containerCPU
+
+- query: sum(container_memory_rss{openshift_cluster_name=~"${MGMT_CLUSTER_NAME}",name!="",container!="POD",namespace=~"${HOSTED_CLUSTER_NS}"} or container_memory_rss{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}",name!="",container!="POD",namespace=~"openshift-(etcd|.*apiserver|ovn-kubernetes|sdn|ingress|.*controller-manager|.*scheduler|image-registry)"}) by (pod, namespace, node, openshift_cluster_name)
+  metricName: containerMemory
+
+# Kubelet & CRI-O runtime metrics
+
+- query: sum(irate(process_cpu_seconds_total{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}",service="kubelet",job="kubelet"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: kubeletCPU
+
+- query: sum(process_resident_memory_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}",service="kubelet",job="kubelet"}) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: kubeletMemory
+
+- query: sum(irate(process_cpu_seconds_total{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}",service="kubelet",job="crio"}[2m]) * 100) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: crioCPU
+
+- query: sum(process_resident_memory_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}",service="kubelet",job="crio"}) by (node) and on (node) kube_node_role{role="worker"}
+  metricName: crioMemory
+
+- query: irate(container_runtime_crio_operations_latency_microseconds{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}",operation_type="network_setup_pod"}[2m]) > 0
+  metricName: containerNetworkSetupLatency
+
+- query: irate(container_runtime_crio_operations_latency_microseconds{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}",operation_type="network_setup_overall"}[2m]) > 0
+  metricName: containerNetworkSetupOverallLatency
+
+# Node metrics: CPU & Memory
+
+- query: (sum(irate(node_cpu_seconds_total{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPU-Workers
+
+- query: (sum(irate(node_cpu_seconds_total{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPU-Masters
+
+- query: (sum(irate(node_cpu_seconds_total{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: nodeCPU-Infra
+
+- query: node_memory_MemAvailable_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryAvailable-Masters
+
+- query: node_memory_MemAvailable_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryAvailable-Workers
+
+# We compute memory utilization by substrating available memory to the total
+- query: (node_memory_MemTotal_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"} - node_memory_MemAvailable_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"}) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryUtilization-Workers
+
+- query: node_memory_MemAvailable_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryAvailable-Infra
+
+- query: node_memory_MemTotal_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryTotal-Masters
+
+- query: node_memory_MemTotal_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryTotal-Workers
+
+- query: node_memory_MemTotal_bytes{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
+  metricName: nodeMemoryTotal-Infra
+
+# Etcd metrics
+
+- query: sum(rate(etcd_server_leader_changes_seen_total{openshift_cluster_name=~"${MGMT_CLUSTER_NAME}",namespace=~"${HOSTED_CLUSTER_NS}"}[2m]))
+  metricName: etcdLeaderChangesRate
+
+- query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{openshift_cluster_name=~"${MGMT_CLUSTER_NAME}",namespace=~"${HOSTED_CLUSTER_NS}"}[2m]))
+  metricName: 99thEtcdDiskBackendCommitDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{openshift_cluster_name=~"${MGMT_CLUSTER_NAME}",namespace=~"${HOSTED_CLUSTER_NS}"}[2m]))
+  metricName: 99thEtcdDiskWalFsyncDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{openshift_cluster_name=~"${MGMT_CLUSTER_NAME}",namespace=~"${HOSTED_CLUSTER_NS}"}[5m]))
+  metricName: 99thEtcdRoundTripTimeSeconds
+
+- query: sum by (cluster_version)(etcd_cluster_version{openshift_cluster_name=~"${MGMT_CLUSTER_NAME}",namespace=~"${HOSTED_CLUSTER_NS}"})
+  metricName: etcdVersion
+  instant: true
+
+- query: histogram_quantile(0.99,sum(rate(etcd_request_duration_seconds_bucket{openshift_cluster_name=~"${MGMT_CLUSTER_NAME}",namespace=~"${HOSTED_CLUSTER_NS}"}[2m])) by (le,operation,apiserver)) > 0
+  metricName: P99APIEtcdRequestLatency
+
+# Cluster metrics
+
+- query: sum(kube_namespace_status_phase{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"}) by (phase) > 0
+  metricName: namespaceCount
+
+- query: sum(kube_pod_status_phase{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"}) by (phase)
+  metricName: podStatusCount
+
+- query: count(kube_secret_info{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"})
+  metricName: secretCount
+  instant: true
+
+- query: count(kube_deployment_labels{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"})
+  metricName: deploymentCount
+  instant: true
+
+- query: count(kube_configmap_info{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"})
+  metricName: configmapCount
+  instant: true
+
+- query: count(kube_service_info{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"})
+  metricName: serviceCount
+  instant: true
+
+- query: kube_node_role{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"}
+  metricName: nodeRoles
+
+- query: sum(kube_node_status_condition{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}",status="true"}) by (condition)
+  metricName: nodeStatus


### PR DESCRIPTION
### Description
Need a custom metric profile to query metrics for a hypershift model cluster. 
They run multiple prom instances individually, so using existing platform connector agent to fwd all metrics to observability thanos instance and querying it from there by kube-burner. 
This script install agents only on workload cluster(HostedCluster), so enabling it on the management cluster is a pre-req(not required if its deployed by [airflow](https://github.com/cloud-bulldozer/airflow-kubernetes/pull/134)).
```
                   │
                   │
Management Cluster │ Hosted Cluster
                   │
 ┌────────────┐    │  ┌────────────┐
 │ Prometheus │    │  │ Prometheus │
 └──────┬─────┘    │  └──────┬─────┘
        │          │         │
 ┌──────┴──────┐   │  ┌──────┴──────┐
 │grafana-agent│   │  │grafana-agent│
 └──────┬──────┘   │  └──────┬──────┘
        │write               │write
        │      ┌──────┐      │
        └──────►Thanos◄──────┘
               └───▲──┘
                   │
                   │query
            ┌──────┴──────┐
            │ Kube-burner │
            └──────┬──────┘
                   │
                   │index
           ┌───────▼───────┐
           │ Elasticsearch │
           └───────────────┘
```
### Fixes
