### PR TITLE
Node density heavy updates

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -96,11 +96,11 @@ These workloads create different objects each:
 Each iteration of this workload creates the following object:
   - 1 pod. (sleep)
 
-- **node-density-heavy**. Creates a **single namespace with a number of applications proportional to the calculated number of pods / 2**. This application consists on two deployments (a postgresql database and a simple client that generates some CPU load) and a service that is used by the client to reach the database.
+- **node-density-heavy**. Creates a **single namespace with a number of pods equals to the calculated number of pods**. This application consists on two deployments (a postgresql database and a simple client that generates some CPU load) and a service that is used by the client to reach the database.
 Each iteration of this workload can be broken down in:
-  - 1 deployment holding a postgresql database
-  - 1 deployment holding a client application for the previous database
-  - 1 service pointing to the postgresl database
+  - 1 deployment of a postgresql database
+  - 2 service pointing to the postgresl database
+  - 4 deployments with client application for the previous database using one of the previous services. Each one of these pods have readiness and liveness probes
 
 - **node-density-cni**. Creates a **single namespace with a number of applications equals to job_iterations**. This application consists on two deployments (a node.js webserver and a simple client that curls the webserver) and a service that is used by the client to reach the webserver.
 Each iteration of this workload creates the following objects:

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -116,7 +116,7 @@ find_running_pods_num() {
   fi
   log "Number of pods to deploy on nodes: ${total_pod_count}"
   if [[ ${1} == "heavy" ]] || [[ ${1} == *cni* ]]; then
-    total_pod_count=$((total_pod_count / 2))
+    total_pod_count=$((total_pod_count / 5))
   fi
   export TEST_JOB_ITERATIONS=${total_pod_count}
 }

--- a/workloads/kube-burner/workloads/node-density-heavy/app-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/app-deployment.yml
@@ -44,7 +44,7 @@ spec:
         - name: POSTGRESQL_DATABASE
           value: node-density
         - name: POSTGRESQL_HOSTNAME
-          value: postgres-{{.Iteration}}
+          value: postgres-{{randInt 1 3}}-{{.Iteration}}
         - name: POSTGRESQL_PORT
           value: '5432'
         - name: POSTGRESQL_RETRY_INTERVAL

--- a/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
@@ -87,7 +87,6 @@ jobs:
         inputVars:
           readinessPeriod: 10
           livenessPeriod: 10
-          postgresPrefix: second
           nodeSelector: "${POD_NODE_SELECTOR}"
 
       - objectTemplate: postgres-service.yml

--- a/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
@@ -83,11 +83,12 @@ jobs:
           nodeSelector: "${POD_NODE_SELECTOR}"
 
       - objectTemplate: app-deployment.yml
-        replicas: 1
+        replicas: 4
         inputVars:
           readinessPeriod: 10
           livenessPeriod: 10
+          postgresPrefix: second
           nodeSelector: "${POD_NODE_SELECTOR}"
 
       - objectTemplate: postgres-service.yml
-        replicas: 1
+        replicas: 2

--- a/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
@@ -1,12 +1,12 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: postgres-{{.Replica}}-{{.Iteration}}
+  name: postgres-{{.Iteration}}
 spec:
   template:
     metadata:
       labels:
-        name: postgres-{{.Replica}}-{{.Iteration}}
+        name: postgres-{{.Iteration}}
     spec:
       nodeSelector: {{.nodeSelector}}
       containers:
@@ -33,7 +33,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: postgres-{{.Replica}}-{{.Iteration}}
+      name: postgres-{{.Iteration}}
   triggers:
   - type: ConfigChange
   strategy:

--- a/workloads/kube-burner/workloads/node-density-heavy/postgres-service.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/postgres-service.yml
@@ -2,10 +2,10 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: postgres-{{.Iteration}}
+  name: postgres-{{.Replica}}-{{.Iteration}}
 spec:
   selector:
-    name: postgres-{{.Replica}}-{{.Iteration}}
+    name: postgres-{{.Iteration}}
   ports:
   - protocol: TCP
     port: 5432


### PR DESCRIPTION
### Description

Let's try to make node-density-heavy great again. The main problem of this benchmark is that it can be "too heavy" depending on how the pods are scheduled. In the previous implementation we've seen several posgres databases being scheduled to a certain node in a short period of time. That generated a very high CPU load in the node, leading to huge increases in the time taken by the workload.

The problem with the previous is that results were not very deterministic, since the test duration was very volatile.

This PR reduces the number of postgres databses deployed and increases the number of client applications. Now every 2 pair of clients will connect to the same database randomly using one of the two created services in each job iteration. 

After executing this test several times in a baremetal based environment with 26 worker nodes, I've verified that results are more stable and reliable:

(UUIDs from today 14th of Sept)
- 8c5f3552-b0be-4b21-af09-bb242f79c9b6
- fae1097f-ee69-4f03-bf38-02d33e0a1480
- 3d181ece-f13a-4889-87b9-8c531e65c7c0

All the tests above were executed in ~600secs and podLatency was quite stable as well, < 3mins in all cases

I think it would be useful to have more results from other platforms, if possible, to ensure the test is stable enough

