### PR TITLE
NetObserv touchstone config update

### DIFF
--- a/utils/touchstone-configs/netobserv_touchstone.json
+++ b/utils/touchstone-configs/netobserv_touchstone.json
@@ -8,7 +8,10 @@
                     "cache_max_flows",
                     "flp_kind",
                     "release",
-                    "sampling"
+                    "sampling",
+                    "aws_s3_bucket_name",
+                    "aws_s3_bucket_objects",
+                    "aws_s3_bucket_size"
                 ],
                 "additional_fields": [
                     "metric_name"
@@ -96,7 +99,7 @@
                 ],
                 "aggregations": {
                     "value": [
-                        "max"
+                        "avg"
                     ]
                 }
             },
@@ -155,6 +158,58 @@
             {
                 "filter": {
                     "metric_name.keyword": "ebpfMemoryUsageWorkingSet"
+                },
+                "buckets": [
+                    "metadata.pod.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "ebpfCpuUsage"
+                },
+                "buckets": [
+                    "metadata.pod.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "kafkaStorageUsage"
+                },
+                "buckets": [
+                    "metadata.persistentvolumeclaim.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "max"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "cpuUsageLoki"
+                },
+                "buckets": [
+                    "metadata.pod.keyword"
+                ],
+                "aggregations": {
+                    "value": [
+                        "avg"
+                    ]
+                }
+            },
+            {
+                "filter": {
+                    "metric_name.keyword": "memoryUsageLoki"
                 },
                 "buckets": [
                     "metadata.pod.keyword"


### PR DESCRIPTION

### Description
updating for metrics added in [PR # 308](https://github.com/openshift-qe/ocp-qe-perfscale-ci/pull/308) and aws s3 storage metric.
