### PR TITLE
create ns only if not exists already

### DIFF
--- a/workloads/network-perf-v2/run.sh
+++ b/workloads/network-perf-v2/run.sh
@@ -7,8 +7,11 @@ source ../../utils/common.sh
 curl -sS -L $NETPERF_URL | tar -xz
 
 # Assuming kubeconfig is set
-oc create ns netperf
-oc create sa netperf -n netperf
+if [[ "$(oc get ns netperf --no-headers --ignore-not-found)" == ""  ]]; then
+  oc create ns netperf
+  oc create sa netperf -n netperf
+fi
+
 oc adm policy add-scc-to-user hostnetwork -z netperf -n netperf
 
 log "###############################################"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

oc create ns fails if it already exists

```
 ./run.sh
Error from server (AlreadyExists): namespaces "netperf" already exists
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
