### PR TITLE
Re-schedule monitoring-stack to worker nodes

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -107,7 +107,7 @@ tune_liveness_probe(){
 reschedule_monitoring_stack(){
    [[ $(oc get cm -n openshift-monitoring cluster-monitoring-config --ignore-not-found --no-headers | wc -l) == 0 ]] && return 0
    log "Re-scheduling monitoring stack to ${1} nodes"
-   oc get cm -n openshift-monitoring cluster-monitoring-config -o yaml | sed "s#kubernetes.io/.*#kubernetes.io/${1}#g" | kubectl apply -f -
+   oc get cm -n openshift-monitoring cluster-monitoring-config -o yaml | sed "s#kubernetes.io/\w*#kubernetes.io/${1}#g" | oc apply -f -
    # cluster-monitoring-operator can take some time to reconcile the changes
    sleep 1m
    oc rollout status -n openshift-monitoring deploy/cluster-monitoring-operator

--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -105,12 +105,13 @@ tune_liveness_probe(){
 }
 
 reschedule_monitoring_stack(){
+   [[ $(oc get cm -n openshift-monitoring cluster-monitoring-config --ignore-not-found --no-headers | wc -l) == 0 ]] && return 0
    log "Re-scheduling monitoring stack to ${1} nodes"
-   kubectl get cm -n openshift-monitoring  cluster-monitoring-config -o yaml | sed "s#kubernetes.io/.*#kubernetes.io/${1}#g" | kubectl apply -f -
+   oc get cm -n openshift-monitoring cluster-monitoring-config -o yaml | sed "s#kubernetes.io/.*#kubernetes.io/${1}#g" | kubectl apply -f -
    # cluster-monitoring-operator can take some time to reconcile the changes
    sleep 1m
-   kubectl rollout status -n openshift-monitoring deploy/cluster-monitoring-operator
-   kubectl rollout status -n openshift-monitoring sts/prometheus-k8s
+   oc rollout status -n openshift-monitoring deploy/cluster-monitoring-operator
+   oc rollout status -n openshift-monitoring sts/prometheus-k8s
 }
 
 tune_workload_node(){

--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -104,6 +104,15 @@ tune_liveness_probe(){
   # TODO: validate liveness period and image
 }
 
+reschedule_monitoring_stack(){
+   log "Re-scheduling monitoring stack to ${1} nodes"
+   kubectl get cm -n openshift-monitoring  cluster-monitoring-config -o yaml | sed "s#kubernetes.io/.*#kubernetes.io/${1}#g" | kubectl apply -f -
+   # cluster-monitoring-operator can take some time to reconcile the changes
+   sleep 1m
+   kubectl rollout status -n openshift-monitoring deploy/cluster-monitoring-operator
+   kubectl rollout status -n openshift-monitoring sts/prometheus-k8s
+}
+
 tune_workload_node(){
   TUNED_NODE_SELECTOR=$(echo ${NODE_SELECTOR} | sed 's/^{\(.*\)\:.*$/\1/')
   log "${1^} tuned profile for node labeled with ${TUNED_NODE_SELECTOR}"

--- a/workloads/router-perf-v2/ingress-performance.sh
+++ b/workloads/router-perf-v2/ingress-performance.sh
@@ -14,6 +14,7 @@ log "###############################################"
 deploy_infra
 tune_workload_node apply
 client_pod=$(oc get pod -l app=http-scale-client -n http-scale-client | awk '/Running/{print $1}')
+reschedule_monitoring_stack worker
 configure_ingress_images
 tune_liveness_probe
 if [[ ${METADATA_COLLECTION} == "true" ]]; then
@@ -46,6 +47,7 @@ done
 
 tune_workload_node delete
 cleanup_infra
+reschedule_monitoring_stack infra
 
 if [[ -n ${ES_SERVER} ]]; then
   log "Installing touchstone"


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Re-scheduling the monitoring stack to worker nodes before the benchmark starts will prevent the benchmark to be affected by prometheus noise (compaction, scraping, etc) and will help us to obtain more deterministic results.
The below graphs show an snippet of the system prometheus system activity during a benchmark

![image](https://user-images.githubusercontent.com/4614641/167824633-0584144c-83f8-456f-b0f0-ef53dbed2981.png)


Where the highest CPU spikes happen during the database compaction: ~19:00 and 21:00

There's also a almost constant network I/O activity caused by metric scraping.

Another interesting fact is that we deploy 3 infrastructure nodes and there's only 2 prometheus replicas, so in some tests it's possible to have an ingress-controller in a node w/o any prometheus replica, that means that the test scenario can be different between runs.
