### PR TITLE
Align default pods per node to new standard of 245

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -71,7 +71,7 @@ Each iteration creates the following objects:
 The `node-density` and `node-density-heavy` workloads support the following environment variables:
 
 - **NODE_COUNT**: Number of worker nodes to deploy the pods on. During the workload nodes will be labeled with `node-density=enabled`. Defaults to the number of worker nodes across the cluster (Nodes resulting of the expression `oc get node -o name --no-headers -l node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",node-role.kubernetes.io/worker=`
-- **PODS_PER_NODE**: Define the maximum number of pods to deploy on each labeled node. Defaults to 250
+- **PODS_PER_NODE**: Define the maximum number of pods to deploy on each labeled node. Defaults to 245
 
 These workloads create different objects each:
 

--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -15,14 +15,14 @@ case ${WORKLOAD} in
     WORKLOAD_TEMPLATE=workloads/node-pod-density/node-pod-density.yml
     METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/metrics.yaml}
     NODE_COUNT=${NODE_COUNT:-$(kubectl get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= -o name | wc -l)}
-    PODS_PER_NODE=${PODS_PER_NODE:-250}
+    PODS_PER_NODE=${PODS_PER_NODE:-245}
     label_nodes regular
   ;;
   node-density-heavy)
     WORKLOAD_TEMPLATE=workloads/node-density-heavy/node-density-heavy.yml
     METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/metrics.yaml}
     NODE_COUNT=${NODE_COUNT:-$(kubectl get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= -o name | wc -l)}
-    PODS_PER_NODE=${PODS_PER_NODE:-250}
+    PODS_PER_NODE=${PODS_PER_NODE:-245}
     label_nodes heavy
   ;;
   pod-density)


### PR DESCRIPTION
### Description
Per https://github.com/cloud-bulldozer/airflow-kubernetes/pull/145 we are aligning to 245 for our node density tests by default.

### Fixes
