### PR TITLE
Fixing broken oc binary

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/openshifttest/python:3.9
 
 LABEL vendor="Red Hat Inc." maintainer="OCP Perfscale Team"
 
-RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | tar -xvzf -  &&\
+RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.15/openshift-client-linux.tar.gz  | tar -xvzf -  &&\
     mv oc /bin && mv kubectl /bin && apt-get update && apt-get install -y gettext-base uuid-runtime jq && \
     ln -s /bin/bash /usr/bin/bash && /usr/local/bin/python -m pip install --upgrade pip && pip install virtualenv jq
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Latest  binary doesn't works in this container image...

```shell
INFO[2024-07-05T14:49:12Z] + cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
NAME="Debian GNU/Linux"
VERSION_ID="11"
VERSION="11 (bullseye)"
VERSION_CODENAME=bullseye
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
+ oc config view
oc: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by oc)
oc: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by oc) 
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
