### PR TITLE
increase connect time for the routes to load up

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -178,7 +178,7 @@ test_routes(){
       local scheme="http://"
     fi
     for host in $(oc get route -n http-scale-${termination} --no-headers -o custom-columns="route:.spec.host"); do
-      curl --retry 3 --connect-timeout 5 -sSk ${scheme}${host}${URL_PATH} -o /dev/null
+      curl --retry 3 --connect-timeout 60 -sSk ${scheme}${host}${URL_PATH} -o /dev/null
     done
   done
 }


### PR DESCRIPTION
5seconds was not enough as we got 
```
[2022-03-29, 22:52:16 EDT] {subprocess.py:89} INFO - [1mWed Mar 30 02:52:16 UTC 2022 Testing all routes before triggering the workload[0m
[2022-03-29, 22:53:17 EDT] {subprocess.py:89} INFO - curl: (52) Empty reply from server
```