### PR TITLE
Revert kube-burner binary to 0.17.3

### DIFF
--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -65,7 +65,11 @@ run_workload() {
     mv ${KUBE_BURNER_DIR}/bin/amd64/kube-burner ${KUBE_DIR}/kube-burner
     rm -rf ${KUBE_BURNER_DIR}
   else
-    curl -sS -L ${KUBE_BURNER_URL} | tar -xzC ${KUBE_DIR}/ kube-burner
+    if [[ -n ${METRICS_ENDPOINT} ]] ; then
+      curl -sS -L ${KUBE_BURNER_URL_14} | tar -xzC ${KUBE_DIR}/ kube-burner
+    else
+      curl -sS -L ${KUBE_BURNER_URL} | tar -xzC ${KUBE_DIR}/ kube-burner
+    fi
   fi
   CMD="timeout ${JOB_TIMEOUT} ${KUBE_DIR}/kube-burner init --uuid=${UUID} -c $(basename ${WORKLOAD_TEMPLATE}) --log-level=${LOG_LEVEL}"
   # When metrics or alerting are enabled we have to pass the prometheus URL to the cmd

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -28,6 +28,7 @@ export PRELOAD_PERIOD=${PRELOAD_PERIOD:-2m}
 
 # Kube-burner benchmark
 export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.3/kube-burner-0.17.3-Linux-x86_64.tar.gz"}
+export KUBE_BURNER_URL_14=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.4.2/kube-burner-1.4.2-Linux-x86_64.tar.gz"}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-4h}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export METRICS_PROFILE=${METRICS_PROFILE}

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -27,7 +27,7 @@ export PRELOAD_IMAGES=${PRELOAD_IMAGES:-true}
 export PRELOAD_PERIOD=${PRELOAD_PERIOD:-2m}
 
 # Kube-burner benchmark
-export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v1.4.2/kube-burner-1.4.2-Linux-x86_64.tar.gz"}
+export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.3/kube-burner-0.17.3-Linux-x86_64.tar.gz"}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-4h}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export METRICS_PROFILE=${METRICS_PROFILE}


### PR DESCRIPTION
### Description
Workload configs have not been updated to be compatible with v1.4.2. So reverting to 0.17 for now.

### Fixes
`[2023-03-09, 19:39:51 UTC] {subprocess.py:92} INFO - time="2023-03-09 19:39:51" level=fatal msg="Error decoding configuration file node-pod-density.yml: yaml: unmarshal errors:\n  line 3: field writeToFile not found in type config.GlobalConfig\n  line 12: field esIndex not found in type types.Measurement"`
