### PR TITLE
Prometheus sizing ocp 1.12 fixes

### DIFF
--- a/workloads/prometheus-sizing/README.md
+++ b/workloads/prometheus-sizing/README.md
@@ -21,6 +21,7 @@ These environment variables can be customized in both scenarios
 | **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
 | **ES_SERVER**        | ElasticSearch endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|
 | **ES_INDEX**         | ElasticSearch index            | ripsaw-kube-burner |
+| **WRITE_TO_FILE**    | Whether to dump collected metrics to files in ./collected-metrics | false |
 
 ## Static scenario
 

--- a/workloads/prometheus-sizing/README.md
+++ b/workloads/prometheus-sizing/README.md
@@ -22,6 +22,7 @@ These environment variables can be customized in both scenarios
 | **ES_SERVER**        | ElasticSearch endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|
 | **ES_INDEX**         | ElasticSearch index            | ripsaw-kube-burner |
 | **WRITE_TO_FILE**    | Whether to dump collected metrics to files in ./collected-metrics | false |
+| **METRICS**          | Metrics profile file | metrics.yaml |
 
 ## Static scenario
 

--- a/workloads/prometheus-sizing/common.sh
+++ b/workloads/prometheus-sizing/common.sh
@@ -5,7 +5,7 @@ openshift_login
 
 export UUID=${UUID:-$(uuidgen)}
 export PROM_URL=https://$(oc get route -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")
-export PROM_TOKEN=$(oc whoami -t)
+export PROM_TOKEN=$(oc create token -n openshift-monitoring prometheus-k8s || oc sa get-token -n openshift-monitoring prometheus-k8s || oc sa new-token -n openshift-monitoring prometheus-k8s)
 
 log(){
   echo -e "\033[1m$(date -u) ${@}\033[0m"

--- a/workloads/prometheus-sizing/common.sh
+++ b/workloads/prometheus-sizing/common.sh
@@ -43,6 +43,6 @@ run_test(){
   ./kube-burner init -c ${1} --uuid=${UUID} -u=${PROM_URL} --token=${PROM_TOKEN} -m=metrics.yaml
   if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then
     log "Cleaning up benchmark stuff"
-    kube-burner destroy -u ${UUID}
+    kube-burner destroy --uuid ${UUID}
   fi
 }

--- a/workloads/prometheus-sizing/common.sh
+++ b/workloads/prometheus-sizing/common.sh
@@ -37,10 +37,10 @@ get_pods_per_namespace(){
 
 # Receives the kube-burner configuration file as parameter
 run_test(){
-  log "Running kube-burner using config ${1}"
+  log "Running kube-burner using config ${1} and metrics ${METRICS}"
   export POD_REPLICAS
   curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz
-  ./kube-burner init -c ${1} --uuid=${UUID} -u=${PROM_URL} --token=${PROM_TOKEN} -m=metrics.yaml
+  ./kube-burner init -c ${1} --uuid=${UUID} -u=${PROM_URL} --token=${PROM_TOKEN} -m="${METRICS}"
   if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then
     log "Cleaning up benchmark stuff"
     kube-burner destroy --uuid ${UUID}

--- a/workloads/prometheus-sizing/common.sh
+++ b/workloads/prometheus-sizing/common.sh
@@ -5,7 +5,7 @@ openshift_login
 
 export UUID=${UUID:-$(uuidgen)}
 export PROM_URL=https://$(oc get route -n openshift-monitoring prometheus-k8s -o jsonpath="{.spec.host}")
-export PROM_TOKEN=$(oc -n openshift-monitoring sa get-token prometheus-k8s)
+export PROM_TOKEN=$(oc whoami -t)
 
 log(){
   echo -e "\033[1m$(date -u) ${@}\033[0m"

--- a/workloads/prometheus-sizing/env.sh
+++ b/workloads/prometheus-sizing/env.sh
@@ -7,6 +7,7 @@ export ENABLE_INDEXING=${ENABLE_INDEXING:-true}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
 export WRITE_TO_FILE=${WRITE_TO_FILE:-false}
+export METRICS=${METRICS:-metrics.yaml}
 
 # prometheus-sizing-static specific
 export JOB_PAUSE=${JOB_PAUSE:-125m}

--- a/workloads/prometheus-sizing/env.sh
+++ b/workloads/prometheus-sizing/env.sh
@@ -6,6 +6,7 @@ export CLEANUP_WHEN_FINISH=${CLEANUP_WHEN_FINISH:-true}
 export ENABLE_INDEXING=${ENABLE_INDEXING:-true}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}
 export ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
+export WRITE_TO_FILE=${WRITE_TO_FILE:-false}
 
 # prometheus-sizing-static specific
 export JOB_PAUSE=${JOB_PAUSE:-125m}

--- a/workloads/prometheus-sizing/prometheus-sizing-churning.yml
+++ b/workloads/prometheus-sizing/prometheus-sizing-churning.yml
@@ -1,6 +1,6 @@
 ---
 global:
-  writeToFile: false
+  writeToFile: {{ .WRITE_TO_FILE }}
   indexerConfig:
     enabled: {{ .ENABLE_INDEXING }}
     esServers: [{{ .ES_SERVER }}]

--- a/workloads/prometheus-sizing/prometheus-sizing-static.yml
+++ b/workloads/prometheus-sizing/prometheus-sizing-static.yml
@@ -1,6 +1,6 @@
 ---
 global:
-  writeToFile: false
+  writeToFile: {{ .WRITE_TO_FILE }}
   indexerConfig:
     enabled: {{ .ENABLE_INDEXING }}
     esServers: [{{.ES_SERVER}}]

--- a/workloads/prometheus-sizing/templates/pod.yml
+++ b/workloads/prometheus-sizing/templates/pod.yml
@@ -21,5 +21,6 @@ spec:
         drop:
           - ALL
       runAsNonRoot: true
+      runAsUser: 1001
       seccompProfile:
         type: RuntimeDefault

--- a/workloads/prometheus-sizing/templates/pod.yml
+++ b/workloads/prometheus-sizing/templates/pod.yml
@@ -16,3 +16,10 @@ spec:
     imagePullPolicy: IfNotPresent
     securityContext:
       privileged: false
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault


### PR DESCRIPTION
### Description

Some fixes and additional configuration to run the prometheus-sizing workload on OCP 4.12 and OpenShift local 4.10.18.  
I can split this PR in pieces if you think it's best

### Fixes

- Correctly specify benchmark id for kube-burner destroy
- Adapt retrieval of auth token for Prometheus API for OCP 4.11 and later
- Update pod template security context
- Add options
   - to dump collected metrics to `./collected-metric`
   - to specify a different metrics file