### PR TITLE
Add OCM server metrics to perf ES

### DIFF
--- a/workloads/api-load/README.md
+++ b/workloads/api-load/README.md
@@ -20,10 +20,13 @@ Workloads can be tweaked with the following environment variables:
 
 | Variable         | Description                         | Default |
 |------------------|-------------------------------------|---------|
+| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16.1/kube-burner-0.16.1-Linux-x86_64.tar.gz` |
 | **OPERATOR_REPO**    | Benchmark-operator repo         | https://github.com/cloud-bulldozer/benchmark-operator.git      |
 | **OPERATOR_BRANCH**  | Benchmark-operator branch       | master  |
 | **ES_SERVER**        | Elasticsearch endpoint          | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|
 | **ES_INDEX**         | Elasticsearch index             | ripsaw-api-load|
+| **PROM_URL**         | OCM server Prometheus endpoint             | https://prometheus.app-sre-stage-01.devshift.net|
+| **PROM_TOKEN**       | OCM server Prometheus token             | |
 | **TEST_TIMEOUT**        | Benchmark timeout, in seconds | 28800 (8 hours) |
 | **JOB_TIMEOUT**        | api-load job timeout, in seconds | 28800 (8 hours) |
 | **TEST_CLEANUP**        | Remove benchmark CR at the end | true |

--- a/workloads/api-load/env.sh
+++ b/workloads/api-load/env.sh
@@ -4,6 +4,11 @@ TEST_CLEANUP=${TEST_CLEANUP:-true}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 export ES_INDEX=ripsaw-api-load
 export ES_SKIP_VERIFY=${ES_SKIP_VERIFY:-true}
+export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16.1/kube-burner-0.16.1-Linux-x86_64.tar.gz}
+
+# OCM server prometheus URL and Token
+export PROM_URL=${PROM_URL:-https://prometheus.app-sre-stage-01.devshift.net}
+export PROM_TOKEN=${PROM_TOKEN}
 
 # ocm-api-load job
 export JOB_TIMEOUT=${JOB_TIMEOUT:-28800}

--- a/workloads/api-load/kube-burner-config.yaml
+++ b/workloads/api-load/kube-burner-config.yaml
@@ -1,0 +1,8 @@
+global:
+  writeToFile: false
+  indexerConfig:
+    enabled: true
+    esServers: [{{.ES_SERVER}}]
+    insecureSkipVerify: true
+    defaultIndex: {{.KUBE_ES_INDEX}}
+    type: elastic

--- a/workloads/api-load/metrics_acct_mgmr.yaml
+++ b/workloads/api-load/metrics_acct_mgmr.yaml
@@ -1,0 +1,405 @@
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: apiOverallRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: apiOverallErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",code!~"2..|404"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: apiOverallErrorsNon404
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: apiOverallErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",code!~"5..|0"}[1m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",code!~"5..|0"}[1m]))'
+  metricName: apiOverallDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/access_review"}[5m]))'
+  metricName: accessReview
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/access_review",code!~"2.."}[5m]))
+  /
+  sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/access_review"}[5m]))'
+  metricName: accessReviewErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/access_review",code=~"5..|0"}[5m]))
+  /
+  sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/access_review"}[5m]))'
+  metricName: accessReviewErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/access_review",code!~"5..|0"}[1m])) /
+  sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/access_review",code!~"5..|0"}[1m]))'
+  metricName: accessReviewDuration
+
+    
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_registrations"}[5m]))'
+  metricName: clusterRegistrationsRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_registrations",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_registrations"}[5m]))'
+  metricName: clusterRegistrationsErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_registrations",code="409"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_registrations"}[5m]))'
+  metricName: clusterRegistrationsErrorsTokenConf
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_registrations",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_registrations"}[5m]))'    
+  metricName: clusterRegistrationsErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_registrations",code!~"5..|0"}[1m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_registrations",code!~"5..|0"}[1m]))'    
+  metricName: clusterRegistrationsDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_authorizations"}[5m]))'
+  metricName: clusterAuthorizationsRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_authorizations",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_authorizations"}[5m]))'
+  metricName: clusterAuthorizationsErrosNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_authorizations",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_authorizations"}[5m]))'
+  metricName: clusterAuthorizationsErros5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_authorizations",code!~"5..|0"}[5m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_authorizations",code!~"5..|0"}[5m]))'
+  metricName: clusterAuthorizationsDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_transfers"}[5m]))'
+  metricName: clusterTransfersRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_transfers",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_transfers"}[5m]))'
+  metricName: clusterTransfersErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_transfers",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_transfers"}[5m]))'
+  metricName: clusterTransfersErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_transfers",code!~"5..|0"}[1m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/cluster_transfers",code!~"5..|0"}[1m]))'
+  metricName: clusterTransfersDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/(access_token|pull_secrets)",method="POST"}[5m]))'
+  metricName: pullSecretsRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/(access_token|pull_secrets)",method="POST",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/(access_token|pull_secrets)",method="POST"}[5m]))'
+  metricName: pullSecretsErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/(access_token|pull_secrets)",method="POST",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/(access_token|pull_secrets)",method="POST"}[5m]))'
+  metricName: pullSecretsErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/(access_token|pull_secrets)",method="POST",code!~"5..|0"}[1m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/(access_token|pull_secrets)",method="POST",code!~"5..|0"}[1m]))'
+  metricName: pullSecretsDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/certificates",method="POST"}[5m]))'
+  metricName: certificatesRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/certificates",method="POST",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/certificates",method="POST"}[5m]))'
+  metricName: certificatesErrosNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/certificates",method="POST",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/certificates",method="POST"}[5m]))'
+  metricName: certificatesErros5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/certificates",method="POST",code!~"5..|0"}[1m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path=~"/api/accounts_mgmt/v1/certificates",method="POST",code!~"5..|0"}[1m]))'
+  metricName: certificatesDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/resource_review"}[5m]))'
+  metricName: resourceReviewRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/resource_review",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/resource_review"}[5m]))'
+  metricName: resourceReviewErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/resource_review",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/resource_review"}[5m]))'
+  metricName: resourceReviewErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/resource_review",code!~"5..|0"}[1m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/authorizations/v1/resource_review",code!~"5..|0"}[1m]))'
+  metricName: resourceReviewDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="GET"}[5m]))'
+  metricName: subscriptionsRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="GET",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="GET"}[5m]))'
+  metricName: subscriptionsErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="GET",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="GET"}[5m]))'
+  metricName: subscriptionsErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="GET",code!~"5..|0"}[1m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="GET",code!~"5..|0"}[1m]))'
+  metricName: subscriptionsDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="GET"}[5m]))'
+  metricName: subscriptionsIDRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="GET",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="GET"}[5m]))'
+  metricName: subscriptionsIDErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="GET",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="GET"}[5m]))'
+  metricName: subscriptionsIDErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="GET",code!~"5..|0"}[1m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="GET",code!~"5..|0"}[1m]))'
+  metricName: subscriptionsIDDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="PATCH"}[5m]))'
+  metricName: subscriptionsUpdateRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="PATCH",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="PATCH"}[5m]))'
+  metricName: subscriptionsUpdateErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="PATCH",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="PATCH"}[5m]))'
+  metricName: subscriptionsUpdateErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="PATCH",code!~"5..|0"}[5m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions/-",method="PATCH",code!~"5..|0"}[5m]))'
+  metricName: subscriptionsUdateDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="POST"}[5m]))'
+  metricName: subscriptionsDisconnRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="POST",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="POST"}[5m]))'
+  metricName: subscriptionsDisconnErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="POST",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="POST"}[5m]))'
+  metricName: subscriptionsDisconnErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="POST",code!~"5..|0"}[5m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/subscriptions",method="POST",code!~"5..|0"}[5m]))'
+  metricName: subscriptionsDisconnDuration
+
+- query: 'sum by (code) (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/token_authorization",method="POST"}[5m]))'
+  metricName: tokenAuthorizationRequests
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/token_authorization",method="POST",code!~"2.."}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/token_authorization",method="POST"}[5m]))'
+  metricName: tokenAuthorizationErrorsNon2xx
+
+- query: 'sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/token_authorization",method="POST",code=~"5..|0"}[5m]))
+/
+sum (rate(api_inbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/token_authorization",method="POST"}[5m]))'
+  metricName: tokenAuthorizationErrors5xx
+
+- query: 'sum (increase(api_inbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/token_authorization",method="POST",code!~"5..|0"}[1m])) /
+sum (increase(api_inbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",path="/api/accounts_mgmt/v1/token_authorization",method="POST",code!~"5..|0"}[1m]))'
+  metricName: tokenAuthorizationDuration
+
+- query: 'sum by (type) (rate(advisory_lock_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: advisoryLockRequests
+
+- query: 'sum (rate(advisory_lock_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics", status="lock error"}[5m]))
+/
+sum (rate(advisory_lock_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: advisoryLockErrorsNon2xx
+
+- query: 'sum (rate(advisory_lock_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics", status="unlock error"}[5m]))
+/
+sum (rate(advisory_lock_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: advisoryLockErrors5xx
+
+- query: 'sum (increase(advisory_lock_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",status="OK"}[1m])) /
+sum (increase(advisory_lock_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",status="OK"}[1m]))'
+  metricName: advisoryLockDuration
+
+- query: 'sum (reg_cred_pool_size{registry="quay.io"}) / scalar(count(count by (pod) (reg_cred_pool_size{registry="quay.io"})))'
+  metricName: RegCredPoolSizeQuay
+
+- query: 'sum (reg_cred_pool_size{registry=~"registry.redhat.io|registry.connect.redhat.com"}) / scalar(count(count by (pod) (reg_cred_pool_size{registry=~"registry.redhat.io|registry.connect.redhat.com"})))'
+  metricName: RegCredPoolSizeRedhat
+
+- query: 'sum by(registry) (reg_cred_pool_size) / scalar(count(count by (pod) (reg_cred_pool_size)))'
+  metricName: RegCredPoolSize
+
+- query: 'sum by (apiservice) (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: DepOverallRequests
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",code!~"2.."}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: DepOverallErrorsNon2xx
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",code=~"5..|0"}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics"}[5m]))'
+  metricName: DepOverallErrors5xx
+
+- query: 'sum (increase(api_outbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",code!~"5..|0"}[1m])) /
+sum (increase(api_outbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",code!~"5..|0"}[1m]))'
+  metricName: DepOverallDuration
+
+- query: 'sum by (code) (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="quay"}[5m]))'
+  metricName: DepQuayRequests
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="quay",code!~"2.."}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="quay"}[5m]))'
+  metricName: DepQuayErrorsNon2xx
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="quay",code=~"5..|0"}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="quay"}[5m]))'
+  metricName: DepQuayErrors5xx
+
+- query: 'sum (increase(api_outbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="quay",code!~"5..|0"}[5m])) /
+sum (increase(api_outbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="quay",code!~"5..|0"}[5m]))'
+  metricName: DepQuayDuration
+
+- query: 'sum by (code) (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit"}[5m]))'
+  metricName: DepRHITRequests
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit",code!~"2.."}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit"}[5m]))'
+  metricName: DepRHITErrorsNon2xx
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit",code=~"5..|0"}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit"}[5m]))'
+  metricName: DepRHITErrors5xx
+
+- query: 'sum (increase(api_outbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit",code!~"5..|0"}[1m])) /
+sum (increase(api_outbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit",code!~"5..|0"}[1m]))'
+  metricName: DepRHITDuration
+
+- query: 'sum by (code) (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit/terms"}[5m]))'
+  metricName: DepTermsConditionsRequests
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit/terms",code!~"2.."}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit/terms"}[5m]))'
+  metricName: DepTermsConditionsErrorsNon2xx
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit/terms",code=~"5..|0"}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit/terms"}[5m]))'
+  metricName: DepTermsConditionsErrors5xx
+
+- query: 'sum (increase(api_outbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit/terms",code!~"5..|0"}[1m])) /
+sum (increase(api_outbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="rhit/terms",code!~"5..|0"}[1m]))'
+  metricName: DepTermsConditionsDuration
+
+- query: 'sum by (code) (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-clusters-service"}[5m]))'
+  metricName: DepClustersServiceRequests
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-clusters-service",code!~"2.."}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-clusters-service"}[5m]))'
+  metricName: DepClustersServiceErrorsNon2xx
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-clusters-service",code=~"5..|0"}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-clusters-service"}[5m]))'
+  metricName: DepClustersServiceErrors5xx
+
+- query: 'sum (increase(api_outbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-clusters-service",code!~"5..|0"}[1m])) /
+sum (increase(api_outbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-clusters-service",code!~"5..|0"}[1m]))'
+  metricName: DepClustersServiceDuration
+
+- query: 'sum by (code) (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-logs-service"}[5m]))'
+  metricName: DepLogsServiceRequests
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-logs-service",code!~"2.."}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-logs-service"}[5m]))'
+  metricName: DepLogsServiceErrorsNon2xx
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-logs-service",code=~"5..|0"}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-logs-service"}[5m]))'
+  metricName: DepLogsServiceErrors5xx
+
+- query: 'sum (increase(api_outbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-logs-service",code!~"5..|0"}[1m])) /
+sum (increase(api_outbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="ocm-logs-service",code!~"5..|0"}[1m]))'
+  metricName: DepLogsServiceDuration
+
+- query: 'sum by (code) (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="pendo"}[5m]))'
+  metricName: DepPendoRequests
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="pendo",code!~"2.."}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="pendo"}[5m]))'
+  metricName: DepPendoErrorsNon2xx
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="pendo",code=~"5..|0"}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="pendo"}[5m]))'
+  metricName: DepPendoErrors5xx
+
+- query: 'sum (increase(api_outbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="pendo",code!~"5..|0"}[1m])) /
+sum (increase(api_outbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="pendo",code!~"5..|0"}[1m]))'
+  metricName: DepPendoDuration
+
+- query: 'sum by (code) (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="candlepin"}[5m]))'
+  metricName: DepCandlepinRequests
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="candlepin",code!~"2.."}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="candlepin"}[5m]))'
+  metricName: DepCandlepinErrorsNon2xx
+
+- query: 'sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="candlepin",code=~"5..|0"}[5m]))
+/
+sum (rate(api_outbound_request_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="candlepin"}[5m]))'
+  metricName: DepCandlepinErrors5xx
+
+- query: 'sum (increase(api_outbound_request_duration_sum{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="candlepin",code!~"5..|0"}[5m])) /
+sum (increase(api_outbound_request_duration_count{namespace="uhc-integration",service="uhc-acct-mngr-metrics",apiservice="candlepin",code!~"5..|0"}[5m]))'
+  metricName: DepCandlepinDuration
+
+- query: '1 - avg(avg_over_time(db_table_size{namespace="uhc-integration",service="uhc-acct-mngr-metrics",type="data",table="whole db"}[24h])) / (100 * 1024)'
+  metricName: DBDiskusageFreeSpace
+
+- query: 'avg(db_table_size{namespace="uhc-integration",service="uhc-acct-mngr-metrics",type="data",table="whole db"})'
+  metricName: DBDiskusageTotalSize
+
+- query: 'db_table_size{namespace="uhc-integration",service="uhc-acct-mngr-metrics",type="data",table!="whole db"}'
+  metricName: DBDiskusageTableSize
+
+- query: 'topk(1, db_table_size{namespace="uhc-integration",service="uhc-acct-mngr-metrics",type="index"}) by (table)'    
+  metricName: DBDiskusageIndexSize

--- a/workloads/api-load/metrics_clusters_service.yaml
+++ b/workloads/api-load/metrics_clusters_service.yaml
@@ -1,0 +1,111 @@
+- query: 'sum(rate(envoy_cluster_upstream_rq_total{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="backend",pod=~"^clusters-service-.*$"}[10m]))'
+  metricName: envoyRequestRateInbound
+
+- query: 'sum(rate(envoy_cluster_upstream_rq_total{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="accounts_mgmt",pod=~"^clusters-service-.*$"}[10m]))'
+  metricName: envoyRequestRateOutboundAcctMgmt
+
+- query: 'sum(rate(envoy_cluster_upstream_rq_total{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="authorizations",pod=~"^clusters-service-.*$"}[10m]))'
+  metricName: envoyRequestRateOutboundAuth
+
+- query: 'sum(rate(envoy_cluster_upstream_rq_total{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="service_logs",pod=~"^clusters-service-.*$"}[10m]))'
+  metricName: envoyRequestRateOutboundServLogs
+
+- query: 'sum(rate(envoy_cluster_upstream_rq_time_sum{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="backend",pod=~"^clusters-service-.*$"}[10m])) /
+  sum(rate(envoy_cluster_upstream_rq_time_count{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="backend",pod=~"^clusters-service-.*$"}[10m]))'
+  metricName: envoyRequestDurationInbound
+
+- query: 'sum(rate(envoy_cluster_upstream_rq_time_sum{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="authorizations",pod=~"^clusters-service-.*$"}[10m])) /
+  sum(rate(envoy_cluster_upstream_rq_time_count{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="authorizations",pod=~"^clusters-service-.*$"}[10m]))'    
+  metricName: envoyRequestDurationOutboundAuth
+
+- query: 'sum(rate(envoy_cluster_upstream_rq_time_sum{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="accounts_mgmt",pod=~"^clusters-service-.*$"}[10m])) /
+  sum(rate(envoy_cluster_upstream_rq_time_count{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="accounts_mgmt",pod=~"^clusters-service-.*$"}[10m]))'    
+  metricName: envoyRequestDurationOutboundAccMgmt
+
+- query: 'sum(rate(envoy_cluster_upstream_rq_time_sum{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="service_logs",pod=~"^clusters-service-.*$"}[10m])) /
+  sum(rate(envoy_cluster_upstream_rq_time_count{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="service_logs",pod=~"^clusters-service-.*$"}[10m]))'    
+  metricName: envoyRequestDurationOutboundServLogs
+
+- query: 'sum(rate(envoy_cluster_upstream_rq{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name="backend",pod=~"^clusters-service-.*$"}[10m])) by (envoy_response_code)'    
+  metricName: envoyInboundCodes
+
+- query: 'sum(rate(envoy_cluster_upstream_rq{namespace="uhc-stage",service="clusters-service-metrics-envoy",envoy_cluster_name=~"^(accounts_mgmt|authorizations|service_logs)$",pod=~"^clusters-service-.*$"}[10m])) by (envoy_response_code)'
+  metricName: envoyOutboundCodes
+
+- query: 'rate(container_cpu_usage_seconds_total{namespace="uhc-stage",pod=~"^clusters-service-.*$",container="envoy",pod=~"^clusters-service-.*$"}[5m]) * 1000'
+  metricName: envoyContainerCpuUsage
+
+- query: 'max(kube_pod_container_resource_limits_cpu_cores{namespace="uhc-stage",pod=~"^clusters-service-.*$",container="envoy"}) * 1000'
+  metricName: envoyContainerCpuCores
+
+- query: 'max(kube_pod_container_resource_requests_cpu_cores{namespace="uhc-stage",pod=~"^clusters-service-.*$",container="envoy"}) * 1000'
+  metricName: envoyContainerCpuRequests
+
+- query: 'container_memory_working_set_bytes{namespace="uhc-stage",pod=~"^clusters-service-.*",container="envoy",pod=~"^clusters-service-.*$"}'
+  metricName: envoyContainerMemory
+
+- query: 'max(kube_pod_container_resource_requests_memory_bytes{namespace="uhc-stage",pod=~"^clusters-service-.*$",container="envoy"})'    
+  metricName: envoyContainerMemoryRequests
+
+- query: 'max(kube_pod_container_resource_limits_memory_bytes{namespace="uhc-stage",pod=~"^clusters-service-.*$",container="envoy"})'    
+  metricName: envoyContainerMemoryLimits
+
+- query: 'sum(rate(container_network_receive_bytes_total{namespace="uhc-stage",pod=~"^clusters-service-.*",interface="eth0"}[10m]))'    
+  metricName: envoyContainerNetworkReceive
+
+- query: 'sum(rate(container_network_transmit_bytes_total{namespace="uhc-stage",pod=~"^clusters-service-.*",interface="eth0"}[10m]))'    
+  metricName: envoyContainerNetworkTransmit
+
+- query: 'sum(rate(api_inbound_request_count{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}[10m]))'
+  metricName: backendInboundRequest
+
+- query: 'sum(rate(api_outbound_request_count{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}[10m]))'
+  metricName: backendOutboundRequest
+
+- query: 'sum(rate(api_inbound_request_duration_sum{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}[10m])) /
+  sum(rate(api_inbound_request_duration_count{namespace="uhc-stage",service=~"clusters-service-metrics",pod=~"^clusters-service-.*$"}[10m]))'
+  metricName: backendInboundRequestDuration
+
+- query: 'sum(rate(api_outbound_request_duration_sum{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}[10m])) /
+  sum(rate(api_outbound_request_duration_count{namespace="uhc-stage",service=~"clusters-service-metrics",pod=~"^clusters-service-.*$"}[10m]))'
+  metricName: backendOutboundRequestDuration
+
+- query: 'sum(rate(api_inbound_request_count{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}[10m])) by (code)'
+  metricName: backendInboundRequestCodes
+
+- query: 'sum(rate(api_outbound_request_count{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}[10m])) by (code)'
+  metricName: backendOutboundRequestCodes
+
+- query: 'process_resident_memory_bytes{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}'
+  metricName: backendMemoryRSS
+
+- query: 'go_memstats_heap_inuse_bytes{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"} +
+  go_memstats_heap_idle_bytes{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}'
+  metricName: backendMemoryHeap
+
+- query: 'go_memstats_heap_inuse_bytes{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}'
+  metricName: backendMemoryHeapInUse
+
+- query: 'max(kube_pod_container_resource_requests_memory_bytes{namespace="uhc-stage",pod=~"^clusters-service-.*$",container="service"})'
+  metricName: backendMemoryRequests
+
+- query: 'max(kube_pod_container_resource_limits_memory_bytes{namespace="uhc-stage",pod=~"^clusters-service-.*$",container="service"})'
+  metricName: backendMemoryLimits
+
+- query: 'rate(process_cpu_seconds_total{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}[5m]) * 1000'
+  metricName: backendCpuUsage
+
+- query: 'max(kube_pod_container_resource_limits_cpu_cores{namespace="uhc-stage",pod=~"^clusters-service-.*$",container="service"}) * 1000'
+  metricName: backendCpuCores
+
+- query: 'max(kube_pod_container_resource_requests_cpu_cores{namespace="uhc-stage",pod=~"^clusters-service-.*$",container="service"}) * 1000'
+  metricName: backendCpuRequests
+
+- query: 'go_goroutines{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}'
+  metricName: backendGoRoutines
+
+- query: 'histogram_quantile(0.9, sum(rate(api_inbound_request_duration_bucket{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}[5m])) by (le))'
+  metricName: p90InboundRequestDuration
+
+- query: 'histogram_quantile(0.9, sum(rate(api_outbound_request_duration_bucket{namespace="uhc-stage",service="clusters-service-metrics",pod=~"^clusters-service-.*$"}[5m])) by (le))'
+  metricName: p90OutboundRequestDuration

--- a/workloads/api-load/run.sh
+++ b/workloads/api-load/run.sh
@@ -10,7 +10,24 @@ log "api-load tests: ${TESTS}"
 log "###############################################"
 
 prepare_tests
+
+start_time=`date +%s`
 run_workload ${CR}
+end_time=`date +%s`
+
+
+curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz
+
+export KUBE_ES_INDEX=ocm-uhc-acct-mngr
+log "Running kube-burner index to scrap metrics from UHC account manager service from ${start_time} to ${end_time} and push to ES"
+./kube-burner index -c kube-burner-config.yaml --uuid=${UUID} -u=${PROM_URL} --job-name ocm-api-load --token=${PROM_TOKEN} -m=metrics_acct_mgmr.yaml --start ${start_time} --end ${end_time}
+log "UHC account manager Metrics stored at elasticsearch server $ES_SERVER on index $KUBE_ES_INDEX with UUID $UUID and jobName: ocm-api-load"
+
+log "Running kube-burner index to scrap metrics from UHC clusters service from ${start_time} to ${end_time} and push to ES"
+export KUBE_ES_INDEX=ocm-uhc-clusters-service
+./kube-burner index -c kube-burner-config.yaml --uuid=${UUID} -u=${PROM_URL} --job-name ocm-api-load --token=${PROM_TOKEN} -m=metrics_clusters_service.yaml --start ${start_time} --end ${end_time}
+log "UHC clusters service metrics stored at elasticsearch server $ES_SERVER on index $KUBE_ES_INDEX with UUID $UUID and jobName: ocm-api-load"
+
 aws iam delete-access-key --user-name OsdCcsAdmin --access-key-id $AWS_ACCESS_KEY || true
 
 log "Finished workload ${0}"


### PR DESCRIPTION
OCM server consists of cluster service and account manager service.
During ocm load testing we monitor metrics from both these services.
In this change, kube-burner pulls metrics from ocm prometheus server
for both the services and index them in perf ES accordingly.

We are using the same prometheus queries which OCM team is using
in their internal grafana dashboards.

Grafana dashboard for clusters service [1] and account manager
service [2] in our perf ES
[1] https://grafana.apps.observability.perfscale.devcluster.openshift.com/d/uhc-clusters-service/uhc-clusters-service?orgId=1&var-datasource=ocm-uhc-clusters-service&var-uuid=a5ed9dce-d7be-40a7-a196-1a5da349dbec&from=1657606690358&to=1657621572537
[2] https://grafana.apps.observability.perfscale.devcluster.openshift.com/d/uhc-account-manager/uhc-account-manager?orgId=1&from=1657607400000&to=1657621800000

ES docs for clusters service [3] and account manager service [4] in
our perf ES
[3] https://perf-results-kibana.apps.observability.perfscale.devcluster.openshift.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2022-07-12T06:30:00.000Z',to:'2022-07-12T11:00:00.000Z'))&_a=(columns:!(),filters:!(),index:'9b6b77e0-fe90-11ec-84f5-13fd83e5c2e7',interval:auto,query:(language:kuery,query:'uuid.keyword%20:%20%22a5ed9dce-d7be-40a7-a196-1a5da349dbec%22%20'),sort:!(!(timestamp,desc)))
[4] https://perf-results-kibana.apps.observability.perfscale.devcluster.openshift.com/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2022-07-12T06:30:00.000Z',to:'2022-07-12T11:00:00.000Z'))&_a=(columns:!(),filters:!(),index:c43ced70-fc60-11ec-b5e5-e5f784bcd40c,interval:auto,query:(language:kuery,query:'uuid.keyword%20:%20%22a5ed9dce-d7be-40a7-a196-1a5da349dbec%22%20'),sort:!(!(timestamp,desc)))

Original internal OCM server grafna dashboards (Maintained by OCM team)
https://grafana.app-sre.devshift.net/d/uhc-account-manager/uhc-account-manager?orgId=1&from=now-30m&to=now&var-datasource=app-sre-stage-01-prometheus&var-namespace=uhc-integration&var-rds_datasource=app-sre-stage-01-prometheus&var-rds_namespace=uhc-acct-mngr-integration&refresh=30s
https://grafana.app-sre.devshift.net/d/uhc-clusters-service/uhc-clusters-service?orgId=1&var-datasource=app-sre-stage-01-prometheus&var-namespace=uhc-stage&var-pod=All
