### PR TITLE
silencing debug errors for hcp

### DIFF
--- a/workloads/network-perf-v2/run.sh
+++ b/workloads/network-perf-v2/run.sh
@@ -32,7 +32,7 @@ echo "============ Debug Info ============"
 echo k8s-netperf version $NETPERF_VERSION
 oc get pods -n netperf -o wide
 oc get nodes -o wide
-oc get machineset -A
+oc get machineset -A || true
 
 log "Finished workload ${0} ${WORKLOAD}, exit code ($run)"
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

PROW hcp data-path [runs](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/44173/rehearse-44173-periodic-ci-openshift-qe-ocp-qe-perfscale-ci-main-rosa-4.13-nightly-x86-perfscale-rosa-hcp-3zones-data-path-9nodes-periodic/1712143864896163840) fail on this error
HCs don't have this resource.

```
error: the server doesn't have a resource type "machineset"
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
