### PR TITLE
Multiple python venvs to resolve conflicts on parallel workload runs

### DIFF
--- a/utils/benchmark-operator.sh
+++ b/utils/benchmark-operator.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
 install_cli() {
-  ripsaw_tmp=/tmp/ripsaw-cli
+  export UUID=${UUID:-`uuidgen`}
+  run_dir=/tmp/${UUID}
+  ripsaw_tmp=${run_dir}/ripsaw-cli
   mkdir -p ${ripsaw_tmp}
   if [[ ! -f ${ripsaw_tmp}/bin/activate ]]; then
       if [[ "${isBareMetal}" == "true" ]]; then
@@ -16,7 +18,7 @@ install_cli() {
 
 remove_cli() {
   deactivate
-  rm -rf ${ripsaw_tmp}
+  rm -rf ${run_dir}
 }
 
 ############################################################################
@@ -40,7 +42,7 @@ deploy_benchmark_operator() {
 remove_benchmark_operator() {
   source ${ripsaw_tmp}/bin/activate
   ripsaw operator delete --repo=${1} --branch=${2}
-  rm -rf ${ripsaw_tmp}
+  rm -rf ${run_dir}
   remove_cli
 }
 

--- a/utils/benchmark-operator.sh
+++ b/utils/benchmark-operator.sh
@@ -4,6 +4,7 @@ install_cli() {
   export UUID=${UUID:-`uuidgen`}
   run_dir=/tmp/${UUID}
   ripsaw_tmp=${run_dir}/ripsaw-cli
+  log "creating python virtual environment at path: ${ripsaw_tmp}"
   mkdir -p ${ripsaw_tmp}
   if [[ ! -f ${ripsaw_tmp}/bin/activate ]]; then
       if [[ "${isBareMetal}" == "true" ]]; then
@@ -17,7 +18,9 @@ install_cli() {
 }
 
 remove_cli() {
+  log "deactivating python virtual environment at path: ${ripsaw_tmp}"
   deactivate
+  log "cleaning up unique run directory at path: ${run_dir}"
   rm -rf ${run_dir}
 }
 
@@ -42,7 +45,6 @@ deploy_benchmark_operator() {
 remove_benchmark_operator() {
   source ${ripsaw_tmp}/bin/activate
   ripsaw operator delete --repo=${1} --branch=${2}
-  rm -rf ${run_dir}
   remove_cli
 }
 


### PR DESCRIPTION
### Description
Bug fix to create multiple python virtual environments to resolve conflicts on parallel workload runs.

#### Before bug fix
Before this bug fix when triggered multiple workloads in parallel on a host, both the workload used `/tmp/ripsaw` as the virtual python environments. So in the final step of a workload execution when the garbage collection happens if one of the workload finishes fist, it removes the directory `/tmp/ripsaw` which was also being used by the other workload ultimately resulting in the following cleanup error. 

Relevant Screenshots :

- <a href="https://drive.google.com/file/d/1eQ4UubemRL_eMnwAwBhqXg9sQQlgis2j/view?usp=sharing"><img src="https://drive.google.com/file/d/1eQ4UubemRL_eMnwAwBhqXg9sQQlgis2j/view?usp=sharing" style="width: 500px; max-width: 100%; height: auto" title="Directory structure before fix" /></a>
- <a href="https://drive.google.com/file/d/10DWGGzo12maAafCpftVkC6HmK4QGyXSW/view?usp=sharing"><img src="https://drive.google.com/file/d/10DWGGzo12maAafCpftVkC6HmK4QGyXSW/view?usp=sharing" style="width: 500px; max-width: 100%; height: auto" title="Cleanup error before fix" /></a>

### Fix
In order to separate each execution in a unique manner we are creating separate virtual environment directories using a unique uuid to avoid conflicts between multiple parallel runs.

#### After bug fix
Relevant Screenshots:

- <a href="https://drive.google.com/file/d/1nCvmilil2jOJl7a8ixsQXNe55pvyw6ff/view?usp=sharing"><img src="https://drive.google.com/file/d/1nCvmilil2jOJl7a8ixsQXNe55pvyw6ff/view?usp=sharing" style="width: 500px; max-width: 100%; height: auto" title="Directory structure after fix" /></a>
- <a href="https://drive.google.com/file/d/1rP5fzSTVvSuLx9tg_k2t6mlMh4dSJt_1/view?usp=sharing"><img src="https://drive.google.com/file/d/1rP5fzSTVvSuLx9tg_k2t6mlMh4dSJt_1/view?usp=sharing" style="width: 500px; max-width: 100%; height: auto" title="Successful parallel runs after the fix" /></a>

After this fix both the parallel runs ran and cleaned up successfully.