### PR TITLE
Use latest version of kube-burner as default but allow to select a fixed one

### DIFF
--- a/workloads/baseline-performance/README.md
+++ b/workloads/baseline-performance/README.md
@@ -9,7 +9,7 @@ These environment variables can be customized
 
 | Variable         | Description                         | Default |
 |------------------|-------------------------------------|---------|
-| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz` |
+| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location, or **latest** to download last version available | latest |
 | **WATCH_TIME**              | Sleep duration for which metrics will be collected in minutes| 30 |
 | **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
 | **ES_SERVER**        | ElasticSearch endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|

--- a/workloads/baseline-performance/baseline_perf.sh
+++ b/workloads/baseline-performance/baseline_perf.sh
@@ -8,7 +8,10 @@ log "Sleeping for ${WATCH_TIME}M "
 sleep ${WATCH_TIME}m 
 end_time=`date +%s`
 log "Running kube-burner index to measure  the performance of the cluster over the past ${WATCH_TIME}M"
-  
+ 
+if [ ${KUBE_BURNER_RELEASE_URL} == "latest" ] ; then
+  KUBE_BURNER_RELEASE_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
+fi
 curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz
 
 ./kube-burner index -c baseline_perf.yml --uuid=${UUID} -u=${PROM_URL} --job-name baseline-performance-workload --token=${PROM_TOKEN} -m=metrics.yaml --start ${start_time} --end ${end_time}

--- a/workloads/baseline-performance/common.sh
+++ b/workloads/baseline-performance/common.sh
@@ -3,7 +3,7 @@ source ../../utils/common.sh
 
 openshift_login
 
-export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.14.2/kube-burner-0.14.2-Linux-x86_64.tar.gz}
+export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-latest}
 
 export ENABLE_INDEXING=${ENABLE_INDEXING:-true}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}

--- a/workloads/prometheus-sizing/README.md
+++ b/workloads/prometheus-sizing/README.md
@@ -14,7 +14,7 @@ These environment variables can be customized in both scenarios
 
 | Variable         | Description                         | Default |
 |------------------|-------------------------------------|---------|
-| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz` |
+| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location, or **latest** to download last version available | latest |
 | **QPS**              | Kube-burner's QPS                     | 40 |
 | **BURST**              | Kube-burner's Burst rate            | 40 |
 | **CLEANUP_WHEN_FINISH** | Delete workload's namespaces after running it | false |

--- a/workloads/prometheus-sizing/common.sh
+++ b/workloads/prometheus-sizing/common.sh
@@ -39,6 +39,10 @@ get_pods_per_namespace(){
 run_test(){
   log "Running kube-burner using config ${1} and metrics ${METRICS}"
   export POD_REPLICAS
+
+  if [ ${KUBE_BURNER_RELEASE_URL} == "latest" ] ; then
+    KUBE_BURNER_RELEASE_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
+  fi
   curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz
   ./kube-burner init -c ${1} --uuid=${UUID} -u=${PROM_URL} --token=${PROM_TOKEN} -m="${METRICS}"
   if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then

--- a/workloads/prometheus-sizing/env.sh
+++ b/workloads/prometheus-sizing/env.sh
@@ -1,5 +1,5 @@
 
-export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz}
+export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-latest}
 export QPS=${QPS:-40}
 export BURST=${BURSTS:-40}
 export CLEANUP_WHEN_FINISH=${CLEANUP_WHEN_FINISH:-true}

--- a/workloads/router-perf-v2/README.md
+++ b/workloads/router-perf-v2/README.md
@@ -42,7 +42,7 @@ It's possible to tune the default configuration through environment variables. T
 | TERMINATIONS          | List of HTTP terminations to test | `http edge passthrough reencrypt mix` |
 | URL_PATH              | URL path to use in the benchmark | `/1024.html` |
 | KEEPALIVE_REQUESTS    | List with the number of keep alive requests to perform in the same HTTP session | `0 1 50` |
-| KUBE_BURNER_RELEASE_URL    | Kube-burner binary URL | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16/kube-burner-0.16-Linux-x86_64.tar.gz` |
+| KUBE_BURNER_RELEASE_URL | kube-burner tarball release location, or **latest** to download last version available | latest |
 | LARGE_SCALE_THRESHOLD | Number of worker nodes required to consider a large scale scenario | `24` |
 | SMALL_SCALE_ROUTES    | Number of routes of each termination to create in the small scale scenario | `100` |
 | SMALL_SCALE_CLIENTS   | Threads/route to use in the small scale scenario | `1 40 200` |

--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -46,6 +46,9 @@ deploy_infra(){
   fi
 
   log "Downloading and extracting kube-burner binary"
+  if [ ${KUBE_BURNER_RELEASE_URL} == "latest" ] ; then
+    KUBE_BURNER_RELEASE_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
+  fi
   curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz kube-burner
   ./kube-burner init -c http-perf.yml --uuid=${UUID}
 

--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -10,7 +10,7 @@ export ES_INDEX=${ES_INDEX:-router-test-results}
 NUM_NODES=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!= --no-headers | grep -cw Ready)
 LARGE_SCALE_THRESHOLD=${LARGE_SCALE_THRESHOLD:-24}
 METADATA_COLLECTION=${METADATA_COLLECTION:-true}
-KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16.2/kube-burner-0.16.2-Linux-x86_64.tar.gz}
+KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-latest}
 KUBE_BURNER_IMAGE=quay.io/cloud-bulldozer/kube-burner:latest
 #HAPROXY_IMAGE="quay.io/cloud-bulldozer/openshift-router-perfscale:-haproxy-v2.2.20"
 #INGRESS_OPERATOR_IMAGE="quay.io/cloud-bulldozer/openshift-cluster-ingress-operator:balance-random"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

By default, use always last version of kube-burner downloading latest from github release.
But, if anytime we need to select an specific version, current variable **KUBE_BURNER_RELEASE_URL** is still available in the same way that we were using until now

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
