### PR TITLE
json error if missing, added `--ignore-not-found`

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -37,13 +37,13 @@ setup(){
         cluster_type="self-managed"
     fi
 
-    masters=$(oc get nodes -l node-role.kubernetes.io/master --no-headers=true | wc -l) || true
-    workers=$(oc get nodes -l node-role.kubernetes.io/worker --no-headers=true | wc -l) || true
-    infra=$(oc get nodes -l node-role.kubernetes.io/infra --no-headers=true | wc -l) || true
-    worker_type=$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[].metadata.labels.beta\.kubernetes\.io/instance-type}') || true
-    infra_type=$(oc get nodes -l node-role.kubernetes.io/infra -o jsonpath='{.items[].metadata.labels.beta\.kubernetes\.io/instance-type}') || true
-    master_type=$(oc get nodes -l node-role.kubernetes.io/master -o jsonpath='{.items[].metadata.labels.beta\.kubernetes\.io/instance-type}') || true
-    all=$(oc get nodes  --no-headers=true | wc -l) || true
+    masters=$(oc get nodes --ignore-not-found -l node-role.kubernetes.io/master --no-headers=true | wc -l) || true
+    workers=$(oc get nodes --ignore-not-found -l node-role.kubernetes.io/worker --no-headers=true | wc -l) || true
+    infra=$(oc get nodes --ignore-not-found -l node-role.kubernetes.io/infra --no-headers=true | wc -l) || true
+    worker_type=$(oc get nodes --ignore-not-found -l node-role.kubernetes.io/worker -o jsonpath='{.items[].metadata.labels.beta\.kubernetes\.io/instance-type}') || true
+    infra_type=$(oc get nodes --ignore-not-found -l node-role.kubernetes.io/infra -o jsonpath='{.items[].metadata.labels.beta\.kubernetes\.io/instance-type}') || true
+    master_type=$(oc get nodes --ignore-not-found -l node-role.kubernetes.io/master -o jsonpath='{.items[].metadata.labels.beta\.kubernetes\.io/instance-type}') || true
+    all=$(oc get nodes  --ignore-not-found --no-headers=true | wc -l) || true
 }
 
 index_task(){


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
on Hosted cluster jobs, json exception due to missing master nodes

```
oc get nodes -l node-role.kubernetes.io/master -o 'jsonpath={.items[].metadata.labels.beta\.kubernetes\.io/instance-type}'
error: error executing jsonpath "{.items[].metadata.labels.beta\\.kubernetes\\.io/instance-type}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
	template was:
		{.items[].metadata.labels.beta\.kubernetes\.io/instance-type}
	object given to jsonpath engine was:
		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":""}}
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
