### PR TITLE
router-perf exit 1 when benchmark comparison fails

### DIFF
--- a/workloads/router-perf-v2/ingress-performance.sh
+++ b/workloads/router-perf-v2/ingress-performance.sh
@@ -52,8 +52,19 @@ cleanup_infra
 reschedule_monitoring_stack infra
 
 export WORKLOAD="router-perf"
-run_benchmark_comparison
+
+# Do not exit when compare function has any non 0 return code when COMPARISON_RC=1
+set +e
+if ! run_benchmark_comparison; then
+  log "Benchmark comparison failed"
+  result="failed"
+fi
+set -e
 
 if [[ ${ENABLE_SNAPPY_BACKUP} == "true" ]] ; then
  snappy_backup "csv json" "http-perf.yml" "router-perf-v2"
+fi
+
+if [[ ${result} == "failed" ]] ; then
+ exit 1
 fi


### PR DESCRIPTION
### Description
I hope the ingress-performance.sh can exit 1 when benchmark comparison fails, so that the CI calling ingress-performance.sh can get this result to set the CI test's final result.

Currently when set COMPARISON_RC=1, this line's return code is 1. https://github.com/cloud-bulldozer/e2e-benchmarking/blob/0bf6622531f2b1fed8ef7c332d2b42c083bd6a04/utils/compare.sh#L110 
As ingress-performance.sh has the `set -e` setting, https://github.com/cloud-bulldozer/e2e-benchmarking/blob/0bf6622531f2b1fed8ef7c332d2b42c083bd6a04/workloads/router-perf-v2/ingress-performance.sh#L2 
the rest codes in run_benchmark_comparison  after compare will not be executed.
https://github.com/cloud-bulldozer/e2e-benchmarking/blob/0bf6622531f2b1fed8ef7c332d2b42c083bd6a04/utils/compare.sh#L59-L68

This PR 
1 Set return code specifically, let compare function to return 1 when touchstone cmd fails, and run_benchmark_comparison to check compare function's return code to determine the return code of itself. This will work no mater there is `set -e` or not in the caller script. Failure return code only happens when COMPARISON_RC=1 (default=0)
2. Fixed formatting in compare.sh
3. Let ingress-performance.sh to exit 1 when benchmark comparison fails