### PR TITLE
HAProxy: Add ability to customize the ingress-operator image

### DIFF
--- a/workloads/router-perf-v2/README.md
+++ b/workloads/router-perf-v2/README.md
@@ -64,6 +64,7 @@ It's possible to tune the default configuration through environment variables. T
 | SERVICE_TYPE          | K8S service type to use | `NodePort` |
 | METADATA_COLLECTION   | Collect metadata prior to trigger the workload | `true` |
 | HAPROXY_IMAGE         | Variable to override the default HAProxy container image | unset |
+| INGRESS_OPERATOR_IMAGE     | Variable to override the default ingress-operator container image | unset |
 
 ### Benchmark-comparison variables:
 

--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -14,6 +14,7 @@ ENGINE=${ENGINE:-podman}
 KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.11/kube-burner-0.11-Linux-x86_64.tar.gz}
 KUBE_BURNER_IMAGE=quay.io/cloud-bulldozer/kube-burner:latest
 #HAPROXY_IMAGE="quay.io/cloud-bulldozer/openshift-router-perfscale:-haproxy-v2.2.20"
+#INGRESS_OPERATOR_IMAGE="quay.io/cloud-bulldozer/openshift-cluster-ingress-operator:balance-random"
 TERMINATIONS=${TERMINATIONS:-"http edge passthrough reencrypt mix"}
 INFRA_TEMPLATE=${INFRA_TEMPLATE:-"http-perf.yml.tmpl"}
 export DEPLOYMENT_REPLICAS=${DEPLOYMENT_REPLICAS:-10}

--- a/workloads/router-perf-v2/ingress-performance.sh
+++ b/workloads/router-perf-v2/ingress-performance.sh
@@ -7,6 +7,7 @@ get_scenario
 deploy_infra
 tune_workload_node apply
 client_pod=$(oc get pod -l app=http-scale-client -n http-scale-client | awk '/Running/{print $1}')
+configure_ingress_images
 tune_liveness_probe
 if [[ ${METADATA_COLLECTION} == "true" ]]; then
   collect_metadata


### PR DESCRIPTION
### Description
Adds the ability to customize the ingress-operator image and adds additional verification and logging for the router image customization.

### Fixes
I would have to do more difficult workarounds for customizing the ingress-operator image. This makes it easier.