### PR TITLE
Set targeted to false for metadata collection by default

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -27,7 +27,7 @@ The run.sh script can be tweaked with the following environment variables
 | **OPERATOR_BRANCH**     | Benchmark-operator branch                     | master      |
 | **ES_SERVER**           | Elasticsearch endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443 |
 | **METADATA_COLLECTION** | Enable metadata collection | true (If indexing is disabled metadata collection will be also disabled) |
-| **METADATA_TARGETED**   | Enable metadata targeted collection | true |
+| **METADATA_TARGETED**   | Enable metadata targeted collection | false |
 | **NETWORK_POLICY**      | If enabled, benchmark-operator will create a network policy to allow ingress trafic in uperf server pods | false |
 | **SERVICETYPE**         | To provide specifics about openshift service types, supported options `clusterip`, `nodeport`, `metallb`. `metallb` type requires manual installation of operators and configuration of BGPPeers as explained [here](https://github.com/cloud-bulldozer/benchmark-operator/blob/master/docs/uperf.md#advanced-service-types) | clusterip |
 | **ADDRESSPOOL**         | To provide MetalLB addresspool for a service, this will be used as LoadBalancer network. Mentioned addresspool should be pre-provisioned before execution of this script. | addresspool-l2 |

--- a/workloads/network-perf/env.sh
+++ b/workloads/network-perf/env.sh
@@ -4,7 +4,9 @@ TEST_CLEANUP=${TEST_CLEANUP:-true}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 export ES_INDEX=ripsaw-uperf-results
 export METADATA_COLLECTION=${METADATA_COLLECTION:-true}
-export METADATA_TARGETED=${METADATA_TARGETED:-true}
+# Metadata collection can sometimes cause port collisions in uperf when running in targeted mode
+# It is recommended to run it with targeted set to false
+export METADATA_TARGETED=${METADATA_TARGETED:-false}
 
 # Benchark-operator
 OPERATOR_REPO=${OPERATOR_REPO:-https://github.com/cloud-bulldozer/benchmark-operator.git}


### PR DESCRIPTION
### Description
Targeted metadata collection may run into issues with ports in use and fail. Setting this to targeted: false by default.

### Fixes
