### PR TITLE
Stop pinning uperf pods 

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -34,7 +34,6 @@ The run.sh script can be tweaked with the following environment variables
 | **ADDRESSPOOL**         | To provide MetalLB addresspool for a service, this will be used as LoadBalancer network. Mentioned addresspool should be pre-provisioned before execution of this script. | addresspool-l2 |
 | **SERVICE_ETP**         | To mention the type of `ExternalTrafficPolicy` of a service, supported option `Cluster` or `Local` | Cluster |
 | **SAMPLES**             | How many times to run the tests | 3 |
-| **MULTI_AZ**            | If true, uperf client and server pods will be colocated in different topology zones or AZs (`topology.kubernetes.io/zone` in k8s terminology). 2 worker nodes in differet topology zones are required to enable this flag.  If false, uperf client and server pods will be colocated in the same topology zone | true |
 | **PAIRS**               | List with the number of pairs the test will be triggered (hostnet variant is executed w/ 1 pair only) | 1 2 4 |
 | **TEST_TIMEOUT**        | Benchmark timeout, in seconds | 7200 (2 hours) |
 | **TEST_CLEANUP**        | Remove benchmark CR at the end | true |

--- a/workloads/network-perf/common.sh
+++ b/workloads/network-perf/common.sh
@@ -12,71 +12,11 @@ export_defaults() {
   export UUID=$(uuidgen)
   export CLUSTER_NAME=$(oc get infrastructure cluster -o jsonpath="{.status.infrastructureName}")
   export PROM_TOKEN=$(oc sa get-token -n openshift-monitoring prometheus-k8s || oc sa new-token -n openshift-monitoring prometheus-k8s || oc create token -n openshift-monitoring  prometheus-k8s)
-  local baremetalCheck=$(oc get infrastructure cluster -o json | jq .spec.platformSpec.type)
-  zones=($(oc get nodes -l node-role.kubernetes.io/workload!=,node-role.kubernetes.io/infra!=,node-role.kubernetes.io/worker -o go-template='{{ range .items }}{{ index .metadata.labels "topology.kubernetes.io/zone" }}{{ "\n" }}{{ end }}' | uniq))
-  platform=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.type}' | tr '[:upper:]' '[:lower:]')
-  #Check to see if the infrastructure type is baremetal to adjust script as necessary 
-  if [[ "${baremetalCheck}" == '"BareMetal"' ]]; then
-    log "BareMetal infastructure: setting isBareMetal accordingly"
-    isBareMetal=true
-  else
-    isBareMetal=false
+  nodes=($(oc get nodes -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="" -o custom-columns=name:{.metadata.name} --no-headers))
+  if [[ ${#nodes[@]} -lt 2 ]]; then
+    log "At least 2 worker nodes are required"
+    exit 1
   fi
-
-  #If using baremetal we use different query to find worker nodes
-  if [[ "${isBareMetal}" == "true" ]]; then
-    #Installing python3.8
-    sudo yum -y install python3.8
-
-    nodeCount=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | wc -l)
-    if [[ ${nodeCount} -ge 2 ]]; then
-      serverNumber=$(( $RANDOM %${nodeCount} + 1 ))
-      clientNumber=$(( $RANDOM %${nodeCount} + 1 ))
-      while (( $serverNumber == $clientNumber ))
-        do
-          clientNumber=$(( $RANDOM %${nodeCount} + 1 ))
-        done
-      export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR=='${serverNumber}'{print $1}')
-      export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR=='${clientNumber}'{print $1}')
-    else
-      log "Colocating uperf pods for baremetal, since only one worker node available"
-      export server=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR=='1'{print $1}')
-      export client=$(oc get nodes --no-headers -l node-role.kubernetes.io/worker | awk 'NR=='1'{print $1}')
-    fi  
-    log "Finished assigning server and client nodes"
-    log "Server to be scheduled on node: $server"
-    log "Client to be scheduled on node: $client"
-    # If multi_az we use one node from the two first AZs
-  elif [[ ${platform} == "vsphere" ]]; then
-    nodes=($(oc get nodes -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="" -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}'))
-    if [[ ${#nodes[@]} -lt 2 ]]; then
-      log "At least 2 worker nodes placed are required"
-      exit 1
-    fi
-    export server=${nodes[0]}
-    export client=${nodes[1]}
-  elif [[ ${MULTI_AZ} == "true" ]]; then
-    # Get AZs from worker nodes
-    log "Colocating uperf pods in different AZs"
-    if [[ ${#zones[@]} -gt 1 ]]; then
-      export server=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",topology.kubernetes.io/zone=${zones[0]} -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}' | head -n1)
-      export client=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",topology.kubernetes.io/zone=${zones[1]} -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}' | tail -n1)
-    else
-      log "At least 2 worker nodes placed in different topology zones are required"
-      exit 1
-    fi
-  # If MULTI_AZ is disabled we use the two first nodes from the first AZ
-  else
-    nodes=($(oc get nodes -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!="",node-role.kubernetes.io/infra!="",topology.kubernetes.io/zone=${zones[0]} -o jsonpath='{range .items[*]}{ .metadata.labels.kubernetes\.io/hostname}{"\n"}{end}'))
-    if [[ ${#nodes[@]} -lt 2 ]]; then
-      log "At least 2 worker nodes placed in the topology zone ${zones[0]} are required"
-      exit 1
-    fi
-    log "Colocating uperf pods in the same AZ"
-    export server=${nodes[0]}
-    export client=${nodes[1]}
-  fi
-
 }
 
 deploy_operator() {

--- a/workloads/network-perf/ripsaw-uperf-crd.yaml
+++ b/workloads/network-perf/ripsaw-uperf-crd.yaml
@@ -30,9 +30,6 @@ spec:
         addresspool: "${ADDRESSPOOL}"
         service_etp: "${SERVICE_ETP}" 
       networkpolicy: ${NETWORK_POLICY}
-      pin: true
-      pin_server: "$server"
-      pin_client: "$client"
       multus:
         enabled: false
       samples: ${SAMPLES}

--- a/workloads/network-perf/smoke-crd.yaml
+++ b/workloads/network-perf/smoke-crd.yaml
@@ -20,9 +20,6 @@ spec:
       hostnetwork: ${HOSTNETWORK}
       serviceip: ${SERVICEIP}
       networkpolicy: ${NETWORK_POLICY}
-      pin: true
-      pin_server: "$server"
-      pin_client: "$client"
       multus:
         enabled: false
       samples: ${SAMPLES}


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Once https://github.com/cloud-bulldozer/benchmark-operator/pull/781 lands, we won't need to pin uperf pods anymore.
Also removing the multi_az implementation, this functionality is useless when we have a fresh deployed cluster, since these cluster usually have 3 or 4 machinesets using different AZs each one.

Removing all this stuff helps in simplifying the benchmark implementation quite a bit.
In case we're interested in providing a pin node feature (which is not available in the orig implementation),  it be addressed in a different PR to keep the original purpose of this one
