### PR TITLE
Defaulting kube-burner version to latest

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -4,7 +4,7 @@ set -e
 
 ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
 LOG_LEVEL=${LOG_LEVEL:-info}
-KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-1.7.3}
+KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-latest}
 CHURN=${CHURN:-true}
 WORKLOAD=${WORKLOAD:?}
 QPS=${QPS:-20}
@@ -15,7 +15,11 @@ UUID=${UUID:-$(uuidgen)}
 KUBE_DIR=${KUBE_DIR:-/tmp}
 
 download_binary(){
-  KUBE_BURNER_URL=https://github.com/cloud-bulldozer/kube-burner/releases/download/v${KUBE_BURNER_VERSION}/kube-burner-V${KUBE_BURNER_VERSION}-linux-x86_64.tar.gz
+  if [ ${KUBE_BURNER_VERSION} == "latest" ] ; then
+    KUBE_BURNER_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
+  else
+    KUBE_BURNER_URL=https://github.com/cloud-bulldozer/kube-burner/releases/download/v${KUBE_BURNER_VERSION}/kube-burner-V${KUBE_BURNER_VERSION}-linux-x86_64.tar.gz
+  fi
   curl -sS -L ${KUBE_BURNER_URL} | tar -xzC ${KUBE_DIR}/ kube-burner
 }
 

--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -46,7 +46,7 @@ Workloads can be tweaked with the following environment variables:
 | **CLEANUP**          | Delete old namespaces for the selected workload before starting benchmark | true |
 | **CLEANUP_WHEN_FINISH** | Delete benchmark objects and workload's namespaces after running it | false |
 | **CLEANUP_TIMEOUT**  | Timeout value used in resource deletion | 30m |
-| **KUBE_BURNER_URL** | Kube-burner tarball URL | https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.3/kube-burner-0.17.3-Linux-x86_64.tar.gz |
+| **KUBE_BURNER_URL** | kube-burner tarball release location, or **latest** to download last version available | latest |
 | **BUILD_FROM_REPO** | Rather than downloading the previous tarball, build the kube-burner binary using a specific git repository.  Ex. https://github.com/rsevilla87/kube-burner | "" (Disabled) |
 | **LOG_LEVEL**        | Kube-burner log level | info |
 | **PPROF_COLLECTION** | Collect and store pprof data locally | false |

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -65,7 +65,10 @@ run_workload() {
     mv ${KUBE_BURNER_DIR}/bin/amd64/kube-burner ${KUBE_DIR}/kube-burner
     rm -rf ${KUBE_BURNER_DIR}
   else
-    curl -sS -L ${KUBE_BURNER_URL} | tar -xzC ${KUBE_DIR}/ kube-burner
+    if [ ${KUBE_BURNER_URL} == "latest" ] ; then
+      KUBE_BURNER_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
+    fi
+    curl -sS -L ${KUBE_BURNER_URL} | tar -xzC ${KUBE_DIR}/kube-burner
   fi
   CMD="timeout ${JOB_TIMEOUT} ${KUBE_DIR}/kube-burner init --uuid=${UUID} -c $(basename ${WORKLOAD_TEMPLATE}) --log-level=${LOG_LEVEL}"
   # When metrics or alerting are enabled we have to pass the prometheus URL to the cmd

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -27,7 +27,7 @@ export PRELOAD_IMAGES=${PRELOAD_IMAGES:-true}
 export PRELOAD_PERIOD=${PRELOAD_PERIOD:-2m}
 
 # Kube-burner benchmark
-export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.3/kube-burner-0.17.3-Linux-x86_64.tar.gz"}
+export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"latest"}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-4h}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export METRICS_PROFILE=${METRICS_PROFILE}


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Defaulting latest version of kube-burner along with an option to specify a version. Similar to this [change](https://github.com/cloud-bulldozer/e2e-benchmarking/pull/603).

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested and verified in self managed cluster.
```
[vchalla@vchalla kube-burner-ocp-wrapper]$ KUBE_BURNER_VERSION=latest WORKLOAD=node-density ./run.sh 
/tmp/kube-burner ocp node-density --log-level=info --qps=20 --burst=20 --gc=true --uuid c8963dd0-423d-48f4-a26b-de5b6eb01461 --es-server=https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com --es-index=ripsaw-kube-burner
time="2023-08-06 16:58:58" level=info msg="File node-density.yml available in the current directory, using it" file="helpers.go:177"
time="2023-08-06 16:58:58" level=info msg="📁 Creating indexer: elastic" file="helpers.go:185"
time="2023-08-06 16:58:59" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.vchalla-clair-test-8.perfscale.devcluster.openshift.com" file="prometheus.go:43"
time="2023-08-06 16:58:59" level=info msg="🔔 Initializing alert manager for prometheus: https://prometheus-k8s-openshift-monitoring.apps.vchalla-clair-test-8.perfscale.devcluster.openshift.com" file="alert_manager.go:83"
time="2023-08-06 16:58:59" level=info msg="🔥 Starting kube-burner (1.7.4@48ea78c3b0323298a31a2a92d2587b05afe5122e) with UUID c8963dd0-423d-48f4-a26b-de5b6eb01461" file="job.go:83"
time="2023-08-06 16:58:59" level=info msg="📈 Creating measurement factory" file="factory.go:51"
time="2023-08-06 16:58:59" level=info msg="Registered measurement: podLatency" file="factory.go:83"
time="2023-08-06 16:58:59" level=info msg="Job node-density: 10 iterations with 1 Pod replicas" file="create.go:87"
time="2023-08-06 16:58:59" level=info msg="QPS: 20" file="job.go:93"
time="2023-08-06 16:58:59" level=info msg="Burst: 20" file="job.go:94"
time="2023-08-06 16:58:59" level=info msg="Pre-load: images from job node-density" file="pre_load.go:45"
time="2023-08-06 16:58:59" level=info msg="Pre-load: Creating DaemonSet using images [registry.k8s.io/pause:3.1] in namespace preload-kube-burner" file="pre_load.go:152"
time="2023-08-06 16:58:59" level=info msg="Pre-load: Sleeping for 10s" file="pre_load.go:58"
time="2023-08-06 16:59:09" level=info msg="Pre-load: Deleting namespace preload-kube-burner" file="pre_load.go:60"
time="2023-08-06 16:59:09" level=info msg="Deleting namespaces with label kube-burner-preload=true" file="namespaces.go:60"
time="2023-08-06 16:59:10" level=info msg="Waiting for namespaces to be definitely deleted" file="namespaces.go:78"
time="2023-08-06 16:59:16" level=info msg="Triggering job: node-density" file="job.go:109"
time="2023-08-06 16:59:16" level=info msg="Creating Pod latency watcher for node-density" file="pod_latency.go:141"
time="2023-08-06 16:59:17" level=info msg="Running job node-density" file="create.go:102"
time="2023-08-06 16:59:17" level=info msg="1/10 iterations completed" file="create.go:119"
```