### PR TITLE
adding set -e to kube-burner's run.sh

### DIFF
--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/bash
 
+set -e
+
 . common.sh
 . build_helper.sh
 


### PR DESCRIPTION
Errors are being obfuscated. Forcing them to bubble up.