### PR TITLE
Make kube-burner QPS for ingress tests consistent with other benchmarks

### DIFF
--- a/workloads/router-perf-v2/http-perf.yml.tmpl
+++ b/workloads/router-perf-v2/http-perf.yml.tmpl
@@ -2,8 +2,8 @@
 jobs:
 - name: http-scale-http
   jobIterations: 1
-  qps: 100
-  burst: 100
+  qps: 20
+  burst: 20
   namespacedIterations: false
   namespace: http-scale-http
   cleanup: true


### PR DESCRIPTION
All other benchmarks use a QPS and BURST of 20.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
