### PR TITLE
Use the existing UUID if already passed in ingress-perf

### DIFF
--- a/workloads/ingress-perf/run.sh
+++ b/workloads/ingress-perf/run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-UUID=$(uuidgen)
+UUID=${UUID:-$(uuidgen)}
 ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
 ES_INDEX=${ES_INDEX:-ingress-performance}
 WORKLOAD=${WORKLOAD:-ingress-perf}


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

PR to fix PROW indexing as we have different UUIDs for benchmark run and the indexing task.

Example run: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.13-nightly-perfscale-rosa-multiaz-data-path-defaultnodes-periodic/1693518550561460224/artifacts/perfscale-rosa-multiaz-data-path-defaultnodes-periodic/openshift-qe-ingress-perf/build-log.txt

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested on local environment as it is a one liner change.
