### PR TITLE
Fix image versions instead of latest

### DIFF
--- a/workloads/kube-burner/workloads/node-density-heavy/app-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/app-deployment.yml
@@ -11,8 +11,8 @@ spec:
       nodeSelector: {{.nodeSelector}}
       containers:
       - name: perfapp
-        image: quay.io/rsevilla/perfapp:latest
-        imagePullPolicy: Always
+        image: quay.io/rsevilla/perfapp@sha256:02848a9c90dd4e345eac4f1dffbf10eab19859612113a427b3e9fa6490fb8c08
+        imagePullPolicy: IfNotPresent
         readinessProbe:
           httpGet:
             path: /ready

--- a/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
@@ -11,7 +11,7 @@ spec:
       nodeSelector: {{.nodeSelector}}
       containers:
       - name: postgresql
-        image: registry.redhat.io/rhel8/postgresql-10:latest
+        image: registry.redhat.io/rhel8/postgresql-10@sha256:4b912c80085b88a03309aeb7907efcc29dd3342fa3952b6ea067afb1914bfe53
         ports:
         - containerPort: 5432
           protocol: TCP


### PR DESCRIPTION
### Description
Replacing use of ":latest" in node-density-heavy with direct image hash.

### Fixes...
... pods that have ContainerCreateError due to `pull QPS exceeded`.