### PR TITLE
Increase scheduling time for rosa upgrades on 1 minute

### DIFF
--- a/workloads/upgrade-perf/rosa_upgrade.sh
+++ b/workloads/upgrade-perf/rosa_upgrade.sh
@@ -40,9 +40,9 @@ rosa_upgrade(){
     echo "INFO: Upgrading cluster to ${VERSION} version..."
   fi
   CURRENT_VERSION=$(oc get clusterversion | grep ^version | awk '{print $2}')
-  rosa upgrade cluster -c ${ROSA_CLUSTER_NAME} --version=${VERSION} -y --schedule-date $(date +%Y-%m-%d) --schedule-time $(date -u --date="+6 minutes" +%H:%M)
-  # Sleep 6 minutes, rosa upgrade dont let to schedule an upgrade in less than 5 minutes from now
-  sleep 360
+  rosa upgrade cluster -c ${ROSA_CLUSTER_NAME} --version=${VERSION} -y --schedule-date $(date +%Y-%m-%d) --schedule-time $(date -u --date="+7 minutes" +%H:%M)
+  # Sleep 7 minutes, rosa upgrade dont let to schedule an upgrade in less than 5 minutes from now
+  sleep 420
   oc delete pods -n openshift-insights --all
   oc delete pods -n openshift-managed-upgrade-operator --all
   rosa_control_plane_upgrade_active_waiting ${VERSION}


### PR DESCRIPTION
It seems that 6 minutes could be not enough when command runs arround second 59

```
[2022-06-17 09:38:58,306] {subprocess.py:92} INFO - ++ date +%Y-%m-%d
[2022-06-17 09:38:58,307] {subprocess.py:92} INFO - ++ date -u '--date=+6 minutes' +%H:%M
[2022-06-17 09:38:58,308] {subprocess.py:92} INFO - + rosa upgrade cluster -c perf-410-e99e --version=4.10.18 -y --schedule-date 2022-06-17 --schedule-time 09:44
[2022-06-17 09:38:58,605] {subprocess.py:92} INFO - INFO: Ensuring account and operator role policies for cluster '1ssu1bvpit0o57ljqph8q1o5hpa3vrg5' are compatible with upgrade.
[2022-06-17 09:38:59,835] {subprocess.py:92} INFO - INFO: Account and operator roles for cluster 'perf-410-e99e' are compatible with upgrade
[2022-06-17 09:39:00,142] {subprocess.py:92} INFO - ERR: Failed to schedule upgrade for cluster 'perf-410-e99e': Cannot set upgrade to start earlier than 5 minutes from now
```
