### PR TITLE
Ingress-perf config for scalelab CPT jobs

### DIFF
--- a/workloads/ingress-perf/config/standard-scalelab.yml
+++ b/workloads/ingress-perf/config/standard-scalelab.yml
@@ -1,0 +1,60 @@
+# vi: expandtab shiftwidth=2 softtabstop=2
+
+# First scenario warm ups ingress controller caches, assigns the router pods to the infra nodes and increase the number of nb threads
+- termination: http
+  connections: 200
+  samples: 1
+  duration: 1m
+  path: /1024.html
+  concurrency: 18
+  tool: wrk
+  serverReplicas: 45
+  requestTimeout: 10s
+  tuningPatch: '{"spec":{"tuningOptions":{"threadCount": 64}, "nodePlacement": {"nodeSelector": {"matchLabels": {"node-role.kubernetes.io/infra": ""}}}, "replicas": 2}}'
+  delay: 10s
+  warmup: true
+
+- termination: http
+  connections: 200
+  samples: 2
+  duration: 3m
+  path: /1024.html
+  concurrency: 18
+  tool: wrk
+  serverReplicas: 45
+  requestTimeout: 10s
+  delay: 10s
+
+- termination: edge
+  connections: 200
+  samples: 2
+  duration: 3m
+  path: /1024.html
+  concurrency: 18
+  tool: wrk
+  serverReplicas: 45
+  requestTimeout: 10s
+  delay: 10s
+
+- termination: reencrypt
+  connections: 200
+  samples: 2
+  duration: 3m
+  path: /1024.html
+  concurrency: 18
+  tool: wrk
+  serverReplicas: 45
+  requestTimeout: 10s
+  delay: 10s
+
+- termination: passthrough
+  connections: 200
+  samples: 2
+  duration: 3m
+  path: /1024.html
+  concurrency: 18
+  tool: wrk
+  serverReplicas: 45
+  requestTimeout: 10s
+  delay: 10s
+


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

cc @jtaleric @josecastillolema 

Still, WIP, but is a starting point.

Note: default number of threads is 4, the r760 servers of the scalelab have 64 physical CPUs, which means that with the default configuration, haproxy doesn't take advantage from most of the resources available

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.