### PR TITLE
Modify router tests to work with HyperShift

### DIFF
--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -33,6 +33,7 @@ export KUBERNETES_VERSION=${KUBERNETES_MAJOR_VERSION}.${KUBERNETES_MINOR_VERSION
 export CLUSTER_NETWORK_TYPE=$(oc get network.config/cluster -o jsonpath='{.spec.networkType}')
 export NETWORK_TYPE=$CLUSTER_NETWORK_TYPE
 export PLATFORM_STATUS=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus}')
+export HYPERSHIFT_MANAGEMENT_KUBECONFIG=""
 
 # Benchmark configuration
 RUNTIME=${RUNTIME:-60}

--- a/workloads/router-perf-v2/ingress-performance.sh
+++ b/workloads/router-perf-v2/ingress-performance.sh
@@ -12,6 +12,7 @@ log "Service type: ${SERVICE_TYPE}"
 log "Terminations: ${TERMINATIONS}"
 log "Deployment replicas: ${DEPLOYMENT_REPLICAS}"
 log "###############################################"
+check_hypershift
 deploy_infra
 tune_workload_node apply
 client_pod=$(oc get pod -l app=http-scale-client -n http-scale-client | awk '/Running/{print $1}')


### PR DESCRIPTION
Fixes: https://github.com/cloud-bulldozer/e2e-benchmarking/issues/487
Signed-off-by: Sai Sindhur Malleni <smalleni@redhat.com>

### Description
This modifies the router tests to work with HyperShift Hosted Clusters since some of the control plane components (openshift-ingress-operator/openshift-cluster-version-operator) do not exist on the hsoted cluster and instead exist on a management cluster.
### Fixes
