### PR TITLE
Fixing noisy index.sh script

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -exo pipefail
+set -eo pipefail
 
 setup(){
     if [[ -n $AIRFLOW_CTX_DAG_ID ]]; then
@@ -85,7 +85,8 @@ index_task(){
         "timestamp":"'"$start_date"'"
         }'
     echo $json_data >> $uuid_dir/index_data.json
-    curl --insecure -X POST -H "Content-Type:application/json" -H "Cache-Control:no-cache" -d "$json_data" "$url"
+    echo "${json_data}"
+    curl -sS --insecure -X POST -H "Content-Type:application/json" -H "Cache-Control:no-cache" -d "$json_data" "$url"
     
 }
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

index.sh prints a lot of lines needlessly, which makes more difficult to find a relevant log line, let's try to keep a clean stdout. 
