### PR TITLE
Remove default value for METRICS_PROFILE

### DIFF
--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -32,7 +32,7 @@ export KUBE_BURNER_IMAGE=${KUBE_BURNER_IMAGE:-quay.io/cloud-bulldozer/kube-burne
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-14400}
 export LOG_STREAMING=${LOG_STREAMING:-true}
-export METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/metrics.yaml}
+export METRICS_PROFILE=${METRICS_PROFILE}
 
 # Misc
 export CLEANUP_WHEN_FINISH=${CLEANUP_WHEN_FINISH:-false}


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

If se set a default value, the METRICS_PROFILE variable is not overriden in the workload, because of the expression `METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/metrics-aggregated.yaml}`

### Fixes

The metrics-aggregated profile is not being set in cluster-density tests