### PR TITLE
Deprecate legacy kube-burner workload

### DIFF
--- a/ci/CI_test_list.yml
+++ b/ci/CI_test_list.yml
@@ -2,10 +2,4 @@ router-perf-v2:./ingress-performance.sh
 etcd-perf:./run_etcd_tests_fromgit.sh 
 scale-perf:./run_scale_fromgit.sh 
 network-perf:GEN_CSV=false ./run.sh
-kube-burner:WORKLOAD=cluster-density ./run.sh
-kube-burner:WORKLOAD=node-density ./run.sh
-kube-burner:WORKLOAD=node-density-heavy ./run.sh
-kube-burner:WORKLOAD=pod-density-heavy ./run.sh
-kube-burner:WORKLOAD=max-services ./run.sh
-kube-burner:WORKLOAD=max-namespaces ./run.sh
 upgrade-perf:./run_upgrade_fromgit.sh 

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -7,18 +7,6 @@ export NEW_WORKER_COUNT=$((ORIGINAL_WORKER_COUNT + 1))
 export SCALE=$NEW_WORKER_COUNT
 export RUNS=2
 
-# For kube burner 
-export JOB_ITERATIONS=1
-export NAMESPACE_COUNT=1
-export SERVICE_COUNT=1
-export CLEANUP=true
-export CLEANUP_WHEN_FINISH=true
-export NODE_COUNT=1
-export PODS_PER_NODE=100
-export PODS=50
-export POD_READY_THRESHOLD=1m
-export ALERTS_PROFILE=alerts-profiles/ci.yml
-
 # For upgrade perf
 export TOVERSION=`oc get clusterversion | grep -o [0-9.]* | head -1`
 

--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -1,3 +1,9 @@
+# Deprecation notice
+
+### The workloads and scripts in this directory are not actively maintained or supported and shouldn't be used anymore, use [kube-burner-ocp-wrapper](../kube-burner-ocp-wrapper) instead.
+
+---
+
 # Kube-burner e2e benchmarks
 
 In order to kick off one of these benchmarks you must use the run.sh script. There are 13 different workloads at the moment, that could be launched as follows:


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Deprecation
- [ ] Documentation Update

## Description

The workload's on this directory shouldn't be used anymore, people should use https://github.com/cloud-bulldozer/e2e-benchmarking/tree/master/workloads/kube-burner-ocp-wrapper going forward.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
