### PR TITLE
Add case 1 network policy workload

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -15,6 +15,7 @@ In order to kick off one of these benchmarks you must use the run.sh script. The
 - **`custom`**: `WORKLOAD=custom ./run.sh`
 - **`concurrent-builds`**: `WORKLOAD=concurrent-builds ./run.sh`
 - **`cluster-density-ms`**: `WORKLOAD=cluster-density-ms ./run.sh`
+- **`networkpolicy-case1`**: `WORKLOAD=networkpolicy-case1 ./run.sh`
 - **`networkpolicy-case2`**: `WORKLOAD=networkpolicy-case2 ./run.sh`
 - **`networkpolicy-case3`**: `WORKLOAD=networkpolicy-case3 ./run.sh`
 

--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -98,6 +98,12 @@ case ${WORKLOAD} in
     METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/hypershift-metrics.yaml}
     export TEST_JOB_ITERATIONS=${JOB_ITERATIONS:-75}
   ;; 
+  networkpolicy-case1)
+    WORKLOAD_TEMPLATE=workloads/networkpolicy/case1.yml
+    METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/metrics-ovn.yaml}
+    export TEST_JOB_ITERATIONS=${JOB_ITERATIONS:-500}
+    prep_networkpolicy_workload
+  ;;
   networkpolicy-case2)
     WORKLOAD_TEMPLATE=workloads/networkpolicy/case2.yml
     METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/metrics-ovn.yaml}

--- a/workloads/kube-burner/workloads/networkpolicy/README.md
+++ b/workloads/kube-burner/workloads/networkpolicy/README.md
@@ -12,6 +12,13 @@ The environmental variables and steps to kick off this test can be found [here](
 A networkpolicy can come in various shapes and sizes. Allow traffic from a specific namespace, Deny traffic from a specific pod IP, Deny all traffic, ...
 Hence we have come up with a few test cases which try to cover most of them. They are as follows.
 
+### Case 1
+
+- 500 namespaces
+- 20 pods in each namespace. Each pod acts as a server and a client
+- Default deny networkpolicy is applied first that blocks traffic to any test namespace
+- 3 network policies in each namespace that allows traffic from the same namespace and two other namespaces using namespace selectors
+
 ### Case 2
 
 - 5 namespaces

--- a/workloads/kube-burner/workloads/networkpolicy/case1-networkpolicy.yml
+++ b/workloads/kube-burner/workloads/networkpolicy/case1-networkpolicy.yml
@@ -1,0 +1,42 @@
+{{- /* We use the replica number as a 0 based offset from the     }}
+{{-    current namespace to a target namespace traffic is allowed }}
+{{-    from. We also document the corresponding namespace traffic }}
+{{-    is allowed to from this namespace as an un-enforced egress }}
+{{-    rule.                                                      }}
+{{-    Examples for 4 total namespaces/iterations:                }}
+{{-    * current ns 2, replica 1, from ns 2, to ns 2              }}
+{{-    * current ns 2, replica 2, from ns 3, to ns 1              }}
+{{-    * current ns 2, replica 3, from ns 4, to ns 4              }}
+{{-    * current ns 2, replica 4, from ns 1, to ns 3            */}}
+{{- $v := sub .Replica 1 }}
+{{- $v = mod $v .job_iterations }}
+{{- $from := add .Iteration $v }}
+{{- if gt $from .job_iterations }}
+{{- $from = mod $from .job_iterations }}
+{{- end }}
+{{- $to := sub .Iteration $v }}
+{{- if lt $to 1 }}
+{{- $to = add .job_iterations $to }}
+{{- end }}
+{{- $from_namespace := print .UUID "-" $from }}
+{{- $to_namespace := print .UUID "-" $to }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: case1-allow-from-{{$from_namespace}}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{$from_namespace}}
+  # non enforcing egress, but provided as information to pod_scraper
+  # to know which namespaces it is allowed to connect
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{$to_namespace}}

--- a/workloads/kube-burner/workloads/networkpolicy/case1.yml
+++ b/workloads/kube-burner/workloads/networkpolicy/case1.yml
@@ -1,0 +1,96 @@
+---
+global:
+  writeToFile: false
+  indexerConfig:
+    enabled: ${INDEXING}
+    esServers: ["${ES_SERVER}"]
+    insecureSkipVerify: true
+    defaultIndex: ${ES_INDEX}
+    type: elastic
+  measurements:
+    - name: podLatency
+      esIndex: ${ES_INDEX}
+{{ if eq .PPROF_COLLECTION "True" }}
+    - name: pprof
+      pprofInterval: {{ .PPROF_COLLECTION_INTERVAL }}
+      pprofDirectory: /tmp/pprof-data
+      pprofTargets:
+
+      - name: kube-apiserver-cpu
+        namespace: "openshift-kube-apiserver"
+        labelSelector: {app: openshift-kube-apiserver}
+        bearerToken: {{ .BEARER_TOKEN }}
+        url: https://localhost:6443/debug/pprof/profile?timeout=30
+
+      - name: kube-apiserver-heap
+        namespace: "openshift-kube-apiserver"
+        labelSelector: {app: openshift-kube-apiserver}
+        bearerToken: {{ .BEARER_TOKEN }}
+        url: https://localhost:6443/debug/pprof/heap
+
+      - name: kube-controller-manager-heap
+        namespace: "openshift-kube-controller-manager"
+        labelSelector: {app: kube-controller-manager}
+        bearerToken: {{ .BEARER_TOKEN }}
+        url: https://localhost:10257/debug/pprof/heap
+
+      - name: kube-controller-manager-cpu
+        namespace: "openshift-kube-controller-manager"
+        labelSelector: {app: kube-controller-manager}
+        bearerToken: {{ .BEARER_TOKEN }}
+        url: https://localhost:10257/debug/pprof/profile?timeout=30
+
+      - name: etcd-heap
+        namespace: "openshift-etcd"
+        labelSelector: {app: etcd}
+        cert: {{ .CERTIFICATE }}
+        key: {{ .PRIVATE_KEY }}
+        url: https://localhost:2379/debug/pprof/heap
+
+      - name: etcd-cpu
+        namespace: "openshift-etcd"
+        labelSelector: {app: etcd}
+        cert: {{ .CERTIFICATE }}
+        key: {{ .PRIVATE_KEY }}
+        url: https://localhost:2379/debug/pprof/profile?timeout=30
+{{ end }}
+jobs:
+  - name: networkpolicy-case1
+    jobIterations: ${TEST_JOB_ITERATIONS}
+    qps: ${QPS}
+    burst: ${BURST}
+    namespacedIterations: true
+    namespace: ${UUID}
+    podWait: ${POD_WAIT}
+    cleanup: ${CLEANUP}
+    waitFor: ${WAIT_FOR}
+    waitWhenFinished: ${WAIT_WHEN_FINISHED}
+    verifyObjects: ${VERIFY_OBJECTS}
+    errorOnVerify: ${ERROR_ON_VERIFY}
+    maxWaitTimeout: ${MAX_WAIT_TIMEOUT}
+    preLoadImages: ${PRELOAD_IMAGES}
+    preLoadPeriod: ${PRELOAD_PERIOD}
+    namespaceLabels:
+      security.openshift.io/scc.podSecurityLabelSync: false
+      pod-security.kubernetes.io/enforce: privileged
+      pod-security.kubernetes.io/audit: privileged
+      pod-security.kubernetes.io/warn: privileged
+    objects:
+      - objectTemplate: deny-all.yml
+        replicas: 1
+
+      - objectTemplate: case1-networkpolicy.yml
+        replicas: 3
+        inputVars:
+          job_iterations: ${TEST_JOB_ITERATIONS}
+      
+      - objectTemplate: nginx.yml
+        replicas: 20
+        inputVars:
+          nodeSelector: "${POD_NODE_SELECTOR}"
+          label1: "unused"
+          label2: "unused"
+          workload: ${WORKLOAD}
+          es_server: ${ES_SERVER}
+          es_index: ${ES_INDEX_NETPOL}
+          set: "1"

--- a/workloads/kube-burner/workloads/networkpolicy/deny-all.yml
+++ b/workloads/kube-burner/workloads/networkpolicy/deny-all.yml
@@ -5,3 +5,5 @@ metadata:
 spec:
   podSelector: {}
   ingress: []
+  policyTypes:
+  - Ingress


### PR DESCRIPTION
Scenario as per README using [NetworkPolicy test cases](https://docs.google.com/document/d/1OQtOXtqqHzV79vJ04r3z1icv5b-9y5AtWGrEgUMnvEg) as reference

Some caveats:
* Since there does not seem to be away to have a different number of replicas in each namespace, used an average of 20 replicas per namespace
* The case uses un-enforced egress rules to provide some information to the pod scraper, unfortunately in OVN there is a bug that causes the selected pods to be isolated for egress even if the policy type is not set to egress. Fixed being worked on here: https://github.com/ovn-org/ovn-kubernetes/pull/3162


Signed-off-by: Jaime Caamaño Ruiz <jcaamano@redhat.com>
