### PR TITLE
Update netperf-v2 tolerance

### DIFF
--- a/workloads/network-perf-v2/env.sh
+++ b/workloads/network-perf-v2/env.sh
@@ -11,5 +11,9 @@ export NETPERF_URL=${NETPERF_URL:-https://github.com/cloud-bulldozer/k8s-netperf
 export WORKLOAD=${WORKLOAD:-smoke.yaml}
 export TEST_TIMEOUT=${TEST_TIMEOUT:-7200}
 
-# Tolerance of delta from hostNetwork to podNetwork
-export TOLERANCE=${TOLERANCE:-20}
+# Tolerance of delta from hostNetwork to podNetwork - single stream
+# Setting high watermark to only alert us if something has really gone
+# sideways. We will be actively montiroing the results. Eventually
+# we will have a better way to determine pass/fail via querying ES for
+# historical data to do the comparison.
+export TOLERANCE=${TOLERANCE:-70}


### PR DESCRIPTION
Two things to consider -
- 8192 single stream will struggle to match the throughput of hostNetwork.
- Cloud variance also causes flux. See below

The below podNetwork is pretty consistent run to run, but the hostNetwork experiences flux.

```
Run 1
+-------------------+---------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+---------------------------------+
|    RESULT TYPE    | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |     95% CONFIDENCE INTERVAL     |
+-------------------+---------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+---------------------------------+
| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | 8192         | false     | 30       | 3       | 7164.306667 (Mb/s) | 7010.984364-7317.628969 (Mb/s)  |
| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | 8192         | false     | 30       | 3       | 8731.176448 (Mb/s) | 5300.568382-12161.784514 (Mb/s) |
| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | 8192         | false     | 30       | 3       | 4930.583333 (Mb/s) | 4929.447038-4931.719628 (Mb/s)  |
| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | 8192         | false     | 30       | 3       | 4924.116309 (Mb/s) | 4919.866823-4928.365796 (Mb/s)  |
+-------------------+---------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+---------------------------------+

Run N
+-------------------+---------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+--------------------------------+
|    RESULT TYPE    | DRIVER  |  SCENARIO  | PARALLELISM | HOST NETWORK | SERVICE | MESSAGE SIZE | SAME NODE | DURATION | SAMPLES |     AVG VALUE      |    95% CONFIDENCE INTERVAL     |
+-------------------+---------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+--------------------------------+
| 📊 Stream Results | netperf | TCP_STREAM | 1           | true         | false   | 8192         | false     | 30       | 3       | 4932.583333 (Mb/s) | 4928.856768-4936.309899 (Mb/s) |
| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | true         | false   | 8192         | false     | 30       | 3       | 4926.862507 (Mb/s) | 4923.951995-4929.773019 (Mb/s) |
| 📊 Stream Results | netperf | TCP_STREAM | 1           | false        | false   | 8192         | false     | 30       | 3       | 4930.953333 (Mb/s) | 4928.020122-4933.886545 (Mb/s) |
| 📊 Stream Results | iperf3  | TCP_STREAM | 1           | false        | false   | 8192         | false     | 30       | 3       | 4925.295787 (Mb/s) | 4920.424834-4930.166740 (Mb/s) |
+-------------------+---------+------------+-------------+--------------+---------+--------------+-----------+----------+---------+--------------------+--------------------------------+
```