### PR TITLE
Moving remove cli till after gen metadata and only if failure

### DIFF
--- a/utils/benchmark-operator.sh
+++ b/utils/benchmark-operator.sh
@@ -65,7 +65,6 @@ run_benchmark() {
       kubectl logs -n benchmark-operator --prefix --tail=30 ${pod}
       kubectl logs -n benchmark-operator --prefix --tail=-1 ${pod} >> ${pod_log}
     done
-    remove_cli
   fi
   local benchmark_name=$(cat ${1} | python -c 'import yaml; import sys; print(yaml.safe_load(sys.stdin.read())["metadata"]["name"])')
   gen_metadata ${benchmark_name} ${start_date} $(date +%s%3N)

--- a/workloads/kube-burner/build_helper.sh
+++ b/workloads/kube-burner/build_helper.sh
@@ -3,20 +3,22 @@
 function prepare_builds_file()
 {
   project_name=`oc get project --no-headers | grep -m 1 conc-b | awk {'print $1'}`
-  bc_name=`oc get bc -n $project_name --no-headers | awk {'print $1'}`
-  running_build_file="running-builds.json"
-  # generate running-builds.json on the fly
-  printf '%s\n' "[" > "${running_build_file}"
-  proj_substring=${project_name::${#project_name}-1}
-  for (( c=1; c<"${MAX_CONC_BUILDS}"; c++ ))
-  do
-    if [[ "$c" == $((MAX_CONC_BUILDS - 1)) ]]; then
-      printf '%s\n' "{\"namespace\":\"$proj_substring${c}\", \"name\":\"$bc_name\"}" >> "${running_build_file}"
-    else
-      printf '%s\n' "{\"namespace\":\"$proj_substring${c}\", \"name\":\"$bc_name\"}," >> "${running_build_file}"
-    fi
-  done
-  printf '%s' "]" >> "${running_build_file}"
+  if [[ $project_name ]]; then
+    bc_name=`oc get bc -n $project_name --no-headers | awk {'print $1'}`
+    running_build_file="running-builds.json"
+    # generate running-builds.json on the fly
+    printf '%s\n' "[" > "${running_build_file}"
+    proj_substring=${project_name::${#project_name}-1}
+    for (( c=1; c<"${MAX_CONC_BUILDS}"; c++ ))
+    do
+      if [[ "$c" == $((MAX_CONC_BUILDS - 1)) ]]; then
+        printf '%s\n' "{\"namespace\":\"$proj_substring${c}\", \"name\":\"$bc_name\"}" >> "${running_build_file}"
+      else
+        printf '%s\n' "{\"namespace\":\"$proj_substring${c}\", \"name\":\"$bc_name\"}," >> "${running_build_file}"
+      fi
+    done
+    printf '%s' "]" >> "${running_build_file}"
+  fi
 }
 
 

--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -140,4 +140,5 @@ if [[ ${ENABLE_SNAPPY_BACKUP} == "true" ]] ; then
   snappy_backup kube-burner-${WORKLOAD}
 fi
 
+remove_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
 exit ${rc}

--- a/workloads/logging/run_logging_test.sh
+++ b/workloads/logging/run_logging_test.sh
@@ -8,4 +8,7 @@ if [[ ${DEPLOY_LOGGING} == "true" ]]; then
   deploy_logging_stack
 fi
 run_workload
+
+remove_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
+
 exit $?

--- a/workloads/network-perf/run.sh
+++ b/workloads/network-perf/run.sh
@@ -55,4 +55,7 @@ run_benchmark_comparison
 if [[ ${ENABLE_SNAPPY_BACKUP} == "true" ]] ; then
   snappy_backup network_perf_${WORKLOAD}_test
 fi
+
+remove_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
+
 log "Finished workload ${0}"

--- a/workloads/scale-perf/run_scale_fromgit.sh
+++ b/workloads/scale-perf/run_scale_fromgit.sh
@@ -44,3 +44,4 @@ done
 end_time=`date`
 duration=`date -ud@$(($(date -ud"$end_time" +%s)-$(date -ud"$start_time" +%s))) +%T`
 log "Duration of execution: ${duration} for number of scale runs: ${RUNS}"
+remove_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}


### PR DESCRIPTION
### Description
Moving remove_cli to after gen metadata so the python virtualenv is still avaiable with pyyaml package. 

Also adding if statement if project_name does not exist in the build helper (was seeing the error under fixes)

### Fixes
https://github.com/cloud-bulldozer/e2e-benchmarking/issues/371


```
04-07 11:40:36.224  No resources found in --no-headers namespace.
04-07 11:40:36.224  build_helper.sh: line 10: ${#project_name}-1: substring expression < 0
```