### PR TITLE
add ocm api load job timeout

### DIFF
--- a/workloads/api-load/README.md
+++ b/workloads/api-load/README.md
@@ -24,7 +24,8 @@ Workloads can be tweaked with the following environment variables:
 | **OPERATOR_BRANCH**  | Benchmark-operator branch       | master  |
 | **ES_SERVER**        | Elasticsearch endpoint          | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|
 | **ES_INDEX**         | Elasticsearch index             | ripsaw-api-load|
-| **TEST_TIMEOUT**        | Benchmark timeout, in seconds | 7200 (2 hours) |
+| **TEST_TIMEOUT**        | Benchmark timeout, in seconds | 28800 (8 hours) |
+| **JOB_TIMEOUT**        | api-load job timeout, in seconds | 28800 (8 hours) |
 | **TEST_CLEANUP**        | Remove benchmark CR at the end | true |
 | **GATEWAY_URL**      | Gateway url to perform the test against       | "https://api.integration.openshift.com |
 | **OCM_TOKEN**| OCM Authorization token |  |

--- a/workloads/api-load/api-load-crd.yaml
+++ b/workloads/api-load/api-load-crd.yaml
@@ -17,6 +17,7 @@ spec:
   workload:
     name: api_load
     args:
+      job_timeout: ${JOB_TIMEOUT}
       gateway_url: ${GATEWAY_URL}
       ocm_token: ${OCM_TOKEN}
       duration: ${DURATION}

--- a/workloads/api-load/env.sh
+++ b/workloads/api-load/env.sh
@@ -5,12 +5,15 @@ export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4b
 export ES_INDEX=ripsaw-api-load
 export ES_SKIP_VERIFY=${ES_SKIP_VERIFY:-true}
 
+# ocm-api-load job
+export JOB_TIMEOUT=${JOB_TIMEOUT:-28800}
+
 # Benchark-operator
 OPERATOR_REPO=${OPERATOR_REPO:-https://github.com/cloud-bulldozer/benchmark-operator.git}
 OPERATOR_BRANCH=${OPERATOR_BRANCH:-master}
 
 # Workload
-export TEST_TIMEOUT=${TEST_TIMEOUT:-7200}
+export TEST_TIMEOUT=${TEST_TIMEOUT:-28800}
 
 # snappy
 export SNAPPY_DATA_SERVER_URL=${SNAPPY_DATA_SERVER_URL:-http://ec2-34-220-107-152.us-west-2.compute.amazonaws.com:7070}


### PR DESCRIPTION
ocm api load testing takes 6 to 7 hours for completion. So set
api-load job timeout to 8 hours so that ocm-api-load job won't
terminate ocp-api-load pod within 8 hours.

### Description

### Fixes
