### PR TITLE
Fix disabling indexing

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ES_SERVER=${ES_SERVER:-https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
+ES_SERVER=${ES_SERVER=https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
 LOG_LEVEL=${LOG_LEVEL:-info}
 KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-1.7.8}
 CHURN=${CHURN:-true}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With the current shell parameter expansion used its not possible to disable indexing when ES_SERVER is set and null. Using the expansion expression ${parameter=word} fixed the issue. reference:

![image](https://github.com/cloud-bulldozer/e2e-benchmarking/assets/4614641/d7aebb76-1f6c-4d51-a2d3-db54a87da997)


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please provide detailed steps to perform tests related to this code change.
```shell
$ WORKLOAD=node-density ./run.sh 
/tmp/kube-burner ocp node-density --log-level=info --qps=20 --burst=20 --gc=true --uuid 7e2ada0b-593f-4c37-b2a3-e5e66b306e2e --es-server=https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com --es-index=ripsaw-kube-burner
etc.
$ ES_SERVER="" WORKLOAD=node-density ./run.sh 
/tmp/kube-burner ocp node-density --log-level=info --qps=20 --burst=20 --gc=true --uuid b621855a-cfb2-483a-9bb8-1f9c30586abe

```
