### PR TITLE
Add metric for pod distribution by node

### DIFF
--- a/workloads/kube-burner/metrics-profiles/metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics.yaml
@@ -129,6 +129,9 @@
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
 
+- query: count(kube_pod_info{}) by (node)
+  metricName: podDistribution
+
 - query: cluster_version{type="completed"}
   metricName: clusterVersion
   instant: true


### PR DESCRIPTION
This helps us quickly check if the scheduler did a fair job.
Updated kube-burner dashboard to add a panel related to this.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
