### PR TITLE
tuned profile for hypershift

### DIFF
--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -149,9 +149,11 @@ tune_workload_node(){
     export KUBECONFIG="${HYPERSHIFT_MANAGEMENT_KUBECONFIG}"
     sed "s#TUNED_NODE_SELECTOR#${TUNED_NODE_SELECTOR}#g" tuned-profile.yml > /tmp/tuning
     oc create configmap tuned-node --from-file=/tmp/tuning -n clusters --dry-run=client -o yaml | oc ${1} -f -
+    TUNING_CONFIG='{"name":"tuned-node"}'
+    if [[ "${1}" == "delete" ]]; then TUNING_CONFIG=''; fi
     for np in $(oc get nodepool -n clusters | grep ${CLUSTER_NAME} | awk '{print$1}');
     do
-      oc patch -n clusters nodepool/$np --type=merge --patch='{"spec":{"tuningConfig":[{"name":"tuned-node"}]}}'
+      oc patch -n clusters nodepool/$np --type=merge --patch='{"spec":{"tuningConfig":["'${TUNING_CONFIG}'"]}}'
     done
     export KUBECONFIG="${HYPERSHIFT_HOSTED_KUBECONFIG}"
   else

--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -153,7 +153,7 @@ tune_workload_node(){
     if [[ "${1}" == "delete" ]]; then TUNING_CONFIG=''; fi
     for np in $(oc get nodepool -n clusters | grep ${CLUSTER_NAME} | awk '{print$1}');
     do
-      oc patch -n clusters nodepool/$np --type=merge --patch='{"spec":{"tuningConfig":["'${TUNING_CONFIG}'"]}}'
+      oc patch -n clusters nodepool/$np --type=merge --patch='{"spec":{"tuningConfig":['${TUNING_CONFIG}']}}'
     done
     export KUBECONFIG="${HYPERSHIFT_HOSTED_KUBECONFIG}"
   else


### PR DESCRIPTION
### Description
Hypershift tuned profile uses `Node Tuning Operator` but it has to be done on the Management cluster in a [different way](https://hypershift-docs.netlify.app/how-to/automated-machine-management/node-tuning/),  create a configmap and add it in to hc `nodepool` as tuning option. 
This PR enables it.
### Fixes
