### PR TITLE
Fix pod-density-heavy config file and update to calculate PODS_PER_NODE

### DIFF
--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -53,9 +53,13 @@ case ${WORKLOAD} in
     export TEST_JOB_ITERATIONS=${PODS:-1000}
   ;;
   pod-density-heavy)
-    WORKLOAD_TEMPLATE=workloads/node-density-heavy/node-density-heavy.yml
+    WORKLOAD_TEMPLATE=workloads/pod-density-heavy/pod-density-heavy.yml
     METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/metrics.yaml}
-    export TEST_JOB_ITERATIONS=${PODS:-1000}
+    NODE_COUNT=${NODE_COUNT:-$(kubectl get node -l ${WORKER_NODE_LABEL},node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= -o name | wc -l)}
+    PODS_PER_NODE=${PODS_PER_NODE:-245}
+    label="pod-density-heavy=enabled"
+    label_node_with_label $label
+    find_running_pods_num regular
   ;;
   pods-service-route)
     WORKLOAD_TEMPLATE=workloads/pods-service-route/pods-service-route.yml


### PR DESCRIPTION
### Description
pod-density-heavy was pointing to node-density-heavy workload, but is indeed a unique workload.

Also: Since it is a pod density test, I updated the workload to use the PODS_PER_NODE calculation used for the other node-density tests.

### Fixes
