### PR TITLE
Set pod resources in node-density workloads

### DIFF
--- a/workloads/kube-burner/workloads/node-density-heavy/app-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/app-deployment.yml
@@ -29,6 +29,9 @@ spec:
           failureThreshold: 1
           timeoutSeconds: 15
           initialDelaySeconds: 30
+        requests:
+          memory: "10Mi"
+          cpu: "10m"
         ports:
         - containerPort: 8080
           protocol: TCP

--- a/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
@@ -25,6 +25,9 @@ spec:
         imagePullPolicy: IfNotPresent
         securityContext:
           privileged: false
+        requests:
+          memory: "20Mi"
+          cpu: "20m"
       restartPolicy: Always
   replicas: 1
   selector:

--- a/workloads/kube-burner/workloads/node-pod-density/pod.yml
+++ b/workloads/kube-burner/workloads/node-pod-density/pod.yml
@@ -9,6 +9,10 @@ spec:
   containers:
   - name: node-density
     image: {{.containerImage}}
+    resources:
+      requests:
+        memory: "10Mi"
+        cpu: "10m"
     ports:
     - containerPort: 8080
       protocol: TCP


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Setting a minimal pod resources in pods helps the scheduler algorithm to evenly spread the pods across worker nodes. Thanks to this change I've managed to get really good pod latency numbers in OVNKubernetes based clusters.

### Fixes
