### PR TITLE
Conc builds update to use python3 

### DIFF
--- a/workloads/kube-burner/build_helper.sh
+++ b/workloads/kube-burner/build_helper.sh
@@ -25,15 +25,16 @@ function prepare_builds_file()
 function install_svt_repo() {
   rm -rf svt
   git clone --single-branch --branch ${build_test_branch} ${build_test_repo} --depth 1
+  pip3 install future pytimeparse
 }
 
 function run_builds() {
+  
   for i in "${build_array[@]}"
   do
     log "running $i $1 concurrent builds"
     fileName="conc_builds_$1.out"
-    pip install future pytimeparse
-    python svt/openshift_performance/ose3_perf/scripts/build_test.py -z -a -n 2 -r $i -f running-builds.json >> $fileName 2>&1
+    python3 svt/openshift_performance/ose3_perf/scripts/build_test.py -z -a -n 2 -r $i -f running-builds.json >> $fileName 2>&1
     sleep 10
   done
 }

--- a/workloads/kube-burner/build_helper.sh
+++ b/workloads/kube-burner/build_helper.sh
@@ -25,12 +25,6 @@ function prepare_builds_file()
 function install_svt_repo() {
   rm -rf svt
   git clone --single-branch --branch ${build_test_branch} ${build_test_repo} --depth 1
-  curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-  python2 --version
-
-  python2 get-pip.py
-  python2 -m pip install futures pytimeparse logging
-  python2 -m pip install futures pytimeparse logging
 }
 
 function run_builds() {
@@ -38,7 +32,8 @@ function run_builds() {
   do
     log "running $i $1 concurrent builds"
     fileName="conc_builds_$1.out"
-    python2 svt/openshift_performance/ose3_perf/scripts/build_test.py -z -a -n 2 -r $i -f running-builds.json >> $fileName 2>&1
+    pip install future pytimeparse
+    python svt/openshift_performance/ose3_perf/scripts/build_test.py -z -a -n 2 -r $i -f running-builds.json >> $fileName 2>&1
     sleep 10
   done
 }
@@ -74,6 +69,8 @@ function run_build_workload() {
   grep "Good builds included in stats" conc_builds_$proj.out >> conc_builds_results.out
   echo "==============================================================" >> conc_builds_results.out
   # have to clean up to be able to run with new configmap/kube-burner with same uuid
+
+  cat conc_builds_$proj.out
   cleanup
 
 }

--- a/workloads/kube-burner/builds/eap.sh
+++ b/workloads/kube-burner/builds/eap.sh
@@ -1,9 +1,9 @@
 export APP=eap-app
 # Concurrent Build Specific
-export BUILD_IMAGE_STREAM=jboss-eap64-openshift
+export BUILD_IMAGE_STREAM=jboss-eap74-openjdk8-openshift
 export SOURCE_STRAT_ENV="''"
 export SOURCE_STRAT_FROM_VERSION=latest
-export SOURCE_STRAT_FROM=jboss-eap64-openshift
+export SOURCE_STRAT_FROM=jboss-eap74-openjdk8-openshift
 export POST_COMMIT_SCRIPT="''"
 
 export BUILD_IMAGE=image-registry.openshift-image-registry.svc:5000/svt-${app}/${BUILD_IMAGE_STREAM}


### PR DESCRIPTION
### Description
I updated the build_test.py script in the svt repo to use python3 packages instead of python2. Need to update this script to take out python 2 references 

Also the eap imagestream name had been updated and the concurrent-build script was not able to properly run that type of build


### Fixes
`Error "Error resolving ImageStreamTag jboss-eap64-openshift:latest in namespace openshift: imagestreams.image.openshift.io "jboss-eap64-openshift" not found" for field "from".`
