### PR TITLE
Add cni and heavy namespaced iterations env.

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -67,6 +67,7 @@ Workloads can be tweaked with the following environment variables:
 | **CHURN_DURATION**             | Time, in time type (ex: 1h10m11s), to churn for | 10m |
 | **CHURN_DELAY**             | Time, in time type (ex: 1m30s), to wait between each churn | 60s |
 | **CHURN_PERCENT**             | Percentage of JOB_ITERATIONS that we should churn each round | 10 |
+| **NAMESPACED_ITERATIONS**             | Run each JOB_ITERATIONS in a distinct namespace.  Configurable on node-density-heavy and node-density-cni only | false |
 
 **Note**: You can use basic authentication for ES indexing using the notation `http(s)://[username]:[password]@[host]:[port]` in **ES_SERVER**.
 
@@ -99,12 +100,14 @@ Each iteration of this workload creates the following object:
   - 1 pod. (sleep)
 
 - **node-density-heavy**. Creates a **single namespace with a number of applications proportional to the calculated number of pods / 2**. This application consists on two deployments (a postgresql database and a simple client that generates some CPU load) and a service that is used by the client to reach the database.
+Single namespace behavior can be changed by using `NAMESPACED_ITERATIONS`.
 Each iteration of this workload can be broken down in:
   - 1 deployment holding a postgresql database
   - 1 deployment holding a client application for the previous database
   - 1 service pointing to the postgresl database
 
 - **node-density-cni**. Creates a **single namespace with a number of applications equals to job_iterations**. This application consists on two deployments (a node.js webserver and a simple client that curls the webserver) and a service that is used by the client to reach the webserver.
+Single namespace behavior can be changed by using `NAMESPACED_ITERATIONS`.
 Each iteration of this workload creates the following objects:
   - 1 deployment holding a node.js webserver
   - 1 deployment holding a client application for curling the webserver
@@ -112,7 +115,7 @@ Each iteration of this workload creates the following objects:
 
     The startupProbe of the client pod depends on being able to reach the webserver so that the PodReady latencies collected by kube-burner reflect network connectivity.
 
-- **node-density-cni-policy**. Creates a **single namespace with a number of applications equals to job_iterations**. This application consists on two deployments (a node.js webserver and a simple client that curls the webserver) and a service that is used by the client to reach the webserver.
+- **node-density-cni-networkpolicy**. Creates a **single namespace with a number of applications equals to job_iterations**. This application consists on two deployments (a node.js webserver and a simple client that curls the webserver) and a service that is used by the client to reach the webserver.
 Each iteration of this workload creates the following objects:
   - 1 deployment holding a node.js webserver
   - 1 deployment holding a client application for curling the webserver

--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -25,6 +25,7 @@ case ${WORKLOAD} in
     METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/metrics.yaml}
     NODE_COUNT=${NODE_COUNT:-$(kubectl get node -l ${WORKER_NODE_LABEL},node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= -o name | wc -l)}
     PODS_PER_NODE=${PODS_PER_NODE:-245}
+    export NAMESPACED_ITERATIONS=${NAMESPACED_ITERATIONS:-false}
     label="node-density=enabled"
     label_node_with_label $label
     find_running_pods_num heavy
@@ -34,6 +35,7 @@ case ${WORKLOAD} in
     METRICS_PROFILE=${METRICS_PROFILE:-metrics-profiles/metrics.yaml}
     NODE_COUNT=${NODE_COUNT:-$(kubectl get node -l ${WORKER_NODE_LABEL},node-role.kubernetes.io/infra!=,node-role.kubernetes.io/workload!= -o name | wc -l)}
     PODS_PER_NODE=${PODS_PER_NODE:-245}
+    export NAMESPACED_ITERATIONS=${NAMESPACED_ITERATIONS:-false}
     label="node-density=enabled"
     label_node_with_label $label
     find_running_pods_num cni

--- a/workloads/kube-burner/workloads/node-density-cni/node-density-cni.yml
+++ b/workloads/kube-burner/workloads/node-density-cni/node-density-cni.yml
@@ -59,7 +59,7 @@ jobs:
     jobIterations: {{.TEST_JOB_ITERATIONS}}
     qps: {{.QPS}}
     burst: {{.BURST}}
-    namespacedIterations: false
+    namespacedIterations: {{.NAMESPACED_ITERATIONS}}
     namespace: {{.UUID}}
     podWait: {{.POD_WAIT}}
     cleanup: {{.CLEANUP}}

--- a/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/node-density-heavy.yml
@@ -59,7 +59,7 @@ jobs:
     jobIterations: {{.TEST_JOB_ITERATIONS}}
     qps: {{.QPS}}
     burst: {{.BURST}}
-    namespacedIterations: false
+    namespacedIterations: {{.NAMESPACED_ITERATIONS}}
     namespace: {{.UUID}}
     podWait: {{.POD_WAIT}}
     cleanup: {{.CLEANUP}}
@@ -80,6 +80,7 @@ jobs:
       - objectTemplate: postgres-deployment.yml
         replicas: 1
         inputVars:
+          readinessPeriod: 1
           nodeSelector: "{{.POD_NODE_SELECTOR}}"
 
       - objectTemplate: app-deployment.yml

--- a/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
+++ b/workloads/kube-burner/workloads/node-density-heavy/postgres-deployment.yml
@@ -12,6 +12,13 @@ spec:
       containers:
       - name: postgresql
         image: registry.redhat.io/rhel8/postgresql-10@sha256:4b912c80085b88a03309aeb7907efcc29dd3342fa3952b6ea067afb1914bfe53
+        readinessProbe:
+          tcpSocket:
+            port: 5432
+          periodSeconds: {{ .readinessPeriod }}
+          failureThreshold: 1
+          timeoutSeconds: 10
+          initialDelaySeconds: 3
         ports:
         - containerPort: 5432
           protocol: TCP


### PR DESCRIPTION
Add postgres readinessProbe that helps performance.

### Description
Larger densities of node-density-cni and node-density-heavy workloads benefit from NAMESPACED_ITERATIONS=true.

A readiness probe on postgres helps reduce failure and restarts of the app-deployment.