### PR TITLE
typo - alerts-profiles, not alert-profiles

### DIFF
--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -78,8 +78,8 @@ run_workload() {
     CMD+=" -m ${KUBE_DIR}/metrics.yml"
   fi
   if [[ ${PLATFORM_ALERTS} == "true" ]]; then
-    log "Platform alerting enabled, using ${PWD}/alert-profiles/${WORKLOAD}-${platform}.yml"
-    CMD+=" -a ${PWD}/alert-profiles/${WORKLOAD}-${platform}.yml"
+    log "Platform alerting enabled, using ${PWD}/alerts-profiles/${WORKLOAD}-${platform}.yml"
+    CMD+=" -a ${PWD}/alerts-profiles/${WORKLOAD}-${platform}.yml"
   fi
   pushd $(dirname ${WORKLOAD_TEMPLATE})
   local start_date=$(date +%s%3N)


### PR DESCRIPTION
### Description

kube-burner script errors trying to find a path when running cluster-density.

### Fixes

```
[2023-02-01 22:21:09,629] {subprocess.py:92} INFO - time="2023-02-01 22:21:09" level=fatal msg="Error reading alert profile /home/airflow/workspace/e2e-benchmarking/workloads/kube-burner/alert-profiles/cluster-density-AWS.yml: /home/airflow/workspace/e2e-benchmarking/workloads/kube-burner/alert-profiles/cluster-density-AWS.yml is not a valid URL"
```