### PR TITLE
Adding multiple endpoints support for kube-burner workloads

### DIFF
--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -30,7 +30,7 @@ Workloads can be tweaked with the following environment variables:
 | **ES_SERVER**        | Elasticsearch endpoint          | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|
 | **ES_INDEX**         | Elasticsearch index             | ripsaw-kube-burner|
 | **PROM_URL**         | Prometheus endpoint, it should be Thanos querier endpoint when running on `HYPERSHIFT` cluster | Prometheus endpoint is automatically discovered |
-| **METRICS_ENDPOINT** | A yaml file with list of prometheus endpoints to scrape. PROM_URL should be set to `None` while using this option | Empty string ("")
+| **METRICS_ENDPOINT** | A yaml file with list of prometheus endpoints to scrape. It will take precedence over PROM_URL option | Empty string ("")
 | **JOB_TIMEOUT**      | Kube-burner's timeout, in seconds | 4h (4 hours) |
 | **QPS**              | Queries/sec                     | 20      |
 | **BURST**            | Maximum number of simultaneous queries | 20      |

--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -30,6 +30,7 @@ Workloads can be tweaked with the following environment variables:
 | **ES_SERVER**        | Elasticsearch endpoint          | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|
 | **ES_INDEX**         | Elasticsearch index             | ripsaw-kube-burner|
 | **PROM_URL**         | Prometheus endpoint, it should be Thanos querier endpoint when running on `HYPERSHIFT` cluster | Prometheus endpoint is automatically discovered |
+| **METRICS_ENDPOINT** | A yaml file with list of prometheus endpoints to scrape. PROM_URL should be set to `None` while using this option | Empty string ("")
 | **JOB_TIMEOUT**      | Kube-burner's timeout, in seconds | 4h (4 hours) |
 | **QPS**              | Queries/sec                     | 20      |
 | **BURST**            | Maximum number of simultaneous queries | 20      |

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -70,19 +70,18 @@ run_workload() {
   CMD="timeout ${JOB_TIMEOUT} ${KUBE_DIR}/kube-burner init --uuid=${UUID} -c $(basename ${WORKLOAD_TEMPLATE}) --log-level=${LOG_LEVEL}"
   # When metrics or alerting are enabled we have to pass the prometheus URL to the cmd
   if [[ ${INDEXING} == "true" ]] || [[ ${PLATFORM_ALERTS} == "true" ]] ; then
-    if [[ -n ${PROM_URL} ]] && [[ ${PROM_URL} != "None" ]]; then
-      CMD+=" -u ${PROM_URL}"
-    fi
-    CMD+=" -t ${PROM_TOKEN}"
+      if [[ -n ${METRICS_ENDPOINT} ]]; then
+        log "Using endpoints from ${METRICS_ENDPOINT}"
+        CMD+=" -e ${METRICS_ENDPOINT}"
+      else
+        log "Using prometheus from ${PROM_URL}"
+        CMD+=" -u=${PROM_URL} -t ${PROM_TOKEN}"
+      fi
   fi
   if [[ -n ${METRICS_PROFILE} ]]; then
     log "Indexing enabled, using metrics from ${METRICS_PROFILE}"
     envsubst < ${METRICS_PROFILE} > ${KUBE_DIR}/metrics.yml || envsubst < ${METRICS_PROFILE} > ${KUBE_DIR}/metrics.yml
     CMD+=" -m ${KUBE_DIR}/metrics.yml"
-  fi
-  if [[ -n ${METRICS_ENDPOINT} ]]; then
-    log "Using endpoints from ${METRICS_ENDPOINT}"
-    CMD+=" -e ${METRICS_ENDPOINT}"
   fi
   if [[ ${PLATFORM_ALERTS} == "true" ]]; then
     log "Platform alerting enabled, using ${PWD}/alerts-profiles/${WORKLOAD}-${platform}.yml"

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -70,12 +70,19 @@ run_workload() {
   CMD="timeout ${JOB_TIMEOUT} ${KUBE_DIR}/kube-burner init --uuid=${UUID} -c $(basename ${WORKLOAD_TEMPLATE}) --log-level=${LOG_LEVEL}"
   # When metrics or alerting are enabled we have to pass the prometheus URL to the cmd
   if [[ ${INDEXING} == "true" ]] || [[ ${PLATFORM_ALERTS} == "true" ]] ; then
-    CMD+=" -u=${PROM_URL} -t ${PROM_TOKEN}"
+    if [[ -n ${PROM_URL} ]] && [[ ${PROM_URL} != "None" ]]; then
+      CMD+=" -u ${PROM_URL}"
+    fi
+    CMD+=" -t ${PROM_TOKEN}"
   fi
   if [[ -n ${METRICS_PROFILE} ]]; then
     log "Indexing enabled, using metrics from ${METRICS_PROFILE}"
     envsubst < ${METRICS_PROFILE} > ${KUBE_DIR}/metrics.yml || envsubst < ${METRICS_PROFILE} > ${KUBE_DIR}/metrics.yml
     CMD+=" -m ${KUBE_DIR}/metrics.yml"
+  fi
+  if [[ -n ${METRICS_ENDPOINT} ]]; then
+    log "Using endpoints from ${METRICS_ENDPOINT}"
+    CMD+=" -e ${METRICS_ENDPOINT}"
   fi
   if [[ ${PLATFORM_ALERTS} == "true" ]]; then
     log "Platform alerting enabled, using ${PWD}/alerts-profiles/${WORKLOAD}-${platform}.yml"

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -18,7 +18,7 @@ export MAX_WAIT_TIMEOUT=${MAX_WAIT_TIMEOUT:-1h}
 export CLEANUP=${CLEANUP:-true}
 export POD_NODE_SELECTOR=${POD_NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export WORKER_NODE_LABEL=${WORKER_NODE_LABEL:-"node-role.kubernetes.io/worker"}
-export WAIT_WHEN_FINISHED=true
+export WAIT_WHEN_FINISHED=${WAIT_WHEN_FINISHED:-true}
 export POD_WAIT=${POD_WAIT:-false}
 export WAIT_FOR=${WAIT_FOR:-[]}
 export VERIFY_OBJECTS=${VERIFY_OBJECTS:-true}
@@ -27,7 +27,7 @@ export PRELOAD_IMAGES=${PRELOAD_IMAGES:-true}
 export PRELOAD_PERIOD=${PRELOAD_PERIOD:-2m}
 
 # Kube-burner benchmark
-export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.4.1/kube-burner-1.4.1-Linux-x86_64.tar.gz"}
+export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.4.2/kube-burner-1.4.2-Linux-x86_64.tar.gz"}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-4h}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export METRICS_PROFILE=${METRICS_PROFILE}

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -27,7 +27,7 @@ export PRELOAD_IMAGES=${PRELOAD_IMAGES:-true}
 export PRELOAD_PERIOD=${PRELOAD_PERIOD:-2m}
 
 # Kube-burner benchmark
-#export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.2/kube-burner-0.17.2-Linux-x86_64.tar.gz"}
+export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.2/kube-burner-0.17.2-Linux-x86_64.tar.gz"}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-4h}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export METRICS_PROFILE=${METRICS_PROFILE}

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -27,10 +27,11 @@ export PRELOAD_IMAGES=${PRELOAD_IMAGES:-true}
 export PRELOAD_PERIOD=${PRELOAD_PERIOD:-2m}
 
 # Kube-burner benchmark
-export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.2/kube-burner-0.17.2-Linux-x86_64.tar.gz"}
+#export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.2/kube-burner-0.17.2-Linux-x86_64.tar.gz"}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-4h}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export METRICS_PROFILE=${METRICS_PROFILE}
+export METRICS_ENDPOINT=${METRICS_ENDPOINT}
 export JOB_PAUSE=${JOB_PAUSE:-1m}
 
 # kube-burner workload defaults

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -27,7 +27,7 @@ export PRELOAD_IMAGES=${PRELOAD_IMAGES:-true}
 export PRELOAD_PERIOD=${PRELOAD_PERIOD:-2m}
 
 # Kube-burner benchmark
-export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.2/kube-burner-0.17.2-Linux-x86_64.tar.gz"}
+export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.4.1/kube-burner-1.4.1-Linux-x86_64.tar.gz"}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-4h}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export METRICS_PROFILE=${METRICS_PROFILE}

--- a/workloads/kube-burner/run.sh
+++ b/workloads/kube-burner/run.sh
@@ -132,6 +132,8 @@ cat << EOF
 ###############################################
 Workload: ${WORKLOAD}
 Workload template: ${WORKLOAD_TEMPLATE}
+Prometheus Url: ${PROM_URL}
+Metrics Endpoint: ${METRICS_ENDPOINT}
 Metrics profile: ${METRICS_PROFILE}
 Alerts profile: ${ALERTS_PROFILE}
 QPS: ${QPS}


### PR DESCRIPTION
### Description
Added support to scrape multiple prometheus endpoints as in https://github.com/cloud-bulldozer/kube-burner/pull/251

### Testing
Tested using below commands
``` 
LOG_LEVEL=debug WORKLOAD=pod-density PROM_URL=https://www.exampleurl.com METRICS_ENDPOINT=/home/vchalla/metrics endpoints.yaml ./run.sh 
```
``` 
LOG_LEVEL=debug WORKLOAD=pod-density METRICS_ENDPOINT=/home/vchalla/metrics-endpoints.yaml ./run.sh
```
```
LOG_LEVEL=debug WORKLOAD=pod-density ./run.sh
```