### PR TITLE
Max touchstone failures

### DIFF
--- a/workloads/network-perf/uperf-tolerancy-rules.yaml
+++ b/workloads/network-perf/uperf-tolerancy-rules.yaml
@@ -1,4 +1,8 @@
-- json_path: ["test_type", "stream", "protocol", "*", "message_size", "*", "num_threads", "*", "avg(norm_byte)"]
-  tolerancy: -30
-- json_path: ["test_type", "rr", "protocol", "*", "message_size", "*", "num_threads", "*", "99.0percentiles(norm_ltcy)"]
-  tolerancy: 30
+- json_path: ["test_type", "stream", "protocol", "*", "message_size", "*", "num_threads", "*", "num_pairs", "*", "avg(norm_byte)"]
+  tolerancy: -25
+  # Maximum percentage of allowed failures
+  max_failures: 33
+- json_path: ["test_type", "rr", "protocol", "*", "message_size", "*", "num_threads", "*", "num_pairs", "*", "99.0percentiles(norm_ltcy)"]
+  tolerancy: 25
+  # Maximum percentage of allowed failures
+  max_failures: 33

--- a/workloads/network-perf/uperf-touchstone-smoke.json
+++ b/workloads/network-perf/uperf-touchstone-smoke.json
@@ -1,30 +1,5 @@
 {
   "elasticsearch": {
-    "metadata": {
-      "cpuinfo-metadata": {
-        "additional_fields": [
-          "pod_name"
-        ],
-        "fields": [
-          "value.Model name",
-          "value.Architecture",
-          "value.CPU(s)"
-        ]
-      },
-      "meminfo-metadata": {
-        "additional_fields": [
-          "pod_name"
-        ],
-        "fields": [
-          "value.MemTotal"
-        ]
-      },
-      "k8s_cluster_info-metadata": {
-        "fields": [
-          "value.cluster_version"
-        ]
-      }
-    },
     "ripsaw-uperf-results": [
       {
         "filter": {

--- a/workloads/network-perf/uperf-touchstone.json
+++ b/workloads/network-perf/uperf-touchstone.json
@@ -1,30 +1,5 @@
 {
   "elasticsearch": {
-    "metadata": {
-      "cpuinfo-metadata": {
-        "additional_fields": [
-          "pod_name"
-        ],
-        "fields": [
-          "value.Model name",
-          "value.Architecture",
-          "value.CPU(s)"
-        ]
-      },
-      "meminfo-metadata": {
-        "additional_fields": [
-          "pod_name"
-        ],
-        "fields": [
-          "value.MemTotal"
-        ]
-      },
-      "k8s_cluster_info-metadata": {
-        "fields": [
-          "value.cluster_version"
-        ]
-      }
-    },
     "ripsaw-uperf-results": [
       {
         "filter": {
@@ -59,9 +34,6 @@
           "num_pairs.keyword"
         ],
         "aggregations": {
-          "norm_ops": [
-            "avg"
-          ],
           "norm_ltcy": [
             {
               "percentiles": {
@@ -69,8 +41,7 @@
                   99
                 ]
               }
-            },
-            "avg"
+            }
           ]
         }
       }

--- a/workloads/router-perf-v2/README.md
+++ b/workloads/router-perf-v2/README.md
@@ -68,19 +68,16 @@ It's possible to tune the default configuration through environment variables. T
 
 The ingress-performance script is able to invoke benchmark-comparison to perform results comparisons and then generate a google spreadsheet document. If `ES_SERVER_BASELINE` is not set, benchmark-comparison is used to generate a CSV results file.
 
-
-| Variable              | Description     | Default	          | Required |
-|-----------------------|-----------------|-------------------|---------------------------------|
-| ES_SERVER_BASELINE    | Elasticsearch endpoint used to fetch baseline results | "" | no |
-| BASELINE_UUID         | UUID of the benchmark to use as baseline in comparison | "" | no | 
-| COMPARISON_CONFIG     | Benchmark-comparison configuration file | `${PWD}/mb-touchstone.json` | no |
-| COMPARISON_ALIASES    | Benchmark-comparison aliases       | "" | no |
-| COMPARISON_OUTPUT_CFG | Benchmark-comparison output file   | `${PWD}/ingress-performance.csv`| no |
-| COMPARISON_RC         | Benchmark-comparison return code if tolerancy check fails | 0 | no |
-| TOLERANCY_RULES_CFG   | Tolerancy rules configuration file | `{PWD}/mb-tolerancy-rules.yaml` | no |
-| GSHEET_KEY_LOCATION   | Path to service account key to generate google sheets (optional) | "" | no |
-| EMAIL_ID_FOR_RESULTS_SHEET | It will push your local results CSV to Google Spreadsheets and send an email with the attachment | "" | no |
-
+| Variable                | Description              | Default |
+|-------------------------|--------------------------|---------|
+| **COMPARISON_ALIASES**  | Benchmark-comparison aliases (UUIDs will be replaced by these aliases | "" |
+| **ES_SERVER_BASELINE**  | Elasticsearch endpoint used used by the baseline benchmark | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443 |
+| **BASELINE_UUID**       | Baseline UUID used for comparison | "" |
+| **COMPARISON_CONFIG**   | Benchmark-comparison config file | `${PWD}/ingress-performance.csv` |
+| **COMPARISON_RC**       | Benchmark-comparison return code if tolerancy check fails | 0 |
+| **TOLERANCY_RULES_CFG** | Tolerancy rules configuration file | mb-tolerancy-rules.yaml |
+| **GSHEET_KEY_LOCATION** | Location of the Google Service Account Key | "" |
+| **EMAIL_ID_FOR_RESULTS_SHEET**   | Email to push CSV results | "" |
 
 ## Metrics
 

--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -43,7 +43,7 @@ KEEPALIVE_REQUESTS=${KEEPALIVE_REQUESTS:-"0 1 50"}
 
 # Comparison and csv generation
 BASELINE_UUID=${BASELINE_UUID}
-ES_SERVER_BASELINE=${ES_SERVER_BASELINE}
+ES_SERVER_BASELINE=${ES_SERVER_BASELINE:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 COMPARISON_CONFIG=${COMPARISON_CONFIG:-${PWD}/mb-touchstone.json}
 COMPARISON_RC=${COMPARISON_RC:-0}
 if [[ -v TOLERANCY_RULES_CFG ]]; then

--- a/workloads/router-perf-v2/mb-tolerancy-rules.yaml
+++ b/workloads/router-perf-v2/mb-tolerancy-rules.yaml
@@ -1,4 +1,8 @@
 - json_path: ["test_type", "*", "routes", "*", "conn_per_targetroute", "*", "keepalive", "*", "avg(requests_per_second)"]
-  tolerancy: -30
+  tolerancy: -25
+  # Maximum percentage of allowed failures
+  max_failures: 33
 - json_path: ["test_type", "*", "routes", "*", "conn_per_targetroute", "*", "keepalive", "*", "avg(latency_95pctl)"]
-  tolerancy: -30
+  tolerancy: 25
+  # Maximum percentage of allowed failures
+  max_failures: 33

--- a/workloads/router-perf-v2/mb-tolerancy-rules.yaml
+++ b/workloads/router-perf-v2/mb-tolerancy-rules.yaml
@@ -2,7 +2,3 @@
   tolerancy: -25
   # Maximum percentage of allowed failures
   max_failures: 33
-- json_path: ["test_type", "*", "routes", "*", "conn_per_targetroute", "*", "keepalive", "*", "avg(latency_95pctl)"]
-  tolerancy: 25
-  # Maximum percentage of allowed failures
-  max_failures: 33

--- a/workloads/router-perf-v2/mb-touchstone.json
+++ b/workloads/router-perf-v2/mb-touchstone.json
@@ -1,30 +1,5 @@
 {
   "elasticsearch": {
-    "metadata": {
-      "cpuinfo-metadata": {
-        "additional_fields": [
-          "pod_name"
-        ],
-        "fields": [
-          "value.Model name",
-          "value.Architecture",
-          "value.CPU(s)"
-        ]
-      },
-      "meminfo-metadata": {
-        "additional_fields": [
-          "pod_name"
-        ],
-        "fields": [
-          "value.MemTotal"
-        ]
-      },
-      "k8s_cluster_info-metadata": {
-        "fields": [
-          "value.cluster_version"
-        ]
-      }
-    },
     "router-test-results": [
       {
         "filter": {

--- a/workloads/router-perf-v2/mb-touchstone.json
+++ b/workloads/router-perf-v2/mb-touchstone.json
@@ -13,9 +13,6 @@
         "aggregations": {
           "requests_per_second": [
             "avg"
-          ],
-          "latency_95pctl": [
-            "avg"
           ]
         }
       },
@@ -30,9 +27,6 @@
         ],
         "aggregations": {
           "requests_per_second": [
-            "avg"
-          ],
-          "latency_95pctl": [
             "avg"
           ]
         }
@@ -49,9 +43,6 @@
         "aggregations": {
           "requests_per_second": [
             "avg"
-          ],
-          "latency_95pctl": [
-            "avg"
           ]
         }
       },
@@ -67,9 +58,6 @@
         "aggregations": {
           "requests_per_second": [
             "avg"
-          ],
-          "latency_95pctl": [
-            "avg"
           ]
         }
       },
@@ -84,9 +72,6 @@
         ],
         "aggregations": {
           "requests_per_second": [
-            "avg"
-          ],
-          "latency_95pctl": [
             "avg"
           ]
         }


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

With this change, touchstone will report error when there's more than 33% of failures on a comparison block, that is to say,  in the following comparison:

```
+-------------+--------+----------------------+-----------+---------------------+--------+-----------+------------+------------+
|  test_type  | routes | conn_per_targetroute | keepalive |       metric        | result | deviation |    4.9     | 4.11  |
+-------------+--------+----------------------+-----------+---------------------+--------+-----------+------------+------------+
| passthrough |  500   |          1           |     0     | avg(latency_95pctl) |  Pass  |  -2.55%   |   5571.5   |   5429.5   |
| passthrough |  500   |          1           |     1     | avg(latency_95pctl) |  Pass  |  -1.17%   |  148717.5  |  146976.5  |
| passthrough |  500   |          1           |    50     | avg(latency_95pctl) |  Pass  |  -0.36%   |   7680.0   |   7652.5   |
| passthrough |  500   |          20          |     0     | avg(latency_95pctl) |  Pass  |  -12.08%  |  81413.5   |  71577.0   |
| passthrough |  500   |          20          |     1     | avg(latency_95pctl) |  Pass  |  -1.84%   | 2903374.5  | 2849896.0  |
| passthrough |  500   |          20          |    50     | avg(latency_95pctl) |  Pass  |  -18.66%  |  132022.0  |  107385.5  |
| passthrough |  500   |          80          |     0     | avg(latency_95pctl) |  Fail  |  85.58%   |  446719.5  |  829003.0  |
| passthrough |  500   |          80          |     1     | avg(latency_95pctl) |  Pass  |  -19.71%  | 14254016.0 | 11444703.5 |
| passthrough |  500   |          80          |    50     | avg(latency_95pctl) |  Pass  |  -38.49%  | 1203344.0  |  740156.0  |
+-------------+--------+----------------------+-----------+---------------------+--------+-----------+------------+------------+
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+----------+-----------+
| test_type | routes | conn_per_targetroute | keepalive |          metric          | result | deviation |   4.9    | 4.11 |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+----------+-----------+
| reencrypt |  500   |          1           |     0     | avg(requests_per_second) |  Pass  |   3.68%   | 122225.0 | 126720.5  |
| reencrypt |  500   |          1           |     1     | avg(requests_per_second) |  Pass  |  -1.03%   |  3801.0  |  3762.0   |
| reencrypt |  500   |          1           |    50     | avg(requests_per_second) |  Pass  |   2.77%   | 91657.0  |  94196.0  |
| reencrypt |  500   |          20          |     0     | avg(requests_per_second) |  Pass  |   1.75%   | 16153.5  |  16435.5  |
| reencrypt |  500   |          20          |     1     | avg(requests_per_second) |  Pass  |  -0.25%   |  3663.0  |  3654.0   |
| reencrypt |  500   |          20          |    50     | avg(requests_per_second) |  Pass  |   2.38%   | 15812.0  |  16188.0  |
| reencrypt |  500   |          80          |     0     | avg(requests_per_second) |  Pass  |  -3.04%   |  4182.5  |  4055.5   |
| reencrypt |  500   |          80          |     1     | avg(requests_per_second) |  Pass  |   1.11%   |  3070.5  |  3104.5   |
| reencrypt |  500   |          80          |    50     | avg(requests_per_second) |  Fail  |  -43.02%  |  4901.0  |  2792.5   |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+----------+-----------+
```

The above comparison won't fail since there's only one fail in the reencrypt comparison block (11.1111)


This change is necessary to prevent hanging when only a few regressions were found in the benchmark. Also removing useless  metadata comparison and improving docs.

