### PR TITLE
build url fix for rehearsel jobs

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -17,6 +17,7 @@ setup(){
     elif [[ -n $PROW_JOB_ID ]]; then
         export ci="PROW"
         export prow_base_url="https://prow.ci.openshift.org/view/gs/origin-ci-test/logs"
+        export prow_pr_base_url="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release"
     elif [[ -n $BUILD_ID ]]; then
         export ci="JENKINS"
         export build_url=${BUILD_URL}
@@ -233,7 +234,11 @@ index_tasks(){
         job_id=$JOB_NAME
         job_run_id=$PROW_JOB_ID
         state=$JOB_STATUS
-        build_url="${prow_base_url}/${job_id}/${task_id}"
+        if [[ "${JOB_TYPE}" == "presubmit" ]]; then
+            build_url="${prow_pr_base_url}/${PULL_NUMBER}/${job_id}/${task_id}"
+        else
+            build_url="${prow_base_url}/${job_id}/${task_id}"
+        fi
         execution_date=$JOB_START
         set_duration "$JOB_START" "$JOB_END"
         index_task "$ES_SERVER/$ES_INDEX/_doc/$job_id%2F$job_run_id%2F$task_id%2F$UUID"


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fixing build url for rehearsel jobs in prow. Currently its broken because it uses the same logic for both PRs and periodic jobs

## Related Tickets & Documents
Look at the build urls for any of the jobs [here](http://dashboard.apps.sailplane.perf.lab.eng.rdu2.redhat.com/ocp?ciSystem=All&platform=All&benchmark=All&version=All&workerCount=All&networkType=All&jobType=All&isRehearse=TRUE&ipsec=All&fips=All&encrypted=All&encryptionType=All&publish=All&computeArch=All&controlPlaneArch=All&startDate=2024-05-07&endDate=2024-05-12), they are broken. Wherein here they are working because they are [periodic jobs](http://dashboard.apps.sailplane.perf.lab.eng.rdu2.redhat.com/ocp?ciSystem=All&platform=All&benchmark=All&version=All&workerCount=All&networkType=All&jobType=All&isRehearse=FALSE&ipsec=All&fips=All&encrypted=All&encryptionType=All&publish=All&computeArch=All&controlPlaneArch=All&startDate=2024-05-07&endDate=2024-05-12).

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Will test and verify through a test job in this PR.
