### PR TITLE
Disable validation-webhook daemonset for managed clusters

### DIFF
--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -5,6 +5,12 @@
 . ../../utils/compare.sh
 
 label=""
+
+check_managed_cluster
+if [[ $managed == true ]]; then
+   remove_managed_webhook_validation
+fi
+
 case ${WORKLOAD} in
   cluster-density)
     WORKLOAD_TEMPLATE=workloads/cluster-density/cluster-density.yml
@@ -161,6 +167,10 @@ if [[ ${WORKLOAD} == "concurrent-builds" ]]; then
   cat conc_builds_results.out
 else
   run_workload
+fi
+
+if [[ $managed == true ]]; then
+   add_managed_webhook_validation
 fi
 
 if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then


### PR DESCRIPTION
When running the node density workloads on managed clusters, starting
with 4.10.5 on ROSA, we are seeing an error like "admission webhook
"regular-user-validation.managed.openshift.io" denied the request" when trying add a label to a
node directly by using oc label node. The recommended way to add labels
to nodes on managed ROSA clusters is by editing the machinepool.
However, the Default machinepool cannot be edited to add labels and we
see an error like "Labels cannot be updated on the Default machine pool".
The only way to add a label is by disabling the
validation-webhook daemonset and thereby admission cotnrol in the
openshift-validation-webhook project that only exists on managed services
clusters. We disable the daemonset by adding a fake nodeSelector before
labeling the nodes and remove thenodeSelector after unlabeling the nodes.
Adding a nodeSelector on top of the existing nodeAffinity means that both
the conditions needs to be met for a pod to be scheduled. Also by adding
the nodeSelector, the spec is not overwritten during reconcillation whereas
changes to nodeAffinity are being overwritten.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
