### PR TITLE
Add unix timestamps for start and end date to payload

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -143,6 +143,9 @@ index_task(){
     uuid_dir=/tmp/$UUID
     mkdir $uuid_dir
 
+    start_date_unix_timestamp=$(date "+%s" -d "${startDate}")
+    end_date_unix_timestamp=$(date "+%s" -d "${end_date}")
+
     json_data='{
         "ciSystem":"'$ci'",
         "uuid":"'$UUID'",
@@ -168,7 +171,9 @@ index_task(){
         "executionDate":"'$execution_date'",
         "jobDuration":"'$duration'",
         "startDate":"'"$start_date"'",
+        "startDateUnixTimestamp":"'"$start_date_unix_timestamp"'",
         "endDate":"'"$end_date"'",
+        "endDateUnixTimestamp":"'"$end_date_unix_timestamp"'",
         "timestamp":"'"$start_date"'",
         "ipsec":"'"$ipsec"'",
         "fips":"'"$fips"'",

--- a/utils/index.sh
+++ b/utils/index.sh
@@ -143,7 +143,7 @@ index_task(){
     uuid_dir=/tmp/$UUID
     mkdir $uuid_dir
 
-    start_date_unix_timestamp=$(date "+%s" -d "${startDate}")
+    start_date_unix_timestamp=$(date "+%s" -d "${start_date}")
     end_date_unix_timestamp=$(date "+%s" -d "${end_date}")
 
     json_data='{
@@ -171,8 +171,8 @@ index_task(){
         "executionDate":"'$execution_date'",
         "jobDuration":"'$duration'",
         "startDate":"'"$start_date"'",
-        "startDateUnixTimestamp":"'"$start_date_unix_timestamp"'",
         "endDate":"'"$end_date"'",
+        "startDateUnixTimestamp":"'"$start_date_unix_timestamp"'",
         "endDateUnixTimestamp":"'"$end_date_unix_timestamp"'",
         "timestamp":"'"$start_date"'",
         "ipsec":"'"$ipsec"'",


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

NetObserv needs UNIX timestamps for start and end dates for the [NOPE](https://github.com/openshift-qe/ocp-qe-perfscale-ci/blob/netobserv-perf-tests/scripts/nope.py) tool - previously we got them from Mr. Sandman but that functionality never made it over here

## Related Tickets & Documents

- Related Issue: [NETOBSERV-1449](https://issues.redhat.com/browse/NETOBSERV-1449)

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
To come
