### PR TITLE
Hypershift: service cluster metrics 

### DIFF
--- a/utils/common.sh
+++ b/utils/common.sh
@@ -153,6 +153,7 @@ gen_metadata() {
   fi
   if [[ ${HYPERSHIFT} == "true" ]]; then
     local MGMT_CLUSTER=${MGMT_CLUSTER_NAME}
+    local SVC_CLUSTER=${SVC_CLUSTER_NAME}    
   fi
   if [[ ${BENCHMARK} =~ "cyclictest" ]]; then
     local WORKLOAD_NODES_COUNT=$(oc get node -l node-role.kubernetes.io/cyclictest= --no-headers --ignore-not-found | wc -l)
@@ -192,6 +193,7 @@ local METADATA=$(cat << EOF
 "workload": "${WORKLOAD}",
 "cluster_name": "${CLUSTER_NAME}",
 "mgmt_cluster_name": "${MGMT_CLUSTER}",
+"svc_cluster_name": "${SVC_CLUSTER}",
 "result":"${RESULT}"
 }
 EOF

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -57,6 +57,7 @@ export HYPERSHIFT=${HYPERSHIFT:-false}
 export MGMT_CLUSTER_NAME=${MGMT_CLUSTER_NAME:-perf-management-cluster}
 export HOSTED_CLUSTER_NS=${HOSTED_CLUSTER_NS:-clusters-perf-hosted-1}
 export THANOS_RECEIVER_URL=${THANOS_RECEIVER_URL:-http://thanos.apps.cluster.devcluster/api/v1/receive}
+export SVC_CLUSTER_NAME=${SVC_CLUSTER_NAME:-""}
 
 # # Concurrent Builds variables
 # Space seperated list of build numbers and build app types

--- a/workloads/kube-burner/metrics-profiles/hypershift-metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/hypershift-metrics.yaml
@@ -207,3 +207,54 @@
 - query: cluster_version{openshift_cluster_name=~"${MGMT_CLUSTER_NAME}",namespace=~"${HOSTED_CLUSTER_NS}",type="completed"}
   metricName: clusterVersion
   instant: true
+
+# Hypershift Service Cluster metris 
+
+- query: (sum(irate(node_cpu_seconds_total{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: svcNodeCPU-Workers
+
+- query: (sum(irate(node_cpu_seconds_total{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
+  metricName: svcNodeCPU-Masters
+
+- query: node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: svcNodeMemoryAvailable-Masters
+
+- query: node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: svcNodeMemoryAvailable-Workers
+
+- query: (node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} - node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: svcNodeMemoryUtilization-Masters
+
+- query: (node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} - node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: svcNodeMemoryUtilization-Workers
+
+- query: node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
+  metricName: svcNodeMemoryTotal-Masters
+
+- query: node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
+  metricName: svcNodeMemoryTotal-Workers
+
+- query: sum(rate(etcd_server_leader_changes_seen_total{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m]))
+  metricName: svcEtcdLeaderChangesRate
+
+- query: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m]))
+  metricName: svc99thEtcdDiskBackendCommitDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m]))
+  metricName: svc99thEtcdDiskWalFsyncDurationSeconds
+
+- query: histogram_quantile(0.99, rate(etcd_network_peer_round_trip_time_seconds_bucket{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[5m]))
+  metricName: svc99thEtcdRoundTripTimeSeconds
+
+- query: sum by (cluster_version)(etcd_cluster_version{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"})
+  metricName: svcEtcdVersion
+  instant: true
+
+- query: sum(kube_namespace_status_phase{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}) by (phase) > 0
+  metricName: svcNamespaceCount
+
+- query: (sum(irate(container_cpu_usage_seconds_total{openshift_cluster_name=~"${SVC_CLUSTER_NAME}", name!="",container!~"POD|"}[2m]) * 100) by (container, pod, namespace, node)) > 0
+  metricName: svcContainerCPU
+
+- query: sum(container_memory_rss{openshift_cluster_name=~"${SVC_CLUSTER_NAME}", name!="",container!~"POD|"}) by (container, pod, namespace, node)
+  metricName: svcContainerMemory

--- a/workloads/kube-burner/metrics-profiles/hypershift-metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/hypershift-metrics.yaml
@@ -210,29 +210,23 @@
 
 # Hypershift Service Cluster metris 
 
-- query: (sum(irate(node_cpu_seconds_total{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) > 0
-  metricName: svcNodeCPU-Workers
+- query: (max(sum(irate(node_cpu_seconds_total{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (mode, instance)) > 0
+  metricName: svcNodeCPU-AggregatedWorkers
 
-- query: (sum(irate(node_cpu_seconds_total{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m])) by (mode,instance) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")) > 0
-  metricName: svcNodeCPU-Masters
+- query: (min(node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance))
+  metricName: svcNodeMemoryAvailable-AggregatedWorkers
 
-- query: node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: svcNodeMemoryAvailable-Masters
+- query: (avg(node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")) by (instance))
+  metricName: svcNodeMemoryTotal-AggregatedWorkers
 
-- query: node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
-  metricName: svcNodeMemoryAvailable-Workers
+- query: (avg((sum(irate(node_cpu_seconds_total{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m])) by (mode,instance) and on (instance) label_replace(cluster:nodes_roles{label_node_role_kubernetes_io_master!=""}, "instance", "$1", "node", "(.+)"))) by (mode, instance)) > 0
+  metricName: svcMasterCPU-AggregatedWorkers
 
-- query: (node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} - node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: svcNodeMemoryUtilization-Masters
+- query: (avg(node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(cluster:nodes_roles{label_node_role_kubernetes_io_master!=""}, "instance", "$1", "node", "(.+)")) by (instance))
+  metricName: svcMasterMemoryAvailable-AggregatedWorkers
 
-- query: (node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} - node_memory_MemAvailable_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}) and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
-  metricName: svcNodeMemoryUtilization-Workers
-
-- query: node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
-  metricName: svcNodeMemoryTotal-Masters
-
-- query: node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)")
-  metricName: svcNodeMemoryTotal-Workers
+- query: (avg(node_memory_MemTotal_bytes{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"} and on (instance) label_replace(cluster:nodes_roles{label_node_role_kubernetes_io_master!=""}, "instance", "$1", "node", "(.+)")) by (instance))
+  metricName: svcMasterMemoryTotal-AggregatedWorkers
 
 - query: sum(rate(etcd_server_leader_changes_seen_total{openshift_cluster_name=~"${SVC_CLUSTER_NAME}"}[2m]))
   metricName: svcEtcdLeaderChangesRate


### PR DESCRIPTION
### Description
For Hypershift builds, collecting basic node level metrics from service cluster to monitor during cluster install.

Presumption:
Service cluster is already configured to remote write metrics to thanos and ready to query metrics from there during installs.

### Fixes
