### PR TITLE
Use unauthenticated repository for postgres image

### DIFF
--- a/workloads/kube-burner/workloads/max-namespaces/postgres-deployment.yml
+++ b/workloads/kube-burner/workloads/max-namespaces/postgres-deployment.yml
@@ -11,7 +11,7 @@ spec:
       nodeSelector: {{.nodeSelector}}
       containers:
       - name: postgresql
-        image: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+        image: registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest
         ports:
         - containerPort: 5432
           protocol: TCP

--- a/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
@@ -11,7 +11,7 @@ spec:
       nodeSelector: {{.nodeSelector}}
       containers:
       - name: postgresql
-        image: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+        image: registry.access.redhat.com/rhscl/postgresql-10-rhel7:latest
         ports:
         - containerPort: 5432
           protocol: TCP


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
We should use the unauthenticated repository to prevent auth issues

### Fixes
