### PR TITLE
Update perfApp image location

### DIFF
--- a/workloads/kube-burner/workloads/node-density-heavy/app-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/app-deployment.yml
@@ -11,7 +11,7 @@ spec:
       nodeSelector: {{.nodeSelector}}
       containers:
       - name: perfapp
-        image: quay.io/rsevilla/perfapp@sha256:02848a9c90dd4e345eac4f1dffbf10eab19859612113a427b3e9fa6490fb8c08
+        image: quay.io/cloud-bulldozer/perfapp:latest
         imagePullPolicy: IfNotPresent
         readinessProbe:
           httpGet:


### PR DESCRIPTION
Signed-off-by: Raul Sevilla <rsevilla@redhat.com>

### Description

The location of the perfApp has been changed. Stop using the sha256 notation of it, as it breaks as soon as the image is updated.

cc: @afcollins 

### Fixes
