### PR TITLE
Remove reference to HYPERSHIFT_MANAGEMENT_KUBECONFIG on env.sh as emp…

### DIFF
--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -33,7 +33,7 @@ export KUBERNETES_VERSION=${KUBERNETES_MAJOR_VERSION}.${KUBERNETES_MINOR_VERSION
 export CLUSTER_NETWORK_TYPE=$(oc get network.config/cluster -o jsonpath='{.spec.networkType}')
 export NETWORK_TYPE=$CLUSTER_NETWORK_TYPE
 export PLATFORM_STATUS=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus}')
-export HYPERSHIFT_MANAGEMENT_KUBECONFIG=""
+export HYPERSHIFT_MANAGEMENT_KUBECONFIG=${HYPERSHIFT_MANAGEMENT_KUBECONFIG:-""}
 
 # Benchmark configuration
 RUNTIME=${RUNTIME:-60}


### PR DESCRIPTION
…ty, because if not, there is no way to set the var as env var

### Description

With current configuration, we can only set the var on the file, any setting from the env will be overrrided as ""

### Fixes
