### PR TITLE
PSA fixes

### DIFF
--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -26,7 +26,7 @@ export PRELOAD_IMAGES=${PRELOAD_IMAGES:-true}
 export PRELOAD_PERIOD=${PRELOAD_PERIOD:-2m}
 
 # Kube-burner job
-export KUBE_BURNER_IMAGE=${KUBE_BURNER_IMAGE:-quay.io/cloud-bulldozer/kube-burner:v0.16}
+export KUBE_BURNER_IMAGE=${KUBE_BURNER_IMAGE:-quay.io/cloud-bulldozer/kube-burner:v0.16.2}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-14400}
 export LOG_STREAMING=${LOG_STREAMING:-true}

--- a/workloads/kube-burner/workloads/cluster-density/cluster-density.yml
+++ b/workloads/kube-burner/workloads/cluster-density/cluster-density.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: imagestream.yml

--- a/workloads/kube-burner/workloads/concurrent-builds/concurrent-builds.yml
+++ b/workloads/kube-burner/workloads/concurrent-builds/concurrent-builds.yml
@@ -68,6 +68,11 @@ jobs:
     verifyObjects: ${VERIFY_OBJECTS}
     errorOnVerify: ${ERROR_ON_VERIFY}
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
       - objectTemplate: imagestream.yml
         replicas: 1

--- a/workloads/kube-burner/workloads/managed-services/cluster-density.yml
+++ b/workloads/kube-burner/workloads/managed-services/cluster-density.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: imagestream.yml

--- a/workloads/kube-burner/workloads/max-namespaces/max-namespaces.yml
+++ b/workloads/kube-burner/workloads/max-namespaces/max-namespaces.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: postgres-deployment.yml

--- a/workloads/kube-burner/workloads/max-services/max-services.yml
+++ b/workloads/kube-burner/workloads/max-services/max-services.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
       - objectTemplate: deployment.yml
         replicas: 1

--- a/workloads/kube-burner/workloads/networkpolicy/case2.yml
+++ b/workloads/kube-burner/workloads/networkpolicy/case2.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
       - objectTemplate: deny-all.yml
         replicas: 1

--- a/workloads/kube-burner/workloads/networkpolicy/case3.yml
+++ b/workloads/kube-burner/workloads/networkpolicy/case3.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
       - objectTemplate: deny-all.yml
         replicas: 1

--- a/workloads/kube-burner/workloads/node-density-cni-networkpolicy/node-density-cni-networkpolicy.yml
+++ b/workloads/kube-burner/workloads/node-density-cni-networkpolicy/node-density-cni-networkpolicy.yml
@@ -82,6 +82,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: webserver-deployment.yml

--- a/workloads/kube-burner/workloads/node-density-cni/node-density-cni.yml
+++ b/workloads/kube-burner/workloads/node-density-cni/node-density-cni.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: webserver-deployment.yml

--- a/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: postgres-deployment.yml

--- a/workloads/kube-burner/workloads/node-pod-density/node-pod-density.yml
+++ b/workloads/kube-burner/workloads/node-pod-density/node-pod-density.yml
@@ -71,6 +71,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: pod.yml

--- a/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
+++ b/workloads/kube-burner/workloads/pod-density-heavy/pod-density-heavy.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: pod.yml

--- a/workloads/kube-burner/workloads/pods-service-route/pods-service-route.yml
+++ b/workloads/kube-burner/workloads/pods-service-route/pods-service-route.yml
@@ -70,6 +70,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: webserver-deployment.yml
@@ -99,6 +104,11 @@ jobs:
     maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
     preLoadImages: ${PRELOAD_IMAGES}
     preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
 
       - objectTemplate: curl-deployment.yml

--- a/workloads/prometheus-sizing/prometheus-sizing-churning.yml
+++ b/workloads/prometheus-sizing/prometheus-sizing-churning.yml
@@ -17,6 +17,11 @@ jobs:
     qps: {{ .QPS }}
     burst: {{ .BURST }}
     jobPause: {{ .POD_CHURNING_PERIOD }}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
       - objectTemplate: templates/pod.yml
         replicas: {{ .PODS_PER_NS }}
@@ -38,6 +43,11 @@ jobs:
     qps: {{ $.QPS }}
     burst: {{ $.BURST }}
     jobPause: {{ $.POD_CHURNING_PERIOD }}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
       - objectTemplate: templates/pod.yml
         replicas: {{ $.PODS_PER_NS }}

--- a/workloads/prometheus-sizing/prometheus-sizing-static.yml
+++ b/workloads/prometheus-sizing/prometheus-sizing-static.yml
@@ -17,6 +17,11 @@ jobs:
     namespace: prometheus-sizing-static
     waitWhenFinished: true
     jobPause: {{ .JOB_PAUSE }}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
     objects:
       - objectTemplate: templates/pod.yml
         replicas: {{ .POD_REPLICAS }}

--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -10,7 +10,7 @@ export ES_INDEX=${ES_INDEX:-router-test-results}
 NUM_NODES=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/workload!=,node-role.kubernetes.io/infra!= --no-headers | grep -cw Ready)
 LARGE_SCALE_THRESHOLD=${LARGE_SCALE_THRESHOLD:-24}
 METADATA_COLLECTION=${METADATA_COLLECTION:-true}
-KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16/kube-burner-0.16-Linux-x86_64.tar.gz}
+KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16.2/kube-burner-0.16.2-Linux-x86_64.tar.gz}
 KUBE_BURNER_IMAGE=quay.io/cloud-bulldozer/kube-burner:latest
 #HAPROXY_IMAGE="quay.io/cloud-bulldozer/openshift-router-perfscale:-haproxy-v2.2.20"
 #INGRESS_OPERATOR_IMAGE="quay.io/cloud-bulldozer/openshift-cluster-ingress-operator:balance-random"

--- a/workloads/router-perf-v2/http-perf.yml
+++ b/workloads/router-perf-v2/http-perf.yml
@@ -9,6 +9,11 @@ jobs:
   namespace: http-scale-http
   cleanup: true
   waitWhenFinished: true
+  namespaceLabels:
+    security.openshift.io/scc.podSecurityLabelSync: false
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   objects:
     - objectTemplate: templates/nginx-deploy.yml
       replicas: {{ .NUMBER_OF_ROUTES }}
@@ -34,6 +39,11 @@ jobs:
   namespace: http-scale-edge
   cleanup: true
   waitWhenFinished: true
+  namespaceLabels:
+    security.openshift.io/scc.podSecurityLabelSync: false
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   objects:
     - objectTemplate: templates/nginx-deploy.yml
       replicas: {{ .NUMBER_OF_ROUTES }}
@@ -59,6 +69,11 @@ jobs:
   namespace: http-scale-passthrough
   cleanup: true
   waitWhenFinished: true
+  namespaceLabels:
+    security.openshift.io/scc.podSecurityLabelSync: false
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   objects:
     - objectTemplate: templates/nginx-deploy.yml
       replicas: {{ .NUMBER_OF_ROUTES }}
@@ -84,6 +99,11 @@ jobs:
   namespace: http-scale-reencrypt
   cleanup: true
   waitWhenFinished: true
+  namespaceLabels:
+    security.openshift.io/scc.podSecurityLabelSync: false
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   objects:
     - objectTemplate: templates/nginx-deploy.yml
       replicas: {{ .NUMBER_OF_ROUTES }}
@@ -106,6 +126,11 @@ jobs:
   namespacedIterations: false
   cleanup: true
   waitWhenFinished: true
+  namespaceLabels:
+    security.openshift.io/scc.podSecurityLabelSync: false
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   objects:
     - objectTemplate: templates/http-client-rolebinding.yml
       replicas: 1


### PR DESCRIPTION
### Description

It's required to add these labels to the namespaces created by kube-burner since PSA is rejecting our pods as of OCP 4.12.

Fixes: https://github.com/cloud-bulldozer/e2e-benchmarking/issues/436



Signed-off-by: Raul Sevilla <rsevilla@redhat.com>
