### PR TITLE
Use workload script to call kube-burner index

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -98,7 +98,7 @@ EOF
 
 download_binary
 if [[ ${WORKLOAD} =~ "index" ]]; then
-  cmd="${KUBE_DIR}/kube-burner index --uuid=${UUID} --start=$START_TIME --end=$((END_TIME+600)) --log-level debug"
+  cmd="${KUBE_DIR}/kube-burner index --uuid=${UUID} --start=$START_TIME --end=$((END_TIME+600)) --log-level ${LOG_LEVEL}"
 else
   cmd="${KUBE_DIR}/kube-burner ocp ${WORKLOAD} --log-level=${LOG_LEVEL} --qps=${QPS} --burst=${BURST} --gc=${GC} --uuid ${UUID}"
   cmd+=" ${EXTRA_FLAGS}"

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -78,7 +78,7 @@ EOF
 
   if [[ ${WORKLOAD} =~ "index" ]]; then
     cat << EOF
-elapsed: "20m:"
+elapsed: "20m"
 EOF
   fi
   

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -77,9 +77,7 @@ MGMT_WORKER_NODES: ${MGMT_WORKER_NODES}
 EOF
 
   if [[ ${WORKLOAD} =~ "index" ]]; then
-    cat << EOF
-elapsed: "20m"
-EOF
+    export elapsed=20m
   fi
   
   echo "Indexing Management cluster stats before executing"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
For hypershift we use kube-burner index to scrape metrics during creation/deletions of clusters to record the MC perf, so instead of re-implementing these(multi-endpoint prep) in rosa-burner it would be easy to use the same script with a conditional tasks. 

WORKLOAD=index --> will only call kube-burner index for the given duration START_TIME & END_TIME

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
