### PR TITLE
Template out infrastructure to match with TERMINATIONS

### DIFF
--- a/workloads/router-perf-v2/README.md
+++ b/workloads/router-perf-v2/README.md
@@ -39,7 +39,7 @@ It's possible to tune the default configuration through environment variables. T
 | Variable              | Description     | Default	          |
 |-----------------------|-----------------|-------------------|
 | KUBECONFIG            | Kubeconfig file | `~/.kube/config` |
-| ENGINE                | Engine to spin up the local kube-burner container that creates the required infrastructure, if you set this to `local` it will try to download kube-burner binary locally using `KUBE_BURNER_RELEASE_URL` and use that instead of creating a container. | `podman` |
+| ENGINE                | Engine to spin up the local kube-burner container that creates the required infrastructure, if you set this to `local` it will try to download kube-burner binary locally using `KUBE_BURNER_RELEASE_URL` and use that instead of creating a container. | `local` |
 | RUNTIME               | Workload duration in seconds | `60` |
 | TERMINATIONS          | List of HTTP terminations to test | `http edge passthrough reencrypt mix` |
 | URL_PATH              | URL path to use in the benchmark | `/1024.html` |

--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -10,8 +10,8 @@ export ES_INDEX=${ES_INDEX:-router-test-results}
 NUM_NODES=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!=,node-role.kubernetes.io/infra!= --no-headers | grep -cw Ready)
 LARGE_SCALE_THRESHOLD=${LARGE_SCALE_THRESHOLD:-24}
 METADATA_COLLECTION=${METADATA_COLLECTION:-true}
-ENGINE=${ENGINE:-podman}
-KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.11/kube-burner-0.11-Linux-x86_64.tar.gz}
+ENGINE=${ENGINE:-local}
+KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.15.4/kube-burner-0.15.4-Linux-x86_64.tar.gz}
 KUBE_BURNER_IMAGE=quay.io/cloud-bulldozer/kube-burner:latest
 TERMINATIONS=${TERMINATIONS:-"http edge passthrough reencrypt mix"}
 INFRA_TEMPLATE=http-perf.yml.tmpl

--- a/workloads/router-perf-v2/http-perf.yml.tmpl
+++ b/workloads/router-perf-v2/http-perf.yml.tmpl
@@ -1,5 +1,6 @@
 ---
 jobs:
+{{ if or (contains "http" .TERMINATIONS) (contains "mix" .TERMINATIONS) }}
 - name: http-scale-http
   jobIterations: 1
   qps: 100
@@ -21,8 +22,9 @@ jobs:
 
     - objectTemplate: templates/http-route.yml
       replicas: ${NUMBER_OF_ROUTES}
+{{ end }}
 
-
+{{ if or (contains "edge" .TERMINATIONS) (contains "mix" .TERMINATIONS) }}
 - name: http-scale-edge
   jobIterations: 1
   qps: 100
@@ -44,8 +46,9 @@ jobs:
 
     - objectTemplate: templates/edge-route.yml
       replicas: ${NUMBER_OF_ROUTES}
+{{ end }}
 
-
+{{ if or (contains "passthrough" .TERMINATIONS) (contains "mix" .TERMINATIONS) }}
 - name: http-scale-passthrough
   jobIterations: 1
   qps: 100
@@ -67,8 +70,9 @@ jobs:
 
     - objectTemplate: templates/passthrough-route.yml
       replicas: ${NUMBER_OF_ROUTES}
+{{ end }}
 
-
+{{ if or (contains "reencrypt" .TERMINATIONS) (contains "mix" .TERMINATIONS) }}
 - name: http-scale-reencrypt
   jobIterations: 1
   qps: 100
@@ -90,6 +94,7 @@ jobs:
 
     - objectTemplate: templates/reencrypt-route.yml
       replicas: ${NUMBER_OF_ROUTES}
+{{ end }}
 
 - name: http-scale-client
   namespace: http-scale-client


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Also shifting to local engine by default (It's the fastest one and does not depends on podman anymore), and updating to a recent kube-burner version which includes the new template functions introduced at https://github.com/cloud-bulldozer/kube-burner/pull/135

- Fixes: https://github.com/cloud-bulldozer/e2e-benchmarking/issues/362
