### PR TITLE
Removing iperf from the mix

### DIFF
--- a/workloads/network-perf-v2/run.sh
+++ b/workloads/network-perf-v2/run.sh
@@ -14,7 +14,7 @@ log "###############################################"
 log "Workload: ${WORKLOAD}"
 log "###############################################"
 
-timeout $TEST_TIMEOUT ./k8s-netperf --debug --metrics --iperf --all --config ${WORKLOAD} --search $ES_SERVER --clean=true
+timeout $TEST_TIMEOUT ./k8s-netperf --debug --metrics --all --config ${WORKLOAD} --search $ES_SERVER --clean=true
 run=$?
 
 # Add debugging info (will be captured in each execution output)


### PR DESCRIPTION
Why?
- Reduce the test time
- Having multiple load-drivers in CI might confuse the results.
