### PR TITLE
Taking out all spaces in value publish

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -120,7 +120,7 @@ get_encryption_config(){
 
 get_publish_config(){
     publish="External"
-    if result=$(oc get cm cluster-config-v1 -n kube-system -o json | jq -r '.data."install-config"' | grep 'publish' | cut -d' ' -f2); then
+    if result=$(oc get cm cluster-config-v1 -n kube-system -o json | jq -r '.data."install-config"' | grep 'publish' | cut -d' ' -f2 | xargs ); then
         publish=$result
     fi
 }


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Sometimes when we are getting indexed details, the publish field has extra spaces and new lines in the front of the value that makes the elastic search post not succeed in posting.
I have seen this from time to time on both Prow and jenkins but only for the publish field specifically, I can add to other calls as well if wanted


Example: 
```
{
        "ciSystem":"PROW",
        "uuid":"3c484837-565c-4ba3-b483-dcb1d02d38e6",
        "releaseStream":"4.15.0-0.nightly",
        "platform":"Azure",
        "clusterType":"self-managed",
        "benchmark":"k8s-netperf",
        "masterNodesCount":3,
        "workerNodesCount":9,
        "infraNodesCount":3,
        "masterNodesType":"Standard_D8s_v3",
        "workerNodesType":"Standard_D4s_v3",
        "infraNodesType":"Standard_D16s_v3",
        "totalNodesCount":15,
        "clusterName":"ci-op-kqwvgvbh-c8ba2-pcstz",
        "ocpVersion":"4.15.0-0.nightly-2024-01-03-140457",
        "networkType":"OVNKubernetes",
        "buildTag":"1743136219115556864",
        "jobStatus":"success",
        "buildUrl":"https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/rehearse-45906-periodic-ci-openshift-qe-XXXXXX-perfscale-ci-main-azure-4.15-nightly-x86-data-path-9nodes/1743136219115556864",
        "upstreamJob":"rehearse-45906-periodic-ci-openshift-qe-XXXXXX-perfscale-ci-main-azure-4.15-nightly-x86-data-path-9nodes",
        "upstreamJobBuild":"0ee7163b-3577-4649-8c1d-5d6f2a362992",
        "executionDate":"2024-01-05T06:34:11Z",
        "jobDuration":"9566",
        "startDate":"2024-01-05T06:34:11Z",
        "endDate":"2024-01-05T09:13:37Z",
        "timestamp":"2024-01-05T06:34:11Z",
        "ipsec":"false",
        "fips":"false",
        "encrypted":"false",
        "encryptionType":"",
        "publish":"

External",
        "computeArch":"amd64",
        "controlPlaneArch":"amd64"
        }
{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"failed to parse field [publish] of type [text] in document with id 'rehearse-45906-periodic-ci-openshift-qe-XXXXXX-perfscale-ci-main-azure-4.15-nightly-x86-data-path-9nodes/0ee7163b-3577-4649-8c1d-5d6f2a362992/1743136219115556864/3c484837-565c-4ba3-b483-dcb1d02d38e6'. Preview of field's value: ''"}],"type":"mapper_parsing_exception","reason":"failed to parse field [publish] of type [text] in document with id 'rehearse-45906-periodic-ci-openshift-qe-XXXXXX-perfscale-ci-main-azure-4.15-nightly-x86-data-path-9nodes/0ee7163b-3577-4649-8c1d-5d6f2a362992/1743136219115556864/3c484837-565c-4ba3-b483-dcb1d02d38e6'. Preview of field's value: ''","caused_by":{"type":"json_parse_exception","reason":"Illegal unquoted character ((CTRL-CHAR, code 10)): has to be escaped using backslash to be included in string value\n at [Source: (byte[])\"{\n        \"ciSystem\":\"PROW\",\n        \"uuid\":\"3c484837-565c-4ba3-b483-dcb1d02d38e6\",\n        \"releaseStream\":\"4.15.0-0.nightly\",\n        \"platform\":\"Azure\",\n        \"clusterType\":\"self-managed\",\n        \"benchmark\":\"k8s-netperf\",\n        \"masterNodesCount\":3,\n        \"workerNodesCount\":9,\n        \"infraNodesCount\":3,\n        \"masterNodesType\":\"Standard_D8s_v3\",\n        \"workerNodesType\":\"Standard_D4s_v3\",\n        \"infraNodesType\":\"Standard_D16s_v3\",\n        \"totalNodesCount\":15,\n        \"clusterN\"[truncated 1030 bytes]; line: 32, column: 21]"}},"status":400}++ head -1
++ ls -t -d /tmp/3c484837-565c-4ba3-b483-dcb1d02d38e6/ /tmp/e2e-benchmarking/ /tmp/entrypoint-wrapper/ /tmp/secret/ /tmp/venv_qe/
+ folder_name=/tmp/3c484837-565c-4ba3-b483-dcb1d02d38e6/
+ cp /tmp/3c484837-565c-4ba3-b483-dcb1d02d38e6//index_data.json /tmp/secret/index_data.json
```


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


```
% publish="

External"
% echo $publish | xargs     
External
```