### PR TITLE
PERFSCALE-2825: Add curl retry flags

### DIFF
--- a/workloads/ingress-perf/run.sh
+++ b/workloads/ingress-perf/run.sh
@@ -20,7 +20,7 @@ HARDWARE=$(uname -m)
 
 download_binary(){
   INGRESS_PERF_URL=https://github.com/cloud-bulldozer/ingress-perf/releases/download/v${INGRESS_PERF_VERSION}/ingress-perf-${OS}-v${INGRESS_PERF_VERSION}-${HARDWARE}.tar.gz
-  curl -sS -L ${INGRESS_PERF_URL} | tar xz ingress-perf
+  curl --fail --retry 8 --retry-all-errors -sS -L ${INGRESS_PERF_URL} | tar xz ingress-perf
 }
 
 download_binary

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -16,26 +16,10 @@ GC=${GC:-true}
 EXTRA_FLAGS=${EXTRA_FLAGS:-}
 UUID=${UUID:-$(uuidgen)}
 KUBE_DIR=${KUBE_DIR:-/tmp}
-MAX_RETRIES=3
-RETRY_DELAY=5
 
 download_binary(){
-  local retries=0
-  while [ $retries -lt $MAX_RETRIES ]; do
-    KUBE_BURNER_URL="https://github.com/kube-burner/kube-burner-ocp/releases/download/v${KUBE_BURNER_VERSION}/kube-burner-ocp-V${KUBE_BURNER_VERSION}-linux-x86_64.tar.gz"
-
-    if curl -sS -L "${KUBE_BURNER_URL}" | tar -xzC "${KUBE_DIR}/" kube-burner-ocp; then
-      echo "Download successful"
-      return 0
-    else
-      ((retries++))
-      echo "Download failed. Retrying (${retries}/$MAX_RETRIES) in $RETRY_DELAY seconds..."
-      sleep $RETRY_DELAY
-    fi
-  done
-
-  echo "Max retries reached. Unable to download the binary."
-  return 1
+  KUBE_BURNER_URL="https://github.com/kube-burner/kube-burner-ocp/releases/download/v${KUBE_BURNER_VERSION}/kube-burner-ocp-V${KUBE_BURNER_VERSION}-linux-x86_64.tar.gz"
+  curl --fail --retry 8 --retry-all-errors -sS -L "${KUBE_BURNER_URL}" | tar -xzC "${KUBE_DIR}/" kube-burner-ocp
 }
 
 hypershift(){

--- a/workloads/network-perf-v2/run.sh
+++ b/workloads/network-perf-v2/run.sh
@@ -7,7 +7,7 @@ source ../../utils/common.sh
 # Download k8s-netperf function
 download_netperf() {
   echo $1
-  curl -sS -L ${NETPERF_URL} | tar -xz
+  curl --fail --retry 8 --retry-all-errors -sS -L ${NETPERF_URL} | tar -xz
 }
 
 # Download and extract k8s-netperf if we haven't already


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When  curl  is  about to retry a transfer, it will first wait one second and then for all forthcoming retries it will double the waiting time until it reaches 10 minutes...
Regarding the `--retry-all-errors` flag, taken from the cURL docs

> By  default  curl will not error on an HTTP response code that indicates an HTTP error, if the transfer was successful. For example, if a server replies 404 Not Found and the reply is fully received then that is not an error. When --retry is used then curl will retry on some HTTP response codes that indicate transient HTTP errors, but that does not include most 4xx response codes such as 404. If you want  to  retry  on  all  response codes that indicate HTTP errors (4xx and 5xx) then combine with -f, --fail.

