### PR TITLE
fix aws keys

### DIFF
--- a/workloads/api-load/README.md
+++ b/workloads/api-load/README.md
@@ -5,7 +5,7 @@ In order to kick off one of these benchmarks you must use the run.sh script.
 Running from CLI:
 
 ```sh
-$TESTS="list-clusters list-subscriptions" GATEWAY_URL="http://localhost:8080" OCM_TOKEN="notARealToken" RATE=10/s AWS_ACCESS_KEY="empty" AWS_ACCESS_SECRET="empty" AWS_ACCOUNT_ID="empty" ./run.sh
+$TESTS="list-clusters list-subscriptions" GATEWAY_URL="http://localhost:8080" OCM_TOKEN="notARealToken" RATE=10/s AWS_ACCESS_KEY_ID="empty" AWS_SECRET_ACCESS_KEY="empty" AWS_ACCOUNT_ID="empty" ./run.sh
 ```
 
 ## Dependencies

--- a/workloads/api-load/api-load-crd.yaml
+++ b/workloads/api-load/api-load-crd.yaml
@@ -21,8 +21,8 @@ spec:
       duration: ${DURATION}
       rate: ${RATE}
       output_path: ${OUTPUT_PATH}
-      aws_access_key: ${AWS_ACCESS_KEY_ID}
-      aws_access_secret: ${AWS_SECRET_ACCESS_KEY}
+      aws_access_key: ${AWS_ACCESS_KEY}
+      aws_access_secret: ${AWS_ACCESS_SECRET}
       aws_account_id: ${AWS_ACCOUNT_ID}
       cooldown: ${COOLDOWN}
       sleep: ${SLEEP}

--- a/workloads/api-load/common.sh
+++ b/workloads/api-load/common.sh
@@ -17,8 +17,8 @@ export_defaults() {
     exit 1
   fi
   export ADMIN_KEY=$(aws iam create-access-key --user-name OsdCcsAdmin --output json)
-  export AWS_ACCESS_KEY_ID=$(echo $ADMIN_KEY | jq -r '.AccessKey.AccessKeyId')
-  export AWS_SECRET_ACCESS_KEY=$(echo $ADMIN_KEY | jq -r '.AccessKey.SecretAccessKey')
+  export AWS_ACCESS_KEY=$(echo $ADMIN_KEY | jq -r '.AccessKey.AccessKeyId')
+  export AWS_ACCESS_SECRET=$(echo $ADMIN_KEY | jq -r '.AccessKey.SecretAccessKey')
   sleep 60
   aws iam get-user --output json | jq -r .User.UserName
 }
@@ -75,7 +75,7 @@ run_workload() {
     log "Cleaning up benchmark"
     kubectl delete -f ${TMPCR}
   fi
-  aws iam delete-access-key --user-name OsdCcsAdmin --access-key-id $AWS_ACCESS_KEY_ID || true
+  aws iam delete-access-key --user-name OsdCcsAdmin --access-key-id $AWS_ACCESS_KEY || true
   return ${rc}
 }
 


### PR DESCRIPTION
Currently we are overriding AWS_ACCESS_KEY_ID and
AWS_SECRET_ACCESS_KEY with OsdCcsAdmin user's keys.

Newly created OsdCcsAdmin user's aws token is needed for only
ocm-api-load tool.

So instead of overriding existing aws keys, we can create
OsdCcsAdmin user keys with different variable names.


