### PR TITLE
Reduce timeoutSeconds for startupProbe in node-density-cni

### DIFF
--- a/workloads/kube-burner/workloads/node-density-cni-networkpolicy/curl-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-cni-networkpolicy/curl-deployment.yml
@@ -28,7 +28,7 @@ spec:
               - "-c"
               - "curl ${WEBSERVER_HOSTNAME}:${WEBSERVER_PORT}"
           periodSeconds: 1
-          timeoutSeconds: 60
+          timeoutSeconds: 1
           failureThreshold: 600
       restartPolicy: Always
   replicas: 1

--- a/workloads/kube-burner/workloads/node-density-cni/curl-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-cni/curl-deployment.yml
@@ -32,7 +32,7 @@ spec:
               - "-c"
               - "curl ${WEBSERVER_HOSTNAME}:${WEBSERVER_PORT}"
           periodSeconds: 1
-          timeoutSeconds: 60
+          timeoutSeconds: 1
           failureThreshold: 600
       restartPolicy: Always
   replicas: 1


### PR DESCRIPTION
Does the same for node-density-cni-networkpolicy to improve granularity
of Pod Startup latency.

Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description

### Fixes
