### PR TITLE
Use k8s-netperf's serverIP flag

### DIFF
--- a/workloads/network-perf-v2/README.md
+++ b/workloads/network-perf-v2/README.md
@@ -2,11 +2,12 @@
 
 The purpose of the network scripts is to run netperf workload on the Openshift Cluster.
 
-There are 3 types of network tests k8s-netperf will run through:
+There are 4 types of network tests k8s-netperf will run through:
 
 1. Pod to Pod using SDN
-3. Pod to Pod using HostNetwork 
-4. Pod to Service 
+2. Pod to Pod using HostNetwork
+3. Pod to Service
+4. Pod to External Server provided by the user
 
 Running from CLI:
 
@@ -46,3 +47,4 @@ This will orchestrate multiple netwok performance tests.
 | TOLERANCE | Tolerance when comparing hostNetwork to podNetwork | 70 |
 | UUID | UUID which will be used for the workload | uuidgen |
 | WORKLOAD | Config definition for k8s-netperf | smoke.yaml |
+| EXTERNAL_SERVER_ADDRESS | IP address where the external server is running. User has to configure the external server with the required k8s-netperf driver | unset |

--- a/workloads/network-perf-v2/env.sh
+++ b/workloads/network-perf-v2/env.sh
@@ -18,6 +18,9 @@ export PROMETHEUS_URL=
 export ARCH=$(uname -m)
 export NETPERF_URL=${NETPERF_URL:-https://github.com/cloud-bulldozer/k8s-netperf/releases/download/${NETPERF_VERSION}/k8s-netperf_${OS}_${NETPERF_VERSION}_${ARCH}.tar.gz}
 
+# External server
+export EXTERNAL_SERVER_ADDRESS=${EXTERNAL_SERVER_ADDRESS:-}
+
 # Workload
 export WORKLOAD=${WORKLOAD:-smoke.yaml}
 export TEST_TIMEOUT=${TEST_TIMEOUT:-14400}

--- a/workloads/network-perf-v2/run.sh
+++ b/workloads/network-perf-v2/run.sh
@@ -44,6 +44,11 @@ add_flag() {
   fi
 }
 
+if [ -n "${EXTERNAL_SERVER_ADDRESS}" ]; then
+  echo "EXTERNAL_SERVER_ADDRESS is set ${EXTERNAL_SERVER_ADDRESS}"
+  add_flag "serverIP" "${EXTERNAL_SERVER_ADDRESS}"
+fi
+
 # Add flags based on conditions
 [ ! ${LOCAL} = true ] && add_flag "all" "${ALL_SCENARIOS}" || echo "LOCAL=true, not setting --all"
 add_flag "clean" "${CLEAN_UP}"


### PR DESCRIPTION
This enables user to call k8s-netperf with serverIP flag to send traffic to external server. User has to configure external server with the required k8s-netperf driver.

Usage:
export EXTERNAL_SERVER_ADDRESS=10.0.61.54;./run.sh

