### PR TITLE
Benchmark-operator v1.0.1

### DIFF
--- a/utils/benchmark-operator.sh
+++ b/utils/benchmark-operator.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-OPERATOR_BRANCH=${OPERATOR_BRANCH:=v1.0.0}
+OPERATOR_BRANCH=${OPERATOR_BRANCH:=v1.0.1}
 OPERATOR_REPO=${OPERATOR_REPO:-https://github.com/cloud-bulldozer/benchmark-operator.git}
 
 install_cli() {


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

We're missing https://github.com/cloud-bulldozer/benchmark-operator/commit/11b3e099f217aa436c89f62ccfceda0462d3de8b in the v1.0.0 tag

### Fixes
