### PR TITLE
unlabel node only on cleanup

### DIFF
--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -152,12 +152,12 @@ if [[ ${WORKLOAD} == "concurrent-builds" ]]; then
 else
   run_workload kube-burner-crd.yaml
 fi
-if [[ ${WORKLOAD} == node-density* ]]; then
-  unlabel_nodes_with_label $label
-fi
 
 if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then
   cleanup
+  if [[ ${WORKLOAD} == node-density* ]]; then
+    unlabel_nodes_with_label $label
+  fi
 fi
 delete_pprof_secrets
 if [[ ${ENABLE_SNAPPY_BACKUP} == "true" ]] ; then


### PR DESCRIPTION
### Description
Node unlabel only when cleanup is set, this let us use node-density to pre-load cluster before [migration](https://github.com/cloud-bulldozer/e2e-benchmarking/pull/477) or upgrade.
 
### Fixes
