### PR TITLE
Updating timestamp value to use current timestamp

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -148,6 +148,7 @@ index_task(){
 
     start_date_unix_timestamp=$(date "+%s" -d "${start_date}")
     end_date_unix_timestamp=$(date "+%s" -d "${end_date}")
+    current_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
     json_data='{
         "ciSystem":"'$ci'",
@@ -177,7 +178,7 @@ index_task(){
         "endDate":"'"$end_date"'",
         "startDateUnixTimestamp":"'"$start_date_unix_timestamp"'",
         "endDateUnixTimestamp":"'"$end_date_unix_timestamp"'",
-        "timestamp":"'"$start_date"'",
+        "timestamp":"'"$current_timestamp"'",
         "ipsec":"'"$ipsec"'",
         "ipsecMode":"'"$ipsecMode"'",
         "fips":"'"$fips"'",


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Previously timestamp field used to use the job start time. Updated it to use the current timestamp.

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested in local in a hacky way.
```
[vchalla@vchalla-thinkpadp1gen2 e2e-benchmarking]$ current_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
[vchalla@vchalla-thinkpadp1gen2 e2e-benchmarking]$ echo $current_timestamp
2024-04-15T18:21:00Z
```