### PR TITLE
Dropping ingress-perf runtime

### DIFF
--- a/workloads/ingress-perf/config/standard-classic-rosa.yml
+++ b/workloads/ingress-perf/config/standard-classic-rosa.yml
@@ -4,7 +4,7 @@
 - termination: http
   connections: 200
   samples: 5
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 5
   tool: wrk
@@ -16,7 +16,7 @@
 - termination: http
   connections: 200
   samples: 2
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 5
   tool: wrk
@@ -27,7 +27,7 @@
 - termination: edge
   connections: 200
   samples: 2
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 5
   tool: wrk
@@ -38,7 +38,7 @@
 - termination: reencrypt
   connections: 200
   samples: 2
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 5
   tool: wrk
@@ -49,7 +49,7 @@
 - termination: passthrough
   connections: 200
   samples: 2
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 5
   tool: wrk

--- a/workloads/ingress-perf/config/standard.yml
+++ b/workloads/ingress-perf/config/standard.yml
@@ -4,7 +4,7 @@
 - termination: http
   connections: 200
   samples: 5
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 18
   tool: wrk
@@ -17,7 +17,7 @@
 - termination: http
   connections: 200
   samples: 2
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 18
   tool: wrk
@@ -28,7 +28,7 @@
 - termination: edge
   connections: 200
   samples: 2
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 18
   tool: wrk
@@ -39,7 +39,7 @@
 - termination: reencrypt
   connections: 200
   samples: 2
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 18
   tool: wrk
@@ -50,7 +50,7 @@
 - termination: passthrough
   connections: 200
   samples: 2
-  duration: 5m
+  duration: 3m
   path: /1024.html
   concurrency: 18
   tool: wrk


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

We need to cut down the duration of some of our tests.

Ideally I'd like to drop it to 2m, but since it's collecting some prometheus metrics I think is better to collect couple of more datapoints (30s each) to get a better data quality.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
