### PR TITLE
Add temporary taint removal until taint bug is resolved

### DIFF
--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -175,3 +175,8 @@ snappy_backup() {
  ../../utils/snappy-move-results/run_snappy.sh metadata.json $snappy_path
  store_on_elastic
 }
+
+remove_update_taint() {
+  # This is only here until BZ https://bugzilla.redhat.com/show_bug.cgi?id=2035005 gets resolved
+  oc adm taint nodes UpdateInProgress:PreferNoSchedule- --all || true
+}

--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -2,6 +2,7 @@
 
 . common.sh
 
+remove_update_taint
 deploy_operator
 check_running_benchmarks
 


### PR DESCRIPTION
There is currently a bug [https://bugzilla.redhat.com/show_bug.cgi?id=2035005] which effects the placement of pods during our tests. This bug can cause a RreferNoSchedule taint to be on some nodes, thus greatly impacting statistics like pod ready times. This PR adds a temporary function that removes the taint from all nodes

### Description

### Fixes
