### PR TITLE
Modify how ROSA is detected as platform and move from cloud_type to platform

### DIFF
--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -29,7 +29,6 @@ KUBERNETES_MAJOR_VERSION=$(oc version -o json |  jq -r '.serverVersion.major')
 KUBERNETES_MINOR_VERSION=$(oc version -o json |  jq -r '.serverVersion.minor')
 export KUBERNETES_VERSION=${KUBERNETES_MAJOR_VERSION}.${KUBERNETES_MINOR_VERSION}
 export CLUSTER_NETWORK_TYPE=$(oc get network.config/cluster -o jsonpath='{.spec.networkType}')
-export CLOUD_TYPE=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.type}')
 export PLATFORM_STATUS=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus}')
 
 # Benchmark configuration

--- a/workloads/router-perf-v2/http-perf.yml.tmpl
+++ b/workloads/router-perf-v2/http-perf.yml.tmpl
@@ -117,5 +117,4 @@ jobs:
         openshiftVersion: "${OPENSHIFT_VERSION}"
         kubernetesVersion: "${KUBERNETES_VERSION}"
         clusterNetworkType: "${CLUSTER_NETWORK_TYPE}"
-        cloudType: "${CLOUD_TYPE}"
         platformStatus: '${PLATFORM_STATUS}'

--- a/workloads/router-perf-v2/templates/http-scale-client.yml
+++ b/workloads/router-perf-v2/templates/http-scale-client.yml
@@ -42,8 +42,6 @@ spec:
           value: "{{.kubernetesVersion}}"
         - name: CLUSTER_NETWORK_TYPE
           value: "{{.clusterNetworkType}}"
-        - name: CLOUD_TYPE
-          value: "{{.cloudType}}"
         - name: PLATFORM_STATUS
           value: '{{.platformStatus}}'
         - name: HOST_NETWORK


### PR DESCRIPTION
ROSA was failing to be detected as platform, as it is not always the first tag on [utils/common.sh](https://github.com/cloud-bulldozer/e2e-benchmarking/blob/master/utils/common.sh#L128), for example:

```
        "platformStatus": {
            "aws": {
                "region": "us-west-2",
                "resourceTags": [
                    {
                        "key": "red-hat-managed",
                        "value": "true"
                    },
                    {
                        "key": "red-hat-clustertype",
                        "value": "rosa"
                    }
                ]
            },
            "type": "AWS"
        }
    }
}
```

Current return: true, instead of rosa


Also moving ROSA installation to PLATFORMs instead of CLUSTERTYPE to allow comparing common installations to managed services ones.



Example executing ingress-performance and uploaded to perf-results-elastic.apps.observability.perfscale.devcluster.openshift.com:80

Workload finished, results:
{
    "termination": "http",
    "test_type": "http",
    "uuid": "fe3194fd-7a41-412a-82cb-a74fc8b342f4",
    "cluster.id": "a8c99ffd-2b59-4680-8e67-433cceffa423",
    "cluster.name": "mrnd-timing-nw4w9",
    "cluster.ocp_version": "4.10.6",
    "cluster.kubernetes_version": "1.23",
    "cluster.sdn": "OVNKubernetes",
    "cluster.platform": "ROSA",
    "requests_per_second": 44207,
    "avg_latency": 2258,
    "latency_95pctl": 3726,
    "latency_99pctl": 7183,
    "host_network": "true",
    "sample": "1",
    "runtime": 60,
    "routes": 100,
    "conn_per_targetroute": 1,
    "keepalive": 0,
    "tls_reuse": true,
    "number_of_routers": "2",
    "200": 2652467
}
