### PR TITLE
adding pod effect lower case

### DIFF
--- a/workloads/kube-burner/workloads/node-pod-density/pod.yml
+++ b/workloads/kube-burner/workloads/node-pod-density/pod.yml
@@ -9,7 +9,7 @@ spec:
   tolerations:
   - key: os
     value: Windows
-    Effect: NoSchedule
+    effect: NoSchedule
   containers:
   - name: node-density
     image: {{.containerImage}}


### PR DESCRIPTION
### Description
Need lower case effect to no get error defined in issue 


```
10-04 15:56:45.891  ###############################################
10-04 15:56:45.891  Workload: node-density
10-04 15:56:45.891  Workload template: workloads/node-pod-density/node-pod-density.yml
10-04 15:56:45.891  Metrics profile: metrics-profiles/metrics.yaml
10-04 15:56:45.891  Alerts profile: 
10-04 15:56:45.891  QPS: 20
10-04 15:56:45.891  Burst: 20
10-04 15:56:45.891  UUID: 60d12be0-2cd4-4270-9ca1-a620371f81e5
10-04 15:56:45.891  Node count: 3
10-04 15:56:45.891  Pods per node: 200
10-04 15:56:45.891  ###############################################
10-04 15:56:46.150  [1mTue Oct  4 19:56:46 UTC 2022 Indexing enabled, using metrics from metrics-profiles/metrics.yaml[0m
10-04 15:56:46.151  ~/ws/workspace/aige-e2e-multibranch_kube-burner/workloads/kube-burner/workloads/node-pod-density ~/ws/workspace/aige-e2e-multibranch_kube-burner/workloads/kube-burner
10-04 15:56:46.151  time="2022-10-04 19:56:46" level=info msg="🔥 Starting kube-burner (0.17.0@3115dcfee072a253b2255bdf585b4dafbc4f2dc2) with UUID 60d12be0-2cd4-4270-9ca1-a620371f81e5"
10-04 15:56:46.409  time="2022-10-04 19:56:46" level=info msg="👽 Initializing prometheus client"
10-04 15:56:47.342  time="2022-10-04 19:56:47" level=info msg="📁 Creating indexer: elastic"
10-04 15:56:47.912  time="2022-10-04 19:56:47" level=info msg="📈 Creating measurement factory"
10-04 15:56:47.912  time="2022-10-04 19:56:47" level=info msg="Registered measurement: podLatency"
10-04 15:56:47.912  time="2022-10-04 19:56:47" level=info msg="Preparing create job: node-density"
10-04 15:56:47.912  time="2022-10-04 19:56:47" level=info msg="Job node-density: 229 iterations with 1 Pod replicas"
10-04 15:56:47.912  time="2022-10-04 19:56:47" level=info msg="Pre-load: images from job node-density"
10-04 15:56:47.912  time="2022-10-04 19:56:47" level=info msg="Pre-load: Creating DaemonSet using image gcr.io/google_containers/pause:3.1 in namespace preload-kube-burner"
10-04 15:56:47.912  time="2022-10-04 19:56:47" level=info msg="Pre-load: Sleeping for 2m0s"
10-04 15:58:54.369  time="2022-10-04 19:58:47" level=info msg="Pre-load: Deleting namespace preload-kube-burner"
10-04 15:58:54.369  time="2022-10-04 19:58:47" level=info msg="Deleting namespaces with label kube-burner-preload=true"
10-04 15:58:54.369  time="2022-10-04 19:58:47" level=info msg="Waiting for namespaces to be definitely deleted"
10-04 15:59:00.928  time="2022-10-04 19:58:59" level=info msg="Triggering job: node-density"
10-04 15:59:00.928  time="2022-10-04 19:58:59" level=info msg="Creating Pod latency watcher for node-density"
10-04 15:59:00.928  time="2022-10-04 19:59:00" level=info msg="QPS: 20"
10-04 15:59:00.928  time="2022-10-04 19:59:00" level=info msg="Burst: 20"
10-04 15:59:00.928  time="2022-10-04 19:59:00" level=info msg="Running job node-density"
10-04 15:59:13.126  time="2022-10-04 19:59:11" level=info msg="Waiting up to 1h0m0s for actions to be completed"
10-04 15:59:23.099  time="2022-10-04 19:59:21" level=info msg="Actions in namespace 60d12be0-2cd4-4270-9ca1-a620371f81e5 completed"
10-04 15:59:23.099  time="2022-10-04 19:59:21" level=info msg="Finished the create job in 22 seconds"
10-04 15:59:23.099  time="2022-10-04 19:59:21" level=info msg="Verifying created objects"
10-04 15:59:23.099  time="2022-10-04 19:59:22" level=info msg="pods found: 229 Expected: 229"
10-04 15:59:23.099  time="2022-10-04 19:59:22" level=info msg="Stopping measurement: podLatency"
10-04 15:59:23.099  time="2022-10-04 19:59:22" level=info msg="Evaluating latency thresholds"
10-04 15:59:23.099  time="2022-10-04 19:59:22" level=error msg="❗ P99 Ready latency (13.64s) higher than configured threshold: 5s"
10-04 15:59:28.370  time="2022-10-04 19:59:27" level=info msg="node-density: PodScheduled 50th: 7 99th: 25 max: 31 avg: 9"
10-04 15:59:28.370  time="2022-10-04 19:59:27" level=info msg="node-density: ContainersReady 50th: 8033 99th: 13640 max: 14874 avg: 8083"
10-04 15:59:28.370  time="2022-10-04 19:59:27" level=info msg="node-density: Initialized 50th: 46 99th: 189 max: 338 avg: 60"
10-04 15:59:28.370  time="2022-10-04 19:59:27" level=info msg="node-density: Ready 50th: 8033 99th: 13640 max: 14874 avg: 8083"
10-04 15:59:28.370  time="2022-10-04 19:59:27" level=info msg="Job node-density took 28.06 seconds"
10-04 15:59:28.370  time="2022-10-04 19:59:27" level=info msg="Indexing metadata information for job: node-density"
10-04 15:59:28.370  time="2022-10-04 19:59:28" level=info msg="Waiting 30s extra before scraping prometheus"
```

### Fixes
https://github.com/cloud-bulldozer/e2e-benchmarking/issues/483