### PR TITLE
Bump kube-burner version

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -4,7 +4,7 @@ set -e
 
 ES_SERVER=${ES_SERVER=https://search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com}
 LOG_LEVEL=${LOG_LEVEL:-info}
-KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-1.7.8}
+KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-1.7.10}
 CHURN=${CHURN:-true}
 WORKLOAD=${WORKLOAD:?}
 QPS=${QPS:-20}


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Details:
- https://github.com/cloud-bulldozer/kube-burner/releases/tag/v1.7.10
- https://github.com/cloud-bulldozer/kube-burner/releases/tag/v1.7.9

Highlights:
- Garbage collection metrics indexing (Disabled by default)
- Prometheus metrics now scrapes missing datapoints at the end of the workload
- New CPU metrics https://github.com/cloud-bulldozer/kube-burner/commit/8dd4df4f9966d357fb8ad478a86bade08d00bf0c
- Fixes the issue found at https://github.com/cloud-bulldozer/e2e-benchmarking/pull/638 (not working --metrics-profile)

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
