### PR TITLE
Fix prometheus token expression for k8s 1.24

### DIFF
--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -12,7 +12,7 @@ if [[ ${INDEXING} == "false" ]]; then
   unset PROM_URL
 else
   if [[ ${HYPERSHIFT} == "false" ]]; then
-    export PROM_TOKEN=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+    export PROM_TOKEN=$(oc sa get-token -n openshift-monitoring prometheus-k8s || oc create token -n openshift-monitoring prometheus-k8s)
   else
     export PROM_TOKEN="dummytokenforthanos"
     export HOSTED_CLUSTER_NAME=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')
@@ -151,7 +151,7 @@ get_pprof_secrets() {
  oc extract -n openshift-etcd secret/$certkey
  export CERTIFICATE=`base64 -w0 tls.crt`
  export PRIVATE_KEY=`base64 -w0 tls.key`
- export BEARER_TOKEN=$(oc sa get-token kube-burner -n benchmark-operator)
+ export BEARER_TOKEN=$(oc sa get-token kube-burner -n benchmark-operator || oc create token -n benchmark-operator kube-burner)
 }
 
 delete_pprof_secrets() {


### PR DESCRIPTION
### Description

As of k8s 1.24 the command oc sa get-token is not valid anymore:

```
[root@ip-172-31-32-243 ~]# oc sa get-token -n openshift-monitoring prometheus-k8s 
Command "get-token" is deprecated, and will be removed in the future version. Use oc create token instead.
error: could not find a service account token for service account "prometheus-k8s"
```

Fixing it and adding backwards compatibility.

### Fixes
