### PR TITLE
Marking perf_scale_ci index as hardcoded value for CI data

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -133,9 +133,7 @@ if [[ -z $ES_SERVER ]]; then
   exit 1
 fi
 
-if [[ -z $ES_INDEX ]]; then
-  export ES_INDEX=perf_scale_ci
-fi
+ES_INDEX=perf_scale_ci
 
 setup
 index_tasks


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Keeping a single index for CI related runs to avoid further mapping issues. And also to keep them separate envisioning our dash-boarding work.

## Related Tickets & Documents

- Related Issue #
- Closes # https://github.com/cloud-bulldozer/e2e-benchmarking/issues/605

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested on my local dev environment.
