### PR TITLE
Checks to see if compare files don't exist

### DIFF
--- a/utils/compare.sh
+++ b/utils/compare.sh
@@ -59,8 +59,7 @@ run_benchmark_comparison() {
         log "python csv modifier"
         python $(dirname $(realpath ${BASH_SOURCE[0]}))/csv_modifier.py -c ${COMPARISON_OUTPUT} -o ${final_csv}
      done
-     if [[ -n ${GSHEET_KEY_LOCATION} ]] && [[ -n ${COMPARISON_OUTPUT} ]]; then
-       echo "sheet $GSHEET_KEY_LOCATION "
+     if [[ -n ${GSHEET_KEY_LOCATION} ]] && [[ ${GEN_CSV} == true ]] ; then
        gen_spreadsheet ${WORKLOAD} ${final_csv} ${EMAIL_ID_FOR_RESULTS_SHEET} ${GSHEET_KEY_LOCATION}
      fi
      log "Removing touchstone"

--- a/utils/csv_gen.py
+++ b/utils/csv_gen.py
@@ -3,7 +3,7 @@
 import argparse
 from oauth2client.service_account import ServiceAccountCredentials
 import gspread
-
+import os
 
 def push_to_gsheet(sheetname, csv_file_name, google_svc_acc_key, email_id):
     scope = [
@@ -16,6 +16,9 @@ def push_to_gsheet(sheetname, csv_file_name, google_svc_acc_key, email_id):
     sh.share(email_id, perm_type="user", role="writer")
     spreadsheet_id = sh.id
     spreadsheet_url = f"https://docs.google.com/spreadsheets/d/{sh.id}"
+    if not os.path.exists(csv_file_name):
+      print(f"CSV File doesn't exist {csv_file_name}")
+      return 
     with open(csv_file_name, "r") as f:
         gc.import_csv(spreadsheet_id, f.read())
     worksheet = sh.get_worksheet(0)

--- a/utils/csv_modifier.py
+++ b/utils/csv_modifier.py
@@ -31,7 +31,16 @@ def get_args() -> argparse.Namespace:
 
 
 def read_csv(filepath: str) -> pd.DataFrame:
-    df = pd.read_csv(filepath)
+    if os.path.exists(filepath):
+        try: 
+            df = pd.read_csv(filepath)
+            return df
+        except Exception as e: 
+            print(f"Error reading csv file {filepath} : {e}")
+            df = pd.DataFrame()
+    else: 
+        # set empty data frame
+        df = pd.DataFrame()
     return df
 
 
@@ -53,21 +62,22 @@ def main():
     output_filepath = args.output
     for csv_filepath in args.csv_list:
         df = read_csv(csv_filepath)
-        num_rows = len(df.index)
-        num_columns = len(df.columns)
-        if num_rows > 0:
-            select_columns = -1
-            if "ES_SERVER_BASELINE" in os.environ and "BASELINE_UUID" in os.environ:
-                select_columns = -2
-            if ("SORT_BY_VALUE" in os.environ) and (os.getenv("SORT_BY_VALUE") == "true"):
-                df.sort_values(df.columns[-1], ascending=False, inplace=True)
-            df[df.columns[select_columns:num_columns]] = df[
-                df.columns[select_columns:num_columns]
-            ].apply(divide_col)
-            output_filepath = output_filepath or f"{df.columns[-1]}.csv"
-        write_df(
-            df.head(int(os.environ.get("NUM_LINES", num_rows))), output_filepath, mode
-        )
+        if not df.empty: 
+            num_rows = len(df.index)
+            num_columns = len(df.columns)
+            if num_rows > 0:
+                select_columns = -1
+                if "ES_SERVER_BASELINE" in os.environ and "BASELINE_UUID" in os.environ:
+                    select_columns = -2
+                if ("SORT_BY_VALUE" in os.environ) and (os.getenv("SORT_BY_VALUE") == "true"):
+                    df.sort_values(df.columns[-1], ascending=False, inplace=True)
+                df[df.columns[select_columns:num_columns]] = df[
+                    df.columns[select_columns:num_columns]
+                ].apply(divide_col)
+                output_filepath = output_filepath or f"{df.columns[-1]}.csv"
+            write_df(
+                df.head(int(os.environ.get("NUM_LINES", num_rows))), output_filepath, mode
+            )
 
 
 main()


### PR DESCRIPTION
### Description
Since I am setting the location of COMPARISON_OUTPUT by default this [line](https://github.com/cloud-bulldozer/e2e-benchmarking/blob/6e6dc1c895cba6cd42459ef28a99d05e5ba37219/utils/compare.sh#L62) no longer properly performs a check. Changing to be GEN_CSV 

Also adding in additional checks in the python scripts to validate csv files exist 

### Fixes
Files in comparison not existing and causing errors

```
10-06 13:23:49.917  [1mThu Oct  6 17:23:49 UTC 2022 python csv modifier[0m
10-06 13:23:50.479  Traceback (most recent call last):
10-06 13:23:50.479    File "/home/jenkins/ws/workspace/ltibranch-pipeline_kube-burner_5/utils/csv_modifier.py", line 73, in <module>
10-06 13:23:50.479      main()
10-06 13:23:50.479    File "/home/jenkins/ws/workspace/ltibranch-pipeline_kube-burner_5/utils/csv_modifier.py", line 55, in main
10-06 13:23:50.479      df = read_csv(csv_filepath)
10-06 13:23:50.479    File "/home/jenkins/ws/workspace/ltibranch-pipeline_kube-burner_5/utils/csv_modifier.py", line 34, in read_csv
10-06 13:23:50.479      df = pd.read_csv(filepath)
10-06 13:23:50.479    File "/tmp/tmp.pwcyhKRkZQ/lib/python3.9/site-packages/pandas/util/_decorators.py", line 211, in wrapper
10-06 13:23:50.479      return func(*args, **kwargs)
10-06 13:23:50.479    File "/tmp/tmp.pwcyhKRkZQ/lib/python3.9/site-packages/pandas/util/_decorators.py", line 317, in wrapper
10-06 13:23:50.479      return func(*args, **kwargs)
10-06 13:23:50.479    File "/tmp/tmp.pwcyhKRkZQ/lib/python3.9/site-packages/pandas/io/parsers/readers.py", line 950, in read_csv
10-06 13:23:50.479      return _read(filepath_or_buffer, kwds)
10-06 13:23:50.479    File "/tmp/tmp.pwcyhKRkZQ/lib/python3.9/site-packages/pandas/io/parsers/readers.py", line 605, in _read
10-06 13:23:50.479      parser = TextFileReader(filepath_or_buffer, **kwds)
10-06 13:23:50.479    File "/tmp/tmp.pwcyhKRkZQ/lib/python3.9/site-packages/pandas/io/parsers/readers.py", line 1442, in __init__
10-06 13:23:50.479      self._engine = self._make_engine(f, self.engine)
10-06 13:23:50.479    File "/tmp/tmp.pwcyhKRkZQ/lib/python3.9/site-packages/pandas/io/parsers/readers.py", line 1729, in _make_engine
10-06 13:23:50.479      self.handles = get_handle(
10-06 13:23:50.479    File "/tmp/tmp.pwcyhKRkZQ/lib/python3.9/site-packages/pandas/io/common.py", line 857, in get_handle
10-06 13:23:50.479      handle = open(
10-06 13:23:50.479  FileNotFoundError: [Errno 2] No such file or directory: '/home/jenkins/ws/workspace/ltibranch-pipeline_kube-burner_5/workloads/kube-burner/cluster-density-*****.csv'
```
