### PR TITLE
Adding tolerance to network-v2

### DIFF
--- a/workloads/network-perf-v2/env.sh
+++ b/workloads/network-perf-v2/env.sh
@@ -10,3 +10,6 @@ export NETPERF_URL=${NETPERF_URL:-https://github.com/jtaleric/k8s-netperf/releas
 # Workload
 export WORKLOAD=${WORKLOAD:-smoke.yaml}
 export TEST_TIMEOUT=${TEST_TIMEOUT:-7200}
+
+# Tolerance of delta from hostNetwork to podNetwork
+export TOLERANCE=${TOLERANCE:-20}

--- a/workloads/network-perf-v2/run.sh
+++ b/workloads/network-perf-v2/run.sh
@@ -14,7 +14,7 @@ log "###############################################"
 log "Workload: ${WORKLOAD}"
 log "###############################################"
 
-timeout $TEST_TIMEOUT ./k8s-netperf --debug --metrics --all --config ${WORKLOAD} --search $ES_SERVER --clean=true
+timeout $TEST_TIMEOUT time ./k8s-netperf --debug --metrics --all --config ${WORKLOAD} --search $ES_SERVER --tcp-tolerance ${TOLERANCE} --clean=true
 run=$?
 
 # Add debugging info (will be captured in each execution output)


### PR DESCRIPTION
Allow the user to override the default tolerance (20% delta). Setting the tolerance higher than currently observed delta.
