### PR TITLE
router-perf to exclude non-200 responses for latency 

### DIFF
--- a/workloads/router-perf-v2/workload.py
+++ b/workloads/router-perf-v2/workload.py
@@ -63,7 +63,9 @@ def run_mb(mb_config, runtime, output):
         if hit[2] not in result_codes:
             result_codes[hit[2]] = 0
         result_codes[hit[2]] += 1
-        latency_list.append(int(hit[1]))
+        # Record latency of 'SUCCESS' 200 OK response only
+        if hit[2] == "200":
+            latency_list.append(int(hit[1]))
     if latency_list:
         p95_latency = numpy.percentile(latency_list, 95)
         p99_latency = numpy.percentile(latency_list, 99)


### PR DESCRIPTION
### Description
MB tool is failing to record the right `delay`(latency) for non-200 response and hence affecting the overall P99 and P90 latency value. The more non-200 response the worse P99 latency value(1657660884527 second) due to the issue, this fix will only include 200 response for latency calculation.

This is a temporary work around while we work on the new benchmark-operator.
### Fixes
