### PR TITLE
Remove 4 pairs scenario

### DIFF
--- a/workloads/network-perf/README.md
+++ b/workloads/network-perf/README.md
@@ -34,7 +34,7 @@ The run.sh script can be tweaked with the following environment variables
 | **ADDRESSPOOL**         | To provide MetalLB addresspool for a service, this will be used as LoadBalancer network. Mentioned addresspool should be pre-provisioned before execution of this script. | addresspool-l2 |
 | **SERVICE_ETP**         | To mention the type of `ExternalTrafficPolicy` of a service, supported option `Cluster` or `Local` | Cluster |
 | **SAMPLES**             | How many times to run the tests | 3 |
-| **PAIRS**               | List with the number of pairs the test will be triggered (hostnet variant is executed w/ 1 pair only) | 1 2 4 |
+| **PAIRS**               | List with the number of pairs the test will be triggered (hostnet variant is executed w/ 1 pair only) | 1 2 |
 | **TEST_TIMEOUT**        | Benchmark timeout, in seconds | 7200 (2 hours) |
 | **TEST_CLEANUP**        | Remove benchmark CR at the end | true |
 

--- a/workloads/network-perf/env.sh
+++ b/workloads/network-perf/env.sh
@@ -20,7 +20,7 @@ export ADDRESSPOOL=${ADDRESSPOOL:-addresspool-l2}
 export SERVICE_ETP=${SERVICE_ETP:-Cluster}
 export TEST_TIMEOUT=${TEST_TIMEOUT:-7200}
 export SAMPLES=${SAMPLES:-3}
-export PAIRS=${PAIRS:-1 2 4}
+export PAIRS=${PAIRS:-1 2}
 
 # Comparison and csv generation
 


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

Stop running this test with 4 pairs, it doesn't add any value to the results in our current scenarios, as we're already using the full bandwidth of the instance with 2 pairs. As shown in the picture below

![image](https://user-images.githubusercontent.com/4614641/187928004-9a30ef26-81de-4bf7-9c30-de35db4e082a.png)

The the graph above, 4 pairs have similar throughput compared to 2 pairs. Apart from this, using more than 1 pair is only required to observe how 2 different process (uperf) behave at the time of sharing the network link

i.e
2 pairs 1024B: 4870 x 2 = 9740
4 pairs 1024B: 2460 x 4 = 9840




