### PR TITLE
Remove benchmark-operator's role dependencies

### DIFF
--- a/utils/benchmark-operator.sh
+++ b/utils/benchmark-operator.sh
@@ -27,7 +27,9 @@ remove_cli() {
 ############################################################################
 deploy_benchmark_operator() {
   install_cli
-  ripsaw operator install --repo=${1} --branch=${2}
+  if ! ripsaw operator install --repo=${1} --branch=${2}; then
+     exit 1
+  fi
   deactivate
 }
 

--- a/workloads/cyclictest/common.sh
+++ b/workloads/cyclictest/common.sh
@@ -148,10 +148,6 @@ deploy_perf_profile() {
 
 deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
-  if [[ $? != 0 ]]; then
-     exit 1
-  fi
-  rm -rf benchmark-operator
 }
 
 run_workload() {

--- a/workloads/etcd-perf/run_etcd_tests_fromgit.sh
+++ b/workloads/etcd-perf/run_etcd_tests_fromgit.sh
@@ -31,11 +31,9 @@ oc create ns backpack
 
 git clone http://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-operator --depth 1
 (cd /tmp/benchmark-operator && make deploy)
-kubectl apply -f /tmp/benchmark-operator/resources/backpack_role.yaml
 oc wait --for=condition=available "deployment/benchmark-controller-manager" -n benchmark-operator --timeout=300s
 
 oc adm policy add-scc-to-user -n benchmark-operator privileged -z benchmark-operator
-oc adm policy add-scc-to-user -n benchmark-operator privileged -z backpack-view
 
 cat << EOF | oc create -n benchmark-operator -f -
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1

--- a/workloads/etcd-perf/run_etcd_tests_fromgit.sh
+++ b/workloads/etcd-perf/run_etcd_tests_fromgit.sh
@@ -33,7 +33,6 @@ git clone http://github.com/cloud-bulldozer/benchmark-operator /tmp/benchmark-op
 (cd /tmp/benchmark-operator && make deploy)
 oc wait --for=condition=available "deployment/benchmark-controller-manager" -n benchmark-operator --timeout=300s
 
-oc adm policy add-scc-to-user -n benchmark-operator privileged -z benchmark-operator
 
 cat << EOF | oc create -n benchmark-operator -f -
 apiVersion: ripsaw.cloudbulldozer.io/v1alpha1
@@ -49,7 +48,6 @@ spec:
   metadata:
     collection: true
     serviceaccount: backpack-view
-    privileged: true
   hostpath: /var/lib/fio-etcd
   workload:
     name: fio_distributed

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -54,11 +54,6 @@ collect_pprof() {
 
 deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
-  if [[ $? != 0 ]]; then
-    exit 1
-  fi
-  rm -rf benchmark-operator
-  git clone --single-branch --branch ${OPERATOR_BRANCH} ${OPERATOR_REPO} --depth 1
 }
 
 run_workload() {

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -59,8 +59,6 @@ deploy_operator() {
   fi
   rm -rf benchmark-operator
   git clone --single-branch --branch ${OPERATOR_BRANCH} ${OPERATOR_REPO} --depth 1
-  kubectl apply -f benchmark-operator/resources/backpack_role.yaml
-  kubectl apply -f benchmark-operator/resources/kube-burner-role.yml
 }
 
 run_workload() {

--- a/workloads/logging/common.sh
+++ b/workloads/logging/common.sh
@@ -25,8 +25,6 @@ fi
 
 deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
-  rm -rf benchmark-operator
-  git clone --single-branch --branch ${OPERATOR_BRANCH} ${OPERATOR_REPO} --depth 1
 }
 
 deploy_logging_stack() {

--- a/workloads/logging/common.sh
+++ b/workloads/logging/common.sh
@@ -27,7 +27,6 @@ deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
   rm -rf benchmark-operator
   git clone --single-branch --branch ${OPERATOR_BRANCH} ${OPERATOR_REPO} --depth 1
-  kubectl apply -f benchmark-operator/resources/backpack_role.yaml
 }
 
 deploy_logging_stack() {

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -80,9 +80,7 @@ export_defaults() {
 
 deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
-  kubectl apply -f https://raw.githubusercontent.com/cloud-bulldozer/benchmark-operator/${OPERATOR_BRANCH}/resources/backpack_role.yaml
   oc adm policy -n benchmark-operator add-scc-to-user privileged -z benchmark-operator
-  oc adm policy -n benchmark-operator add-scc-to-user privileged -z backpack-view
 }
 
 run_workload() {

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -80,7 +80,6 @@ export_defaults() {
 
 deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
-  oc adm policy -n benchmark-operator add-scc-to-user privileged -z benchmark-operator
 }
 
 run_workload() {

--- a/workloads/network-perf/ripsaw-uperf-crd.yaml
+++ b/workloads/network-perf/ripsaw-uperf-crd.yaml
@@ -12,7 +12,6 @@ spec:
   metadata:
     collection: ${METADATA_COLLECTION}
     serviceaccount: backpack-view
-    privileged: true
     targeted: ${METADATA_TARGETED}
   workload:
     name: uperf

--- a/workloads/network-perf/smoke-crd.yaml
+++ b/workloads/network-perf/smoke-crd.yaml
@@ -12,7 +12,6 @@ spec:
   metadata:
     collection: ${METADATA_COLLECTION}
     serviceaccount: backpack-view
-    privileged: true
     targeted: ${METADATA_TARGETED}
   workload:
     name: uperf

--- a/workloads/oslat/common.sh
+++ b/workloads/oslat/common.sh
@@ -149,10 +149,6 @@ deploy_perf_profile() {
 
 deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
-  if [[ $? != 0 ]]; then
-     exit 1
-  fi
-  rm -rf benchmark-operator
 }
 
 run_workload() {

--- a/workloads/scale-perf/common.sh
+++ b/workloads/scale-perf/common.sh
@@ -22,9 +22,6 @@ fi
 
 deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
-  rm -rf benchmark-operator
-  git clone --single-branch --branch ${OPERATOR_BRANCH} ${OPERATOR_REPO} --depth 1
-  oc adm policy -n benchmark-operator add-scc-to-user privileged -z benchmark-operator
 }
 
 run_workload() {

--- a/workloads/scale-perf/common.sh
+++ b/workloads/scale-perf/common.sh
@@ -24,10 +24,7 @@ deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
   rm -rf benchmark-operator
   git clone --single-branch --branch ${OPERATOR_BRANCH} ${OPERATOR_REPO} --depth 1
-  kubectl apply -f benchmark-operator/resources/backpack_role.yaml
-  kubectl apply -f benchmark-operator/resources/scale_role.yaml
   oc adm policy -n benchmark-operator add-scc-to-user privileged -z benchmark-operator
-  oc adm policy -n benchmark-operator add-scc-to-user privileged -z backpack-view
 }
 
 run_workload() {

--- a/workloads/testpmd/common.sh
+++ b/workloads/testpmd/common.sh
@@ -331,10 +331,6 @@ cleanup_network() {
 
 deploy_operator() {
   deploy_benchmark_operator ${OPERATOR_REPO} ${OPERATOR_BRANCH}
-  if [[ $? != 0 ]]; then
-     exit 1
-  fi
-  rm -rf benchmark-operator
 }
 
 run_workload() {


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description
Depends-on: https://github.com/cloud-bulldozer/benchmark-operator/pull/763

### Fixes
