### PR TITLE
adding create token instead of new-token

### DIFF
--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -12,7 +12,7 @@ if [[ ${INDEXING} == "false" ]]; then
   unset PROM_URL
 else
   if [[ ${HYPERSHIFT} == "false" ]]; then
-    export PROM_TOKEN=$(oc sa get-token -n openshift-monitoring prometheus-k8s || oc sa new-token -n openshift-monitoring prometheus-k8s || oc create token -n openshift-monitoring  prometheus-k8s)
+    export PROM_TOKEN=$(oc create token -n openshift-monitoring prometheus-k8s || oc sa get-token -n openshift-monitoring prometheus-k8s || oc sa new-token -n openshift-monitoring prometheus-k8s)
   else
     export PROM_TOKEN="dummytokenforthanos"
     export HOSTED_CLUSTER_NAME=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}')
@@ -145,7 +145,7 @@ get_pprof_secrets() {
  oc extract -n openshift-etcd secret/$certkey
  export CERTIFICATE=`base64 -w0 tls.crt`
  export PRIVATE_KEY=`base64 -w0 tls.key`
- export BEARER_TOKEN=$(oc sa get-token kube-burner -n benchmark-operator || oc sa new-token -n benchmark-operator kube-burner)
+ export BEARER_TOKEN=$(oc create token -n benchmark-operator kube-burner || oc sa get-token kube-burner -n benchmark-operator)
 }
 
 delete_pprof_secrets() {


### PR DESCRIPTION
### Description
New-token is not going to be in the next release. Create should work for all versions


### Fixes
`
08-16 12:46:44.231  Command "get-token" is deprecated, and will be removed in the future version. Use oc create token instead.
08-16 12:46:44.529  error: could not find a service account token for service account "prometheus-k8s"
08-16 12:46:45.133  Command "new-token" is deprecated, and will be removed in the future version. Use oc create token instead.
`