### PR TITLE
Decrease concurrency to 5 on router tests for rosa

### DIFF
--- a/workloads/ingress-perf/config/standard-classic-rosa.yml
+++ b/workloads/ingress-perf/config/standard-classic-rosa.yml
@@ -6,7 +6,7 @@
   samples: 5
   duration: 5m
   path: /1024.html
-  concurrency: 18
+  concurrency: 5
   tool: wrk
   serverReplicas: 45
   delay: 10s
@@ -17,7 +17,7 @@
   samples: 2
   duration: 5m
   path: /1024.html
-  concurrency: 18
+  concurrency: 5
   tool: wrk
   serverReplicas: 45
   delay: 10s
@@ -27,7 +27,7 @@
   samples: 2
   duration: 5m
   path: /1024.html
-  concurrency: 18
+  concurrency: 5
   tool: wrk
   serverReplicas: 45
   delay: 10s
@@ -37,7 +37,7 @@
   samples: 2
   duration: 5m
   path: /1024.html
-  concurrency: 18
+  concurrency: 5
   tool: wrk
   serverReplicas: 45
   delay: 10s
@@ -47,7 +47,7 @@
   samples: 2
   duration: 5m
   path: /1024.html
-  concurrency: 18
+  concurrency: 5
   tool: wrk
   serverReplicas: 45
   delay: 10s


### PR DESCRIPTION
Because of the size of the infra nodes when installing rosa, we need to decrease this parameter to 5