### PR TITLE
Removing benchmark operator only when cleanup when finish is true

### DIFF
--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -139,5 +139,11 @@ if [[ ${ENABLE_SNAPPY_BACKUP} == "true" ]] ; then
   snappy_backup kube-burner-${WORKLOAD}
 fi
 run_benchmark_comparison
-remove_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
+
+if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then
+  remove_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
+else
+  remove_cli
+fi
+
 exit ${rc}


### PR DESCRIPTION
### Description
Want to only fully clean up benchmark-operator namespace and benchmarks when CLEANUP_WHEN_FINISH is set to true, otherwise want to just deactivate/remove the cli 

Note that in previous PR I had added the cleanup of benchmark operator in multiple places, but it looks like the CLEANUP_WHEN_FINISH variable is only for kube-burner workload so only editing this workload
https://github.com/cloud-bulldozer/e2e-benchmarking/pull/372/files

