### PR TITLE
Include workload field as metadata

### DIFF
--- a/utils/common.sh
+++ b/utils/common.sh
@@ -180,6 +180,7 @@ local METADATA=$(cat << EOF
 "benchmark":"${BENCHMARK}",
 "timestamp":"${START_DATE}",
 "end_date":"${END_DATE}",
+"workload": "${WORKLOAD}",
 "result":"${RESULT}"
 }
 EOF


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Including the workload name as metadata field will be useful to perform comparisons. The value of this field, namely WORKLOAD, is already set by the different benchmarks of this repo.

