### PR TITLE
Adding Virt for k8s-netperf

### DIFF
--- a/workloads/network-perf-v2/env.sh
+++ b/workloads/network-perf-v2/env.sh
@@ -11,6 +11,7 @@ fi
 export ALL_SCENARIOS=${ALL_SCENARIOS:-true}
 export DEBUG=${DEBUG:-true}
 export METRICS=${METRICS:-true}
+export VM=${VIRT:-false}
 export NETPERF_FILENAME=${NETPERF_FILENAME:-k8s-netperf}
 export NETPERF_VERSION=${NETPERF_VERSION:-v0.1.25}
 export OS=${OS:-Linux}

--- a/workloads/network-perf-v2/run.sh
+++ b/workloads/network-perf-v2/run.sh
@@ -55,6 +55,7 @@ add_flag "prom" "${PROMETHEUS_URL}"
 add_flag "search" "${ES_SERVER}"
 add_flag "tcp-tolerance" "${TOLERANCE}"
 add_flag "uuid" "${UUID}"
+add_flag "vm" "${VM}"
 
 # Execute the constructed command
 eval "$cmd"


### PR DESCRIPTION

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Allow the user to set env var of "VIRT" to set VM network performance test.

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
