### PR TITLE
Incorrect string comparison for workload type of run

### DIFF
--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -117,7 +117,7 @@ if [[ ${PPROF_COLLECTION} == "true" ]] ; then
   get_pprof_secrets
 fi
 
-if [[ ${WORKLOAD} -eq "concurrent-builds" ]]; then
+if [[ ${WORKLOAD} == "concurrent-builds" ]]; then
    app_array=($APP_LIST)
    for app in "${app_array[@]}"
     do


### PR DESCRIPTION
### Description
The string comparison of the type of workload was not working properly. All workloads were getting into the if statement and causing a bunch of problems with running workloads multiple times 

### Fixes
All workloads that aren't concurrent builds to run once and properly