### PR TITLE
Adding job_type to the fingerprint index

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -14,15 +14,47 @@ setup(){
         export KUBECONFIG=/home/airflow/auth/config
         curl -sS https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | tar xz oc
         export PATH=$PATH:/home/airflow/.local/bin:$(pwd)
+        if echo "$job_run_id" | grep -qi "scheduled"; then
+            job_type="scheduled"
+        elif echo "$job_run_id" | grep -qi "backfill"; then
+            job_type="backfill"
+        elif echo "$job_run_id" | grep -qi "dataset"; then
+            job_type="dataset dependancy"
+        else
+            job_type="manual"
+        fi
     elif [[ -n $PROW_JOB_ID ]]; then
         export ci="PROW"
         export prow_base_url="https://prow.ci.openshift.org/view/gs/origin-ci-test/logs"
         export prow_pr_base_url="https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release"
+        job_type=${JOB_TYPE}
+        if [[ "${job_type}" == "presubmit" && "${JOB_NAME}" == *pull* ]]; then
+            # Indicates a ci test triggered in PR against source code
+            job_type="pull"
+        fi
+        if [[ "${job_type}" == "presubmit" && "${JOB_NAME}" == *rehearse* ]]; then
+            # Indicates a rehearsel in PR against openshift/release repo
+            job_type="rehearse"
+        fi
+        
     elif [[ -n $BUILD_ID ]]; then
         export ci="JENKINS"
         export build_url=${BUILD_URL}
+        LATEST_CAUSE=$(curl -s "${BUILD_URL}"/api/json | jq -r '.actions[].causes[].shortDescription' 2>/dev/null | grep -v "null" | tail -n 1)
+        if echo "$LATEST_CAUSE" | grep -iq "SCM"; then
+            job_type="scm trigger"
+        elif echo "$LATEST_CAUSE" | grep -iq "timer"; then
+            job_type="time trigger"
+        elif echo "$LATEST_CAUSE" | grep -iq "upstream"; then
+            job_type="upstream trigger"
+        elif echo "$LATEST_CAUSE" | grep -iq "user"; then
+            job_type="manual trigger"
+        else
+            job_type="unknown"
+        fi
     fi
 
+    export job_type
     export UUID=$UUID
     # Elasticsearch Config
     export ES_SERVER=$ES_SERVER
@@ -170,6 +202,7 @@ index_task(){
         "networkType":"'"$network_type"'",
         "buildTag":"'"$task_id"'",
         "jobStatus":"'"$state"'",
+        "jobType":"'"$job_type"'",
         "buildUrl":"'"$build_url"'",
         "upstreamJob":"'"$job_id"'",
         "upstreamJobBuild":"'"$job_run_id"'",


### PR DESCRIPTION
## Type of change

- [x] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Adding job types to CI fingerprint.

## Related Tickets & Documents
- Closes # https://github.com/cloud-bulldozer/e2e-benchmarking/issues/743

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Tested in local in a hacky way.
1. Jenkins
```
vchalla@vchalla-thinkpadp1gen2:~/myforks/e2e-benchmarking$ curl -s "$JENKINS_JOB_URL" | jq -r '.actions[].causes[].shortDescription' 2>/dev/null
Started by upstream project "scale-ci/e2e-benchmarking-multibranch-pipeline/loaded-upgrade" build number 1,920
Started by user Meha Bhalodiya
Rebuilds build #2,086
```
2. Prow - Followed the docs to make use of ENVs: https://docs.prow.k8s.io/docs/jobs/
3. Airflow - Looked at other usage of Airflow Envs: https://github.com/search?q=AIRFLOW_CTX_DAG_RUN_ID&type=code&p=1