### PR TITLE
Migrate churn function to native kube-bruner functionality

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -192,7 +192,7 @@ Each iteration creates the following objects:
 
 ### Churn
 
-Churning a workload allows you to scale down and then up a percentage of **JOB_ITERATIONS** after the objects have been created. It takes in a percentage, **CHURN_PERCENT**, which is the percentage of JOB_ITERATIONS it churns during each cycle. It will delete and recreate **ALL** the objects specified in the job definition. After each churn cycle it will sleep for the **CHURN_DELAT**. This loop continues until the **CHURN_DURATION** has elapsed.
+Churning a workload allows you to scale down and then up a percentage of **JOB_ITERATIONS** after the objects have been created. It takes in a percentage, **CHURN_PERCENT**, which is the percentage of JOB_ITERATIONS it churns during each cycle. It will delete and recreate **ALL** the objects specified in the job definition. After each churn cycle it will sleep for the **CHURN_DELAY**. This loop continues until the **CHURN_DURATION** has elapsed.
 
 To churn 20% of your **JOB_ITERATIONS** every 30 seconds for a total duration (the calculated time from when the first churn begins + the **CHURN_DURATION**) of 60 minutes you would utilize these variables:
 

--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -60,11 +60,10 @@ Workloads can be tweaked with the following environment variables:
 | **GSHEET_KEY_LOCATION**        | Location of service account key to generate google sheets |  |
 | **EMAIL_ID_FOR_RESULTS_SHEET**        | Email id where the google sheets needs to be sent |  |
 | **GEN_CSV**             | Generate a benchmark-comparison csv, required to generate the spreadsheet | "false" |
-| **CHURN**             | Enable "churning" of the workload after the benchmark completes | "false" |
-| **CHURN_DURATION**             | Time, in minutes, to churn for | 10 |
-| **CHURN_WAIT**             | Time, in seconds, to wait between each churn | 60 |
+| **CHURN**             | Enable "churning" of the workload after the objects are created | "false" |
+| **CHURN_DURATION**             | Time, in time type (ex: 1h10m11s), to churn for | 10m |
+| **CHURN_DELAY**             | Time, in time type (ex: 1m30s), to wait between each churn | 60s |
 | **CHURN_PERCENT**             | Percentage of JOB_ITERATIONS that we should churn each round | 10 |
-| **CHURN_TYPE**             | Type of object to churn. pod or namespace. Namespace will delete/recreate everything in the namespace | pod |
 
 **Note**: You can use basic authentication for ES indexing using the notation `http(s)://[username]:[password]@[host]:[port]` in **ES_SERVER**.
 
@@ -193,17 +192,16 @@ Each iteration creates the following objects:
 
 ### Churn
 
-Churning a workload allows you to scale down and then up a percentage of pods or namespaces **AFTER** the workload has run, but before cleanup (if enabled). It takes in a percentage, **CHURN_PERCENT**, which is the percentage of JOB_ITERATIONS it churns during each churn cycle. If the **pod** CHURN_TYPE is used then it will delete and recreate all the pods in a namespace. If the **namespace** CHURN_TYPE is used then it will delete and recreate **ALL** the resources in the namespace. After each churn cycle it will sleep for the remainder of **CHURN_WAIT** seconds if the time it took to churn was less than the **CHURN_WAIT** otherwise it continues immediately. This loop continues until the **CHURN_DURATION** has elapsed.
+Churning a workload allows you to scale down and then up a percentage of **JOB_ITERATIONS** after the objects have been created. It takes in a percentage, **CHURN_PERCENT**, which is the percentage of JOB_ITERATIONS it churns during each cycle. It will delete and recreate **ALL** the objects specified in the job definition. After each churn cycle it will sleep for the **CHURN_DELAT**. This loop continues until the **CHURN_DURATION** has elapsed.
 
-To churn 20% of your **JOB_ITERATIONS** using the namespace method every 30 seconds for a total duration (the calculated time from when the first churn begins + the **CHURN_DURATION**) of 60 minutes you would utilize these variables:
+To churn 20% of your **JOB_ITERATIONS** every 30 seconds for a total duration (the calculated time from when the first churn begins + the **CHURN_DURATION**) of 60 minutes you would utilize these variables:
 
 - **CHURN**=true
-- **CHURN_DURATION**=60
-- **CHURN_PERCENT**=75
-- **CHURN_WAIT**=30
-- **CHURN_TYPE**=namespace
+- **CHURN_DURATION**=60m
+- **CHURN_PERCENT**=20
+- **CHURN_DELAY**=30s
 
-**NOTE: The churn functionality is only designed to work with current cluster-density type tests**
+**NOTE: The churn functionality is only implemented for namespacedIteration creation jobs (ex: cluster-density)**
 
 ### Snappy integration configurations
 

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -35,6 +35,12 @@ export METRICS_PROFILE=${METRICS_PROFILE}
 # kube-burner workload defaults
 export NODE_POD_DENSITY_IMAGE=${NODE_POD_DENSITY_IMAGE:-gcr.io/google_containers/pause:3.1}
 
+# kube-burner churn enablement
+export CHURN=${CHURN:-false}
+export CHURN_DURATION=${CHURN_DURATION:-10m}
+export CHURN_DELAY=${CHURN_DELAY:-60s}
+export CHURN_PERCENT=${CHURN_PERCENT:-10}
+
 # Misc
 export CLEANUP_WHEN_FINISH=${CLEANUP_WHEN_FINISH:-false}
 export CLEANUP_TIMEOUT=${CLEANUP_TIMEOUT:-30m}
@@ -71,13 +77,6 @@ export POD_READY_THRESHOLD=${POD_READY_THRESHOLD:-5000ms}
 
 # Alerting
 export PLATFORM_ALERTS=${PLATFORM_ALERTS:-false}
-
-# Churn
-export CHURN=${CHURN:-false}
-export CHURN_DURATION=${CHURN_DURATION:-10}
-export CHURN_WAIT=${CHURN_WAIT:-30}
-export CHURN_PERCENT=${CHURN_PERCENT:-10}
-export CHURN_TYPE=${CHURN_TYPE:-pod}
 
 # Output and Comparisons
 export COMPARISON_CONFIG=${COMPARISON_CONFIG:-""}

--- a/workloads/kube-burner/workloads/cluster-density/cluster-density.yml
+++ b/workloads/kube-burner/workloads/cluster-density/cluster-density.yml
@@ -69,6 +69,10 @@ jobs:
     maxWaitTimeout: {{.MAX_WAIT_TIMEOUT}}
     preLoadImages: {{.PRELOAD_IMAGES}}
     preLoadPeriod: {{.PRELOAD_PERIOD}}
+    churn: {{.CHURN}}
+    churnDuration: {{.CHURN_DURATION}}
+    churnPercent: {{.CHURN_PERCENT}}
+    churnDelay: {{.CHURN_DELAY}}
     namespaceLabels:
       security.openshift.io/scc.podSecurityLabelSync: false
       pod-security.kubernetes.io/enforce: privileged

--- a/workloads/kube-burner/workloads/managed-services/cluster-density.yml
+++ b/workloads/kube-burner/workloads/managed-services/cluster-density.yml
@@ -2,10 +2,10 @@
 global:
   writeToFile: false
   indexerConfig:
-    enabled: {{.INDEXING}
+    enabled: {{.INDEXING}}
     esServers: ["{{.ES_SERVER}}"]
     insecureSkipVerify: true
-    defaultIndex: {{.ES_INDEX}
+    defaultIndex: {{.ES_INDEX}}
     type: elastic
   measurements:
     - name: podLatency
@@ -70,6 +70,10 @@ jobs:
     maxWaitTimeout: {{.MAX_WAIT_TIMEOUT}}
     preLoadImages: {{.PRELOAD_IMAGES}}
     preLoadPeriod: {{.PRELOAD_PERIOD}}
+    churn: {{.CHURN}}
+    churnDuration: {{.CHURN_DURATION}}
+    churnPercent: {{.CHURN_PERCENT}}
+    churnDelay: {{.CHURN_DELAY}}
     namespaceLabels:
       security.openshift.io/scc.podSecurityLabelSync: false
       pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
### Description

The churn functionality has been added to kube-burner. This PR moves to using that native functionality instead of what is coded in e2e. This gives us the benefit of gathering the metrics from during the churn cycles as well as simplifying the e2e code base.

### Fixes
