### PR TITLE
Adjust fsync wal alerting

### DIFF
--- a/workloads/kube-burner/alerts-profiles/cluster-density-Azure.yml
+++ b/workloads/kube-burner/alerts-profiles/cluster-density-Azure.yml
@@ -5,7 +5,7 @@
   severity: error
 
 - expr: avg_over_time(histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))[5m:]) > 0.09
-  description: 5 minutes avg. 99th etcd commit latency on {{$labels.pod}} higher than 900ms. {{$value}}s
+  description: 5 minutes avg. 99th etcd commit latency on {{$labels.pod}} higher than 90ms. {{$value}}s
   severity: error
 
 - expr: rate(etcd_server_leader_changes_seen_total[2m]) > 0

--- a/workloads/kube-burner/alerts-profiles/cluster-density.yml
+++ b/workloads/kube-burner/alerts-profiles/cluster-density.yml
@@ -1,11 +1,11 @@
 # etcd
 
-- expr: avg_over_time(histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))[5m:]) > 0.01
-  description: 5 minutes avg. 99th etcd fsync latency on {{$labels.pod}} higher than 10ms. {{$value}}s
+- expr: avg_over_time(histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[2m]))[5m:]) > 0.02
+  description: 5 minutes avg. 99th etcd fsync latency on {{$labels.pod}} higher than 20ms. {{$value}}s
   severity: error
 
 - expr: avg_over_time(histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[2m]))[5m:]) > 0.03
-  description: 5 minutes avg. 99th etcd commit latency on {{$labels.pod}} higher than 300ms. {{$value}}s
+  description: 5 minutes avg. 99th etcd commit latency on {{$labels.pod}} higher than 30ms. {{$value}}s
   severity: error
 
 - expr: rate(etcd_server_leader_changes_seen_total[2m]) > 0


### PR DESCRIPTION
### Description

We regularly see etcd disk wal fsync times between 10-20 ms without any visible detriment. To help avoid failures due to this aggressive time I'd like to move it up to 20ms.

### Fixes

Fixes mistype in description of backed commit duration