### PR TITLE
Remobe BASELINE_POD_UUID

### DIFF
--- a/workloads/network-perf/run.sh
+++ b/workloads/network-perf/run.sh
@@ -48,7 +48,6 @@ for pairs in ${PAIRS}; do
   fi
 done
 
-BASELINE_UUID=${BASELINE_POD_UUID}
 COMPARISON_OUTPUT=${PWD}/${WORKLOAD}-${UUID}.csv
 run_benchmark_comparison
 


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

No idea what was the purpose of this variable, but it's useless now.

### Fixes
