### PR TITLE
Dropping the number of clients in the ingress benchmark

### DIFF
--- a/workloads/router-perf-v2/README.md
+++ b/workloads/router-perf-v2/README.md
@@ -45,11 +45,11 @@ It's possible to tune the default configuration through environment variables. T
 | KUBE_BURNER_RELEASE_URL    | Kube-burner binary URL | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16/kube-burner-0.16-Linux-x86_64.tar.gz` |
 | LARGE_SCALE_THRESHOLD | Number of worker nodes required to consider a large scale scenario | `24` |
 | SMALL_SCALE_ROUTES    | Number of routes of each termination to create in the small scale scenario | `100` |
-| SMALL_SCALE_CLIENTS   | Threads/route to use in the small scale scenario | `1 40 200` |
-| SMALL_SCALE_CLIENTS_MIX | Threads/route to use in the small scale scenario with mix termination | `1 20 80` |
+| SMALL_SCALE_CLIENTS   | Threads/route to use in the small scale scenario | `1 100` |
+| SMALL_SCALE_CLIENTS_MIX | Threads/route to use in the small scale scenario with mix termination | `1 50` |
 | LARGE_SCALE_ROUTES    | Number of routes of each termination to create in the large scale scenario | `500` |
-| LARGE_SCALE_CLIENTS   | Threads/route to use in the large scale scenario | `1 20 80` |
-| LARGE_SCALE_CLIENTS_MIX | Threads/route to use in the large scale scenario with mix termination | `1 10 20` |
+| LARGE_SCALE_CLIENTS   | Threads/route to use in the large scale scenario | `1 20` |
+| LARGE_SCALE_CLIENTS_MIX | Threads/route to use in the large scale scenario with mix termination | `1 10` |
 | DEPLOYMENT_REPLICAS   | Number of pod replicas per deployment | `1` |
 | TLS_REUSE             | Reuse TLS session | `true` |
 | SAMPLES               | Number of samples to perform of each test | `2` |

--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -10,13 +10,13 @@ get_scenario(){
   if [[ ${NUM_NODES} -ge ${LARGE_SCALE_THRESHOLD} ]]; then
     log "Large scale scenario detected: #workers >= ${LARGE_SCALE_THRESHOLD}"
     export NUMBER_OF_ROUTES=${LARGE_SCALE_ROUTES:-500}
-    CLIENTS=${LARGE_SCALE_CLIENTS:-"1 20 80"}
-    CLIENTS_MIX=${LARGE_SCALE_CLIENTS_MIX:-"1 10 20"}
+    CLIENTS=${LARGE_SCALE_CLIENTS:-"1 20"}
+    CLIENTS_MIX=${LARGE_SCALE_CLIENTS_MIX:-"1 10"}
   else
     log "Small scale scenario detected: #workers < ${LARGE_SCALE_THRESHOLD}"
     export NUMBER_OF_ROUTES=${SMALL_SCALE_ROUTES:-100}
-    CLIENTS=${SMALL_SCALE_CLIENTS:-"1 40 200"}
-    CLIENTS_MIX=${SMALL_SCALE_CLIENTS_MIX:-"1 20 80"}
+    CLIENTS=${SMALL_SCALE_CLIENTS:-"1 100"}
+    CLIENTS_MIX=${SMALL_SCALE_CLIENTS_MIX:-"1 50"}
   fi
 }
 


### PR DESCRIPTION
Fixes: https://github.com/cloud-bulldozer/e2e-benchmarking/issues/451

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

We shouldn't use maxConnection=-1, as we always work with OOTB parameters, as the goal of the benchmarks is not reaching the best results, but to detect performance regressions. The parameter maxConnection=-1 is already part of the [ingress-controller tuning guide](https://docs.openshift.com/container-platform/4.11/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress).

Reducing the number of clients to prevent running out of connections, this should help to increase test stability, this parameters is configured OOTB with `maxconn=20000`
Also, reducing the test scope, by removing one of the clients iterations. cc: @qiliRedHat 

---

With this change:

**Large-scale:**
20 clients: 20 x 500 routes x 2 (edge and re-encrypt terminations) => up to 20K connections
mix termination @ 10 clients: 10 x 2000 routes x 1.5 (edge and re-encrypt terminations) =>  up to 30K connections

Preliminary results after a couple of runs in different 4.11 clusters based on OpenShiftSDN are pretty stable _**(max observed deviation was 9.53% )**_

```bash
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
| test_type | routes | conn_per_targetroute | keepalive |          metric          | result | deviation | 7112fc71-router-20220809 | 2ba26d9d-router-20220810 |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
|   http    |  500   |          1           |     0     | avg(requests_per_second) |  Pass  |  -6.87%   |         49891.0          |         46461.5          |
|   http    |  500   |          1           |     1     | avg(requests_per_second) |  Pass  |   9.53%   |         11783.5          |         12906.5          |
|   http    |  500   |          1           |    50     | avg(requests_per_second) |  Pass  |   6.39%   |         54539.0          |         58022.5          |
|   http    |  500   |          20          |     0     | avg(requests_per_second) |  Pass  |  -3.09%   |         86976.0          |         84292.5          |
|   http    |  500   |          20          |     1     | avg(requests_per_second) |  Pass  |  -6.14%   |         22313.5          |         20943.0          |
|   http    |  500   |          20          |    50     | avg(requests_per_second) |  Pass  |  -4.44%   |         83683.5          |         79965.0          |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
| test_type | routes | conn_per_targetroute | keepalive |          metric          | result | deviation | 7112fc71-router-20220809 | 2ba26d9d-router-20220810 |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
|   edge    |  500   |          1           |     0     | avg(requests_per_second) |  Pass  |  -0.55%   |         119625.0         |         118971.0         |
|   edge    |  500   |          1           |     1     | avg(requests_per_second) |  Pass  |   0.28%   |          3711.5          |          3722.0          |
|   edge    |  500   |          1           |    50     | avg(requests_per_second) |  Pass  |   0.98%   |         98786.5          |         99759.5          |
|   edge    |  500   |          20          |     0     | avg(requests_per_second) |  Pass  |   3.29%   |         58950.5          |         60889.0          |
|   edge    |  500   |          20          |     1     | avg(requests_per_second) |  Pass  |   0.01%   |          3599.5          |          3600.0          |
|   edge    |  500   |          20          |    50     | avg(requests_per_second) |  Pass  |   3.29%   |         53534.5          |         55297.0          |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
+-------------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
|  test_type  | routes | conn_per_targetroute | keepalive |          metric          | result | deviation | 7112fc71-router-20220809 | 2ba26d9d-router-20220810 |
+-------------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
| passthrough |  500   |          1           |     0     | avg(requests_per_second) |  Pass  |   0.08%   |         136808.0         |         136920.5         |
| passthrough |  500   |          1           |     1     | avg(requests_per_second) |  Pass  |   0.34%   |          3714.0          |          3726.5          |
| passthrough |  500   |          1           |    50     | avg(requests_per_second) |  Pass  |   0.83%   |         109858.0         |         110773.5         |
| passthrough |  500   |          20          |     0     | avg(requests_per_second) |  Pass  |   1.27%   |         142737.5         |         144544.0         |
| passthrough |  500   |          20          |     1     | avg(requests_per_second) |  Pass  |   0.54%   |          3587.0          |          3606.5          |
| passthrough |  500   |          20          |    50     | avg(requests_per_second) |  Pass  |   1.54%   |         102508.0         |         104091.5         |
+-------------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
| test_type | routes | conn_per_targetroute | keepalive |          metric          | result | deviation | 7112fc71-router-20220809 | 2ba26d9d-router-20220810 |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
| reencrypt |  500   |          1           |     0     | avg(requests_per_second) |  Pass  |   4.23%   |         122159.0         |         127332.0         |
| reencrypt |  500   |          1           |     1     | avg(requests_per_second) |  Pass  |   0.39%   |          3738.5          |          3753.0          |
| reencrypt |  500   |          1           |    50     | avg(requests_per_second) |  Pass  |   3.06%   |         92213.0          |         95030.5          |
| reencrypt |  500   |          20          |     0     | avg(requests_per_second) |  Pass  |   2.08%   |         16137.5          |         16473.5          |
| reencrypt |  500   |          20          |     1     | avg(requests_per_second) |  Pass  |   0.66%   |          3618.0          |          3642.0          |
| reencrypt |  500   |          20          |    50     | avg(requests_per_second) |  Pass  |   2.49%   |         15873.0          |         16269.0          |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
| test_type | routes | conn_per_targetroute | keepalive |          metric          | result | deviation | 7112fc71-router-20220809 | 2ba26d9d-router-20220810 |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
|    mix    |  2000  |          1           |     0     | avg(requests_per_second) |  Pass  |   6.29%   |         164314.5         |         174642.0         |
|    mix    |  2000  |          1           |     1     | avg(requests_per_second) |  Pass  |   2.52%   |         26342.0          |         27006.5          |
|    mix    |  2000  |          1           |    50     | avg(requests_per_second) |  Pass  |   5.82%   |         141775.0         |         150033.0         |
|    mix    |  2000  |          5           |     0     | avg(requests_per_second) |  Pass  |   3.74%   |         65049.5          |         67484.5          |
|    mix    |  2000  |          5           |     1     | avg(requests_per_second) |  Pass  |   3.56%   |         25241.0          |         26139.0          |
|    mix    |  2000  |          5           |    50     | avg(requests_per_second) |  Pass  |   3.90%   |         63860.0          |         66353.5          |
+-----------+--------+----------------------+-----------+--------------------------+--------+-----------+--------------------------+--------------------------+
```

**Small-scale:**
100 clients: 100x100 routes x 2 (edge and re-encrypt terminations) => up to 20K connections 
mix termination @ 50 clients: 25 x 400 routes x 1.5 (edge and re-encrypt terminations) => up to 30K connections


