### PR TITLE
Adding pod latency tolerancy for kube burner worklaod

### DIFF
--- a/workloads/kube-burner/pod-latency-tolerancy-rules.yaml
+++ b/workloads/kube-burner/pod-latency-tolerancy-rules.yaml
@@ -1,0 +1,4 @@
+- json_path: ["metricName", "podLatencyQuantilesMeasurement", "quantileName", "*", "avg(P99)"]
+  tolerancy: -15
+  # Maximum percentage of allowed failures
+  max_failures: 25


### PR DESCRIPTION
### Description
Want to add a pod latency tolerancy file to use in comparisons for getting final result of 

Need to address https://github.com/cloud-bulldozer/e2e-benchmarking/issues/540 to further look into all the data that can be collected with the [touchstone-configs](https://github.com/cloud-bulldozer/e2e-benchmarking/tree/master/utils/touchstone-configs)
