### PR TITLE
update channels for logging

### DIFF
--- a/workloads/logging/env.sh
+++ b/workloads/logging/env.sh
@@ -36,7 +36,8 @@ export DEPLOY_LOGGING=${DEPLOY_LOGGING:-true}
 export TEST_CLEANUP=${TEST_CLEANUP:-"false"}
 
 # Deploy Variables
-export CHANNEL=${CHANNEL:="stable-5.6"}
+export ESCHANNEL=${ESCHANNEL:="stable-5.8"}
+export LOGCHANNEL=${LOGCHANNEL:="stable-6.1"}
 export CUSTOM_ES_URL=${CUSTOM_ES_URL:=""}
 export ES_NODE_COUNT=${ES_NODE_COUNT:=3}
 export ES_STORAGE_CLASS=${ES_STORAGE_CLASS:="gp3-csi"}

--- a/workloads/logging/files/logging-stack.yml
+++ b/workloads/logging/files/logging-stack.yml
@@ -30,7 +30,7 @@ metadata:
   name: "elasticsearch-operator"
   namespace: "openshift-operators-redhat"
 spec:
-  channel: "${CHANNEL}"
+  channel: "${ESCHANNEL}"
   installPlanApproval: "Automatic"
   source: "redhat-operators"
   sourceNamespace: "openshift-marketplace"
@@ -51,7 +51,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: "${CHANNEL}"
+  channel: "${LOGCHANNEL}"
   name: cluster-logging
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug 

- [ ] Optimization
- [ ] Documentation Update

## Description
The `cluster-logging` and `elasticsearch-operator` don't use the same channel, so, we shouldn't use the same env var for them. 
```console
  - message: 'constraints not satisfiable: no operators found in channel stable-5.8
      of package cluster-logging in the catalog referenced by subscription cluster-logging,
      subscription cluster-logging exists'
    reason: ConstraintsNotSatisfiable
    status: "True"
    type: ResolutionFailed
```


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
