### PR TITLE
Add CLEANUP_TIMEOUT variable

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -45,6 +45,7 @@ Workloads can be tweaked with the following environment variables:
 | **LOG_STREAMING**    | Enable log streaming of kube-burner pod | true |
 | **CLEANUP**          | Delete old namespaces for the selected workload before starting benchmark | true |
 | **CLEANUP_WHEN_FINISH** | Delete benchmark objects and workload's namespaces after running it | false |
+| **CLEANUP_TIMEOUT**  | Timeout value used in resource deletion | 30m |
 | **KUBE_BURNER_IMAGE** | Kube-burner container image | quay.io/cloud-bulldozer/kube-burner:v0.14.3 |
 | **LOG_LEVEL**        | Kube-burner log level | info |
 | **PPROF_COLLECTION** | Collect and store pprof data locally | false |

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -136,7 +136,7 @@ cleanup() {
   log "Cleaning up benchmark"
   kubectl delete -f ${TMPCR}
   kubectl delete configmap -n benchmark-operator kube-burner-cfg-${UUID}
-  if ! oc delete ns -l kube-burner-uuid=${UUID} --grace-period=600 --timeout=30m; then
+  if ! oc delete ns -l kube-burner-uuid=${UUID} --grace-period=600 --timeout=${CLEANUP_TIMEOUT}; then
     log "Namespaces cleanup failure"
     rc=1
   fi

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -39,6 +39,7 @@ export LOG_STREAMING=${LOG_STREAMING:-true}
 
 # Misc
 export CLEANUP_WHEN_FINISH=${CLEANUP_WHEN_FINISH:-false}
+export CLEANUP_TIMEOUT=${CLEANUP_TIMEOUT:-30m}
 export LOG_LEVEL=${LOG_LEVEL:-info}
 
 # Pprof


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Moar vars, in large-scale tests, deleting the created resources can take a while. We should be able to configure this timeout
