### PR TITLE
New templating for http-perf.yaml, do not remove

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -157,7 +157,7 @@ enable_ingress_operator(){
 cleanup_infra(){
   log "Deleting infrastructure"
   oc delete ns -l kube-burner-uuid=${UUID} --ignore-not-found
-  rm -f /tmp/temp-route*.txt http-perf.yml http-*.json
+  rm -f /tmp/temp-route*.txt http-*.json
 }
 
 gen_mb_config(){


### PR DESCRIPTION
### Description
PR https://github.com/cloud-bulldozer/e2e-benchmarking/pull/391/ changed how the config is templated, small `rm` overlooked.

### Fixes
Annoying deletion of `http-perf.yml`