### PR TITLE
Bump kube burner and fix confusing doc typos

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/README.md
+++ b/workloads/kube-burner-ocp-wrapper/README.md
@@ -40,10 +40,10 @@ $ export EXTRA_FLAGS="--churn-duration=1d --churn-percent=5 --churn-delay=5m"
 $ ITERATIONS=500 WORKLOAD=cluster-density-v2 ./run.sh
 ```
 
-Or disable the namespace garbage collection:
+Or increase the benchmark timeout (by default 3h):
 
-```
-$ EXTRA_FLAGS="--gc=false" ITERATIONS=500 WORKLOAD=cluster-density-v2 ./run.sh
+```shell
+$ EXTRA_FLAGS="--timeout=5h" ITERATIONS=500 WORKLOAD=cluster-density-v2 ./run.sh
 ```
 
 

--- a/workloads/kube-burner-ocp-wrapper/README.md
+++ b/workloads/kube-burner-ocp-wrapper/README.md
@@ -1,6 +1,6 @@
 # Kube-burner
 
-The `./run.sh` script is just a small wrapper on top of kube-burner to be used as entrypoint of some of its flags. The supported workloads are described in the [OpenShift OCP wrapper section](https://kube-burner.readthedocs.io/en/latest/ocp/) of the kube-burner docs.
+The `./run.sh` script is just a small wrapper on top of kube-burner to be used as entrypoint of some of its flags. The supported workloads are described in the [OpenShift OCP wrapper section](https://cloud-bulldozer.github.io/kube-burner/ocp/) of the kube-burner docs.
 
 In order to run a workload you have to set the `WORKLOAD` environment variable to one of the workloads supported by kube-burner. Example
 
@@ -32,7 +32,7 @@ This wrapper supports some variables to tweak some basic parameters of the workl
 
 ### Using the EXTRA_FLAGS variable
 
-All the flags that can be appeneded through the `EXTRA_FLAGS` variable can be found in the [kube-burner docs](https://kube-burner.readthedocs.io/en/latest/ocp/)
+All the flags that can be appeneded through the `EXTRA_FLAGS` variable can be found in the [kube-burner docs](https://cloud-bulldozer.github.io/kube-burner/ocp/)
 For example, we can tweak the churning behaviour of the cluster-density workload with:
 
 ```shell

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -4,7 +4,7 @@ set -e
 
 ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
 LOG_LEVEL=${LOG_LEVEL:-info}
-KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-1.5}
+KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-1.6}
 CHURN=${CHURN:-true}
 WORKLOAD=${WORKLOAD:?}
 QPS=${QPS:-20}


### PR DESCRIPTION
### Description

Release notes: https://github.com/cloud-bulldozer/kube-burner/releases/tag/v1.6
