### PR TITLE
Add missing HAPROXY_IMAGE to README

### DIFF
--- a/workloads/router-perf-v2/README.md
+++ b/workloads/router-perf-v2/README.md
@@ -63,6 +63,7 @@ It's possible to tune the default configuration through environment variables. T
 | ES_INDEX              | Elasticsearch index | `router-test-results` |
 | SERVICE_TYPE          | K8S service type to use | `NodePort` |
 | METADATA_COLLECTION   | Collect metadata prior to trigger the workload | `true` |
+| HAPROXY_IMAGE         | Variable to override the default HAProxy container image | unset |
 
 ### Benchmark-comparison variables:
 


### PR DESCRIPTION
### Description
Add `HAPROXY_IMAGE` to README.md

### Fixes
Missing docs for router workload