### PR TITLE
Revert "Defaulting kube-burner version to latest

### DIFF
--- a/workloads/baseline-performance/README.md
+++ b/workloads/baseline-performance/README.md
@@ -9,7 +9,7 @@ These environment variables can be customized
 
 | Variable         | Description                         | Default |
 |------------------|-------------------------------------|---------|
-| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz` |
+| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.14.2/kube-burner-0.14.2-Linux-x86_64.tar.gz` |
 | **WATCH_TIME**              | Sleep duration for which metrics will be collected in minutes| 30 |
 | **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
 | **ES_SERVER**        | ElasticSearch endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|

--- a/workloads/baseline-performance/README.md
+++ b/workloads/baseline-performance/README.md
@@ -9,7 +9,7 @@ These environment variables can be customized
 
 | Variable         | Description                         | Default |
 |------------------|-------------------------------------|---------|
-| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location, or **latest** to download last version available | latest |
+| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz` |
 | **WATCH_TIME**              | Sleep duration for which metrics will be collected in minutes| 30 |
 | **ENABLE_INDEXING**  | Enable/disable ES indexing      | true |
 | **ES_SERVER**        | ElasticSearch endpoint         | https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443|

--- a/workloads/baseline-performance/baseline_perf.sh
+++ b/workloads/baseline-performance/baseline_perf.sh
@@ -8,10 +8,7 @@ log "Sleeping for ${WATCH_TIME}M "
 sleep ${WATCH_TIME}m 
 end_time=`date +%s`
 log "Running kube-burner index to measure  the performance of the cluster over the past ${WATCH_TIME}M"
- 
-if [ ${KUBE_BURNER_RELEASE_URL} == "latest" ] ; then
-  KUBE_BURNER_RELEASE_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
-fi
+  
 curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz
 
 ./kube-burner index -c baseline_perf.yml --uuid=${UUID} -u=${PROM_URL} --job-name baseline-performance-workload --token=${PROM_TOKEN} -m=metrics.yaml --start ${start_time} --end ${end_time}

--- a/workloads/baseline-performance/common.sh
+++ b/workloads/baseline-performance/common.sh
@@ -3,7 +3,7 @@ source ../../utils/common.sh
 
 openshift_login
 
-export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-latest}
+export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.14.2/kube-burner-0.14.2-Linux-x86_64.tar.gz}
 
 export ENABLE_INDEXING=${ENABLE_INDEXING:-true}
 export ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com:443}

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -4,7 +4,7 @@ set -e
 
 ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
 LOG_LEVEL=${LOG_LEVEL:-info}
-KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-latest}
+KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-1.7.6}
 CHURN=${CHURN:-true}
 WORKLOAD=${WORKLOAD:?}
 QPS=${QPS:-20}
@@ -15,11 +15,7 @@ UUID=${UUID:-$(uuidgen)}
 KUBE_DIR=${KUBE_DIR:-/tmp}
 
 download_binary(){
-  if [ ${KUBE_BURNER_VERSION} == "latest" ] ; then
-    KUBE_BURNER_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
-  else
-    KUBE_BURNER_URL=https://github.com/cloud-bulldozer/kube-burner/releases/download/v${KUBE_BURNER_VERSION}/kube-burner-V${KUBE_BURNER_VERSION}-linux-x86_64.tar.gz
-  fi
+  KUBE_BURNER_URL=https://github.com/cloud-bulldozer/kube-burner/releases/download/v${KUBE_BURNER_VERSION}/kube-burner-V${KUBE_BURNER_VERSION}-linux-x86_64.tar.gz
   curl -sS -L ${KUBE_BURNER_URL} | tar -xzC ${KUBE_DIR}/ kube-burner
 }
 

--- a/workloads/kube-burner/README.md
+++ b/workloads/kube-burner/README.md
@@ -46,7 +46,7 @@ Workloads can be tweaked with the following environment variables:
 | **CLEANUP**          | Delete old namespaces for the selected workload before starting benchmark | true |
 | **CLEANUP_WHEN_FINISH** | Delete benchmark objects and workload's namespaces after running it | false |
 | **CLEANUP_TIMEOUT**  | Timeout value used in resource deletion | 30m |
-| **KUBE_BURNER_URL** | kube-burner tarball release location, or **latest** to download last version available | latest |
+| **KUBE_BURNER_URL** | Kube-burner tarball URL | https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.3/kube-burner-0.17.3-Linux-x86_64.tar.gz |
 | **BUILD_FROM_REPO** | Rather than downloading the previous tarball, build the kube-burner binary using a specific git repository.  Ex. https://github.com/rsevilla87/kube-burner | "" (Disabled) |
 | **LOG_LEVEL**        | Kube-burner log level | info |
 | **PPROF_COLLECTION** | Collect and store pprof data locally | false |

--- a/workloads/kube-burner/common.sh
+++ b/workloads/kube-burner/common.sh
@@ -65,9 +65,6 @@ run_workload() {
     mv ${KUBE_BURNER_DIR}/bin/amd64/kube-burner ${KUBE_DIR}/kube-burner
     rm -rf ${KUBE_BURNER_DIR}
   else
-    if [ ${KUBE_BURNER_URL} == "latest" ] ; then
-      KUBE_BURNER_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
-    fi
     curl -sS -L ${KUBE_BURNER_URL} | tar -xzC ${KUBE_DIR}/ kube-burner
   fi
   CMD="timeout ${JOB_TIMEOUT} ${KUBE_DIR}/kube-burner init --uuid=${UUID} -c $(basename ${WORKLOAD_TEMPLATE}) --log-level=${LOG_LEVEL}"

--- a/workloads/kube-burner/env.sh
+++ b/workloads/kube-burner/env.sh
@@ -27,7 +27,7 @@ export PRELOAD_IMAGES=${PRELOAD_IMAGES:-true}
 export PRELOAD_PERIOD=${PRELOAD_PERIOD:-2m}
 
 # Kube-burner benchmark
-export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"latest"}
+export KUBE_BURNER_URL=${KUBE_BURNER_URL:-"https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.17.3/kube-burner-0.17.3-Linux-x86_64.tar.gz"}
 export JOB_TIMEOUT=${JOB_TIMEOUT:-4h}
 export NODE_SELECTOR=${NODE_SELECTOR:-'{node-role.kubernetes.io/worker: }'}
 export METRICS_PROFILE=${METRICS_PROFILE}

--- a/workloads/prometheus-sizing/README.md
+++ b/workloads/prometheus-sizing/README.md
@@ -14,7 +14,7 @@ These environment variables can be customized in both scenarios
 
 | Variable         | Description                         | Default |
 |------------------|-------------------------------------|---------|
-| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location, or **latest** to download last version available | latest |
+| **KUBE_BURNER_RELEASE_URL** | kube-burner tarball release location | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz` |
 | **QPS**              | Kube-burner's QPS                     | 40 |
 | **BURST**              | Kube-burner's Burst rate            | 40 |
 | **CLEANUP_WHEN_FINISH** | Delete workload's namespaces after running it | false |

--- a/workloads/prometheus-sizing/common.sh
+++ b/workloads/prometheus-sizing/common.sh
@@ -39,10 +39,6 @@ get_pods_per_namespace(){
 run_test(){
   log "Running kube-burner using config ${1} and metrics ${METRICS}"
   export POD_REPLICAS
-
-  if [ ${KUBE_BURNER_RELEASE_URL} == "latest" ] ; then
-    KUBE_BURNER_RELEASE_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
-  fi
   curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz
   ./kube-burner init -c ${1} --uuid=${UUID} -u=${PROM_URL} --token=${PROM_TOKEN} -m="${METRICS}"
   if [[ ${CLEANUP_WHEN_FINISH} == "true" ]]; then

--- a/workloads/prometheus-sizing/env.sh
+++ b/workloads/prometheus-sizing/env.sh
@@ -1,5 +1,5 @@
 
-export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-latest}
+export KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.9.1/kube-burner-0.9.1-Linux-x86_64.tar.gz}
 export QPS=${QPS:-40}
 export BURST=${BURSTS:-40}
 export CLEANUP_WHEN_FINISH=${CLEANUP_WHEN_FINISH:-true}

--- a/workloads/router-perf-v2/README.md
+++ b/workloads/router-perf-v2/README.md
@@ -42,7 +42,7 @@ It's possible to tune the default configuration through environment variables. T
 | TERMINATIONS          | List of HTTP terminations to test | `http edge passthrough reencrypt mix` |
 | URL_PATH              | URL path to use in the benchmark | `/1024.html` |
 | KEEPALIVE_REQUESTS    | List with the number of keep alive requests to perform in the same HTTP session | `0 1 50` |
-| KUBE_BURNER_RELEASE_URL | kube-burner tarball release location, or **latest** to download last version available | latest |
+| KUBE_BURNER_RELEASE_URL    | Kube-burner binary URL | `https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16/kube-burner-0.16-Linux-x86_64.tar.gz` |
 | LARGE_SCALE_THRESHOLD | Number of worker nodes required to consider a large scale scenario | `24` |
 | SMALL_SCALE_ROUTES    | Number of routes of each termination to create in the small scale scenario | `100` |
 | SMALL_SCALE_CLIENTS   | Threads/route to use in the small scale scenario | `1 40 200` |

--- a/workloads/router-perf-v2/common.sh
+++ b/workloads/router-perf-v2/common.sh
@@ -46,9 +46,6 @@ deploy_infra(){
   fi
 
   log "Downloading and extracting kube-burner binary"
-  if [ ${KUBE_BURNER_RELEASE_URL} == "latest" ] ; then
-    KUBE_BURNER_RELEASE_URL=$(curl -s https://api.github.com/repos/cloud-bulldozer/kube-burner/releases/latest | jq -r '.assets | map(select(.name | test("linux-x86_64"))) | .[0].browser_download_url')
-  fi
   curl -LsS ${KUBE_BURNER_RELEASE_URL} | tar xz kube-burner
   ./kube-burner init -c http-perf.yml --uuid=${UUID}
 

--- a/workloads/router-perf-v2/env.sh
+++ b/workloads/router-perf-v2/env.sh
@@ -10,7 +10,7 @@ export ES_INDEX=${ES_INDEX:-router-test-results}
 NUM_NODES=$(oc get node -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!= --no-headers | grep -cw Ready)
 LARGE_SCALE_THRESHOLD=${LARGE_SCALE_THRESHOLD:-24}
 METADATA_COLLECTION=${METADATA_COLLECTION:-true}
-KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-latest}
+KUBE_BURNER_RELEASE_URL=${KUBE_BURNER_RELEASE_URL:-https://github.com/cloud-bulldozer/kube-burner/releases/download/v0.16.2/kube-burner-0.16.2-Linux-x86_64.tar.gz}
 KUBE_BURNER_IMAGE=quay.io/cloud-bulldozer/kube-burner:latest
 #HAPROXY_IMAGE="quay.io/cloud-bulldozer/openshift-router-perfscale:-haproxy-v2.2.20"
 #INGRESS_OPERATOR_IMAGE="quay.io/cloud-bulldozer/openshift-cluster-ingress-operator:balance-random"


### PR DESCRIPTION
This reverts commit 3cd258cae8ac358788badd99da79055261a84870.

## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

I think we should revert these changes, I've reconsidered my thoughts for several reasons:

- Using a fixed kube-burner version guarantees backwards compatibility and should be generally more stable: A breaking change on kube-burner won't break any benchmark
- Better issue traceability: Identifying a bug should be easier, specially for CPT runs
- We should decide when and when not to bump the kube-burner version. i.e: Sometimes new releases just ship some bug fixes not affecting any of the functionality available within this repository. Continuously changing the kube-burner version without justification is not recommended and can be confusing when reviewing results

## Related Tickets & Documents

- Related Issue #619
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.