### PR TITLE
moved api latency queries to guest side

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/metrics-profiles/hosted-cluster-metrics.yml
+++ b/workloads/kube-burner-ocp-wrapper/metrics-profiles/hosted-cluster-metrics.yml
@@ -90,3 +90,17 @@
 
 - query: process_resident_memory_bytes{service="kubelet",job="crio"} and on (node) topk(5,max_over_time(irate(process_resident_memory_bytes{service="kubelet",job="crio"}[2m])[{{ .elapsed }}:]) and on (node) kube_node_role{role="worker"})
   metricName: crioMemory
+
+# API server
+
+- query: irate(apiserver_request_total{verb="POST", resource="pods", subresource="binding",code="201"}[2m]) > 0
+  metricName: schedulingThroughput
+
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{job="kube-apiserver", verb=~"LIST|GET", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
+  metricName: readOnlyAPICallsLatency
+
+- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{job="kube-apiserver", verb=~"POST|PUT|DELETE|PATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
+  metricName: mutatingAPICallsLatency
+
+- query: sum(irate(apiserver_request_total{job="kube-apiserver",verb!="WATCH"}[2m])) by (verb,resource,instance) > 0
+  metricName: APIRequestRate

--- a/workloads/kube-burner-ocp-wrapper/metrics-profiles/hosted-cp-metrics.yml
+++ b/workloads/kube-burner-ocp-wrapper/metrics-profiles/hosted-cp-metrics.yml
@@ -2,20 +2,6 @@
 # All these metrics should use the namespace=~".+{{.HCP_NAMESPACE}}" filter
 # Collected metrics about API, OVN, etcd and cluster_version provided by the CVO
 
-# API server
-
-- query: irate(apiserver_request_total{namespace=~".+{{.HCP_NAMESPACE}}", verb="POST", resource="pods", subresource="binding",code="201"}[2m]) > 0
-  metricName: schedulingThroughput
-
-- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{namespace=~".+{{.HCP_NAMESPACE}}", job="kube-apiserver", verb=~"LIST|GET", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
-  metricName: readOnlyAPICallsLatency
-
-- query: histogram_quantile(0.99, sum(irate(apiserver_request_duration_seconds_bucket{namespace=~".+{{.HCP_NAMESPACE}}", job="kube-apiserver", verb=~"POST|PUT|DELETE|PATCH", subresource!~"log|exec|portforward|attach|proxy"}[2m])) by (le, resource, verb, scope)) > 0
-  metricName: mutatingAPICallsLatency
-
-- query: sum(irate(apiserver_request_total{namespace=~".+{{.HCP_NAMESPACE}}", job="kube-apiserver",verb!="WATCH"}[2m])) by (verb,resource,instance) > 0
-  metricName: APIRequestRate
-
 # OVN service sync latency
 
 - query: histogram_quantile(0.99, sum(rate(ovnkube_master_network_programming_duration_seconds_bucket{namespace=~".+{{.HCP_NAMESPACE}}", kind="service"}[2m])) by (le))


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
API latency metrics scrapped by OBO are only for SRE alerting purpose, they are limited to collect only few buckets to save storage due to its volume.  But all KAPI metrics are forwarded to guest cluster side as well for user benefits, we should be able to scrape them from hosted cluster prometheus instance, so moving API latency metrics to hosted-cluster-metric profile will be the right approach for our reports.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
