### PR TITLE
Updating metrics-endpoint file to sync with latest kb changes

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/metrics-endpoint.yml
+++ b/workloads/kube-burner-ocp-wrapper/metrics-endpoint.yml
@@ -1,10 +1,30 @@
 - endpoint: {{.MC_OBO}}
-  profile: metrics-profiles/hosted-cp-metrics.yml
-  alertProfile: alerts-profiles/hosted-cp-alerts.yml
+  metrics:
+    - metrics-profiles/hosted-cp-metrics.yml
+  alerts:
+    - alerts-profiles/hosted-cp-alerts.yml
+  indexer:
+      esServers: ["{{.ES_SERVER}}"]
+      insecureSkipVerify: true
+      defaultIndex: {{.ES_INDEX}}
+      type: opensearch
 - endpoint: {{.MC_PROMETHEUS}}
   token: {{.MC_PROMETHEUS_TOKEN}}
-  profile: metrics-profiles/mc-metrics.yml
+  metrics:
+    - metrics-profiles/mc-metrics.yml
+  indexer:
+      esServers: ["{{.ES_SERVER}}"]
+      insecureSkipVerify: true
+      defaultIndex: {{.ES_INDEX}}
+      type: opensearch
 - endpoint: {{.HOSTED_PROMETHEUS}}
   token: {{.HOSTED_PROMETHEUS_TOKEN}}
-  profile: metrics-profiles/hosted-cluster-metrics.yml
-  alertProfile: alerts-profiles/hosted-cluster-alerts.yml
+  metrics:
+    - metrics-profiles/hosted-cluster-metrics.yml
+  alerts:
+    - alerts-profiles/hosted-cluster-alerts.yml
+  indexer:
+      esServers: ["{{.ES_SERVER}}"]
+      insecureSkipVerify: true
+      defaultIndex: {{.ES_INDEX}}
+      type: opensearch


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

Updating metrics-endpoint file to be in sync with latest kb changes.

## Testing
Tested in local
```
[vchalla@vchalla-thinkpadp1gen2 kube-burner-ocp]$ kube-burner-ocp cluster-density-v2 --log-level=info --qps=20 --burst=20 --gc=true --uuid 78cf9e75-1d7a-407f-98cc-a389e0ed4852 --gc-metrics=true --profile-type=reporting --gc-metrics=true --profile-type=reporting --iterations=1 --churn=true --es-server='https://ocp-qe:Perfscale24!@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com' --es-index=ripsaw-kube-burner --metrics-endpoint=metrics-endpoint.yml --log-level=debug
time="2024-05-10 16:00:44" level=info msg=metrics-endpoint.yml file="helpers.go:96"
time="2024-05-10 16:00:44" level=info msg="📁 Creating opensearch indexer: indexer-0" file="metrics.go:62"
time="2024-05-10 16:00:44" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="prometheus.go:47"
time="2024-05-10 16:00:45" level=info msg=../../e2e-benchmarking/workloads/kube-burner-ocp-wrapper/metrics-profiles/hosted-cluster-metrics.yml file="metrics.go:85"
time="2024-05-10 16:00:45" level=info msg="Embeded config doesn't contain metrics profile. Falling back to original path" file="prometheus.go:137"
time="2024-05-10 16:00:45" level=info msg="🔔 Initializing alert manager for prometheus: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="alert_manager.go:85"
time="2024-05-10 16:00:45" level=info msg="📁 Creating opensearch indexer: indexer-1" file="metrics.go:62"
time="2024-05-10 16:00:45" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="prometheus.go:47"
time="2024-05-10 16:00:45" level=info msg=metrics.yml file="metrics.go:85"
time="2024-05-10 16:00:45" level=info msg="📁 Creating opensearch indexer: indexer-2" file="metrics.go:62"
time="2024-05-10 16:00:46" level=info msg="👽 Initializing prometheus client with URL: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="prometheus.go:47"
time="2024-05-10 16:00:46" level=info msg=metrics.yml file="metrics.go:85"
time="2024-05-10 16:00:46" level=info msg="🔔 Initializing alert manager for prometheus: https://prometheus-k8s-openshift-monitoring.apps.ci-ln-05jz1tk-76ef8.origin-ci-int-aws.dev.rhcloud.com" file="alert_manager.go:85"
time="2024-05-10 16:00:46" level=info msg="🔥 Starting kube-burner (main@3f46dbfafc10ddc24d16ce840996c67ee989d4fa) with UUID 78cf9e75-1d7a-407f-98cc-a389e0ed4852" file="job.go:99"
time="2024-05-10 16:00:46" level=info msg="📈 Registered measurement: podLatency" file="factory.go:91"
```
