### PR TITLE
uuidgen only if not set

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -11,7 +11,7 @@ QPS=${QPS:-20}
 BURST=${BURST:-20}
 GC=${GC:-true}
 EXTRA_FLAGS=${EXTRA_FLAGS:-}
-UUID=$(uuidgen)
+UUID=${UUID:-$(uuidgen)}
 KUBE_DIR=${KUBE_DIR:-/tmp}
 
 download_binary(){


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Minor change, UUID set by the airflow job gets overridden by this so logs have 2 different IDs, changed it to generate only if not set by the user. 

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
