### PR TITLE
New configs to support OCP-40557 polarion test case to replace loaded workers

### DIFF
--- a/utils/touchstone-configs/nodeAggWorkers.json
+++ b/utils/touchstone-configs/nodeAggWorkers.json
@@ -1,0 +1,33 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner": [
+        {
+          "filter": {
+            "metricName.keyword": "nodeCPU-AggregatedWorkers"
+          },
+          "buckets": [
+            "labels.mode.keyword"
+          ],
+          "aggregations": {
+            "value": [
+              "avg",
+              "max"
+            ]
+          }
+        },
+        {
+          "filter": {
+            "metricName.keyword": "nodeMemoryAvailable-AggregatedWorkers"
+          },
+          "buckets": [
+            "jobName.keyword"
+          ],
+          "aggregations": {
+            "value": [
+              "avg"
+            ]
+          }
+        }
+    ]
+  }
+}

--- a/utils/touchstone-configs/nodeMasters-max.json
+++ b/utils/touchstone-configs/nodeMasters-max.json
@@ -1,0 +1,33 @@
+{
+  "elasticsearch": {
+    "ripsaw-kube-burner": [
+        {
+          "filter": {
+            "metricName.keyword": "nodeCPU-Masters"
+          },
+          "buckets": [
+            "labels.mode.keyword",
+            "labels.instance.keyword"
+          ],
+          "aggregations": {
+            "value": [
+              "max"
+            ]
+          }
+        },
+        {
+          "filter": {
+            "metricName.keyword": "nodeMemoryUtilization-Masters"
+          },
+          "buckets": [
+            "labels.instance.keyword"
+          ],
+          "aggregations": {
+            "value": [
+              "max"
+            ]
+          }
+        }
+    ]
+  }
+}


### PR DESCRIPTION
### Description
### Fixes

Changes to generate google sheets to support automated testing of:
https://issues.redhat.com/browse/OCPQE-11961 - OCP-40557 - Replace loaded worker nodes with larger instances
https://issues.redhat.com/browse/OCPQE-12152 - Extend automation for "OCP-40557 - Replace loaded worker nodes with larger instances" to other providers.

Passing Jenkins Runs:
https://mastern-jenkins-csb-openshift-qe.apps.ocp-c1.prod.psi.redhat.com/job/scale-ci/job/svetsa-e2e-benchmarking-multibranch-pipeline/job/regression-test/8/console
File generated: 
https://docs.google.com/spreadsheets/d/1jrnS05dd2p3WM63TIOXNYqW0KDWXoboSewYa3_hffXk/edit#gid=1321307691



