### PR TITLE
Mutli Tolerancy comparison

### DIFF
--- a/utils/compare.sh
+++ b/utils/compare.sh
@@ -82,7 +82,7 @@ run_benchmark_comparison() {
 
         if [[ -n ${TOLERANCY_RULES_LIST} ]]; then
 
-          if [[ -z $CONFIG_LOC ]]; then
+          if [[ -z $TOLERANCE_LOC ]]; then
             SUB_TOLERANCY_RULES=benchmark-comparison/tolerancy-configs/${TOLERANCY_RULES_LIST[i]}
           else
             SUB_TOLERANCY_RULES=$TOLERANCE_LOC/${TOLERANCY_RULES_LIST[i]}

--- a/workloads/kube-burner/pod-latency-tolerancy-rules.yaml
+++ b/workloads/kube-burner/pod-latency-tolerancy-rules.yaml
@@ -1,0 +1,8 @@
+- json_path: ["metricName", "podLatencyQuantilesMeasurement", "quantileName", "ContainersReady", "avg(P99)"]
+  tolerancy: -25
+  # Maximum percentage of allowed failures
+  max_failures: 100
+- json_path: ["metricName", "podLatencyQuantilesMeasurement", "quantileName", "Ready", "avg(P99)"]
+  tolerancy: -25
+  # Maximum percentage of allowed failures
+  max_failures: 100

--- a/workloads/kube-burner/pod-latency-tolerancy-rules.yaml
+++ b/workloads/kube-burner/pod-latency-tolerancy-rules.yaml
@@ -1,4 +1,0 @@
-- json_path: ["metricName", "podLatencyQuantilesMeasurement", "quantileName", "*", "avg(P99)"]
-  tolerancy: -15
-  # Maximum percentage of allowed failures
-  max_failures: 25


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The current comparison code has an option to add multiple config files to generate a csv file. Want to be able to also specify multiple tolerancy comparison files to use when determining pass/fail of a test

I am also editing the pod latency tolerancy file that is in the kube-burner workload because the Initialized and PodScheduled latencies have been 0 a lot recently and it causes a divide by 0 error 

## Related Tickets & Documents

- Related Work [OCPQE-13796](https://issues.redhat.com/browse/OCPQE-13796)

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Comparing with baseline 

export COMPARISON_CONFIG="podLatency.json nodeMasters.json nodeWorkers.json etcd.json crio.json kubelet.json"
export TOLERANCY_RULES=pod-latency-tolerancy-rules.yaml master-tolerancy.yaml worker-tolerancy.yaml etcd-tolerancy.yaml crio-tolerancy.yaml kubelet-tolerancy.yaml

Tolerancy files are in my branch/fork: https://github.com/paigerube14/ocp-qe-perfscale-ci/tree/benchmark-comparison (need to continue to enhance these files with relevant data points) 
```
07-10 18:09:56.166  [1mMon Jul 10 22:09:56 UTC 2023 benchmark[0m
07-10 18:09:56.166  [1mMon Jul 10 22:09:56 UTC 2023 Installing touchstone[0m
07-10 18:10:10.981  openshift-sdn
07-10 18:10:10.981  final csv /tmp/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd/8773f78e-81aa-4c78-a940-6297c8ac44fd.csv
07-10 18:10:10.981  config /home/jenkins/ws/workspace/multibranch_benchmark-comparison/configs/podLatency.json
07-10 18:10:10.981  comparison output
07-10 18:10:10.981  [1mMon Jul 10 22:10:10 UTC 2023 Querying results[0m
07-10 18:10:10.981  [1mMon Jul 10 22:10:10 UTC 2023 Running: touchstone_compare --database elasticsearch -url https://ocp-qe:****@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/ -u 8773f78e-81aa-4c78-a940-6297c8ac44fd --config /tmp/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd/podLatency.json -o csv --output-file /home/jenkins/ws/workspace/multibranch_benchmark-comparison/e2e-benchmarking/utils/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd.csv[0m
07-10 18:10:12.645  [1mMon Jul 10 22:10:12 UTC 2023 compare result: 0[0m
07-10 18:10:12.645  [1mMon Jul 10 22:10:12 UTC 2023 python csv modifier[0m
07-10 18:10:13.204  config /home/jenkins/ws/workspace/multibranch_benchmark-comparison/configs/nodeMasters.json
07-10 18:10:13.204  comparison output
07-10 18:10:13.204  [1mMon Jul 10 22:10:13 UTC 2023 Querying results[0m
07-10 18:10:13.204  [1mMon Jul 10 22:10:13 UTC 2023 Running: touchstone_compare --database elasticsearch -url https://ocp-qe:****@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/ -u 8773f78e-81aa-4c78-a940-6297c8ac44fd --config /tmp/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd/nodeMasters.json -o csv --output-file /home/jenkins/ws/workspace/multibranch_benchmark-comparison/e2e-benchmarking/utils/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd.csv[0m
07-10 18:10:14.645  2023-07-10 22:10:14,379 - touchstone - ERROR - Error: Issue capturing results from elasticsearch using config {'filter': {'metricName.keyword': 'nodeMemoryUtilization-Masters'}, 'buckets': ['jobName.keyword'], 'aggregations': {'value': ['max']}}
07-10 18:10:14.646  [1mMon Jul 10 22:10:14 UTC 2023 compare result: 0[0m
07-10 18:10:14.646  [1mMon Jul 10 22:10:14 UTC 2023 python csv modifier[0m
07-10 18:10:15.301  config /home/jenkins/ws/workspace/multibranch_benchmark-comparison/configs/nodeWorkers.json
07-10 18:10:15.301  comparison output
07-10 18:10:15.301  [1mMon Jul 10 22:10:15 UTC 2023 Querying results[0m
07-10 18:10:15.301  [1mMon Jul 10 22:10:15 UTC 2023 Running: touchstone_compare --database elasticsearch -url https://ocp-qe:****@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/ -u 8773f78e-81aa-4c78-a940-6297c8ac44fd --config /tmp/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd/nodeWorkers.json -o csv --output-file /home/jenkins/ws/workspace/multibranch_benchmark-comparison/e2e-benchmarking/utils/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd.csv[0m
07-10 18:10:16.660  [1mMon Jul 10 22:10:16 UTC 2023 compare result: 0[0m
07-10 18:10:16.660  [1mMon Jul 10 22:10:16 UTC 2023 python csv modifier[0m
07-10 18:10:17.300  config /home/jenkins/ws/workspace/multibranch_benchmark-comparison/configs/etcd.json
07-10 18:10:17.300  comparison output
07-10 18:10:17.300  [1mMon Jul 10 22:10:17 UTC 2023 Querying results[0m
07-10 18:10:17.300  [1mMon Jul 10 22:10:17 UTC 2023 Running: touchstone_compare --database elasticsearch -url https://ocp-qe:****@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/ -u 8773f78e-81aa-4c78-a940-6297c8ac44fd --config /tmp/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd/etcd.json -o csv --output-file /home/jenkins/ws/workspace/multibranch_benchmark-comparison/e2e-benchmarking/utils/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd.csv[0m
07-10 18:10:18.748  [1mMon Jul 10 22:10:18 UTC 2023 compare result: 0[0m
07-10 18:10:18.748  [1mMon Jul 10 22:10:18 UTC 2023 python csv modifier[0m
07-10 18:10:19.307  config /home/jenkins/ws/workspace/multibranch_benchmark-comparison/configs/crio.json
07-10 18:10:19.307  comparison output
07-10 18:10:19.307  [1mMon Jul 10 22:10:19 UTC 2023 Querying results[0m
07-10 18:10:19.307  [1mMon Jul 10 22:10:19 UTC 2023 Running: touchstone_compare --database elasticsearch -url https://ocp-qe:****@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/ -u 8773f78e-81aa-4c78-a940-6297c8ac44fd --config /tmp/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd/crio.json -o csv --output-file /home/jenkins/ws/workspace/multibranch_benchmark-comparison/e2e-benchmarking/utils/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd.csv[0m
07-10 18:10:20.644  [1mMon Jul 10 22:10:20 UTC 2023 compare result: 0[0m
07-10 18:10:20.644  [1mMon Jul 10 22:10:20 UTC 2023 python csv modifier[0m
07-10 18:10:21.299  config /home/jenkins/ws/workspace/multibranch_benchmark-comparison/configs/kubelet.json
07-10 18:10:21.299  comparison output
07-10 18:10:21.299  [1mMon Jul 10 22:10:21 UTC 2023 Querying results[0m
07-10 18:10:21.299  [1mMon Jul 10 22:10:21 UTC 2023 Running: touchstone_compare --database elasticsearch -url https://ocp-qe:****@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com/ -u 8773f78e-81aa-4c78-a940-6297c8ac44fd --config /tmp/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd/kubelet.json -o csv --output-file /home/jenkins/ws/workspace/multibranch_benchmark-comparison/e2e-benchmarking/utils/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd.csv[0m
07-10 18:10:22.849  [1mMon Jul 10 22:10:22 UTC 2023 compare result: 0[0m
07-10 18:10:22.849  [1mMon Jul 10 22:10:22 UTC 2023 python csv modifier[0m
07-10 18:10:23.407  [1mMon Jul 10 22:10:23 UTC 2023 Installing requirements to generate spreadsheet[0m
07-10 18:10:26.660  WARNING: You are using pip version 21.1.3; however, version 23.1.2 is available.
07-10 18:10:26.660  You should consider upgrading via the '/tmp/tmp.XJVPOA8q1k/bin/python3 -m pip install --upgrade pip' command.
07-10 18:10:26.660  [1mMon Jul 10 22:10:26 UTC 2023 Sheetname: node-density-2023-07-10T22:10:26[0m
07-10 18:10:26.660  [1mMon Jul 10 22:10:26 UTC 2023 CSV: /tmp/node-density-8773f78e-81aa-4c78-a940-6297c8ac44fd/8773f78e-81aa-4c78-a940-6297c8ac44fd.csv[0m
07-10 18:10:26.660  [1mMon Jul 10 22:10:26 UTC 2023 Email: prubenda@redhat.com[0m
07-10 18:10:26.660  [1mMon Jul 10 22:10:26 UTC 2023 Service-account: /home/jenkins/ws/workspace/multibranch_benchmark-comparison/.gsheet.json[0m
07-10 18:10:36.579  ************** Google Spreadsheet link ---> https://docs.google.com/spreadsheets/d/1ypbL93fAQ8kySjUjAGN-SdKyAIDblNOiT_cnqpThBVo ***************
07-10 18:10:36.580  [1mMon Jul 10 22:10:35 UTC 2023 Removing touchstone[0m
```

