### PR TITLE
Take out new lines and don't fail on null

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -39,8 +39,10 @@ setup(){
         
     elif [[ -n $BUILD_ID ]]; then
         export ci="JENKINS"
-        export build_url=${BUILD_URL}
-        LATEST_CAUSE=$(curl -s "${BUILD_URL}"/api/json | jq -r '.actions[].causes[].shortDescription' 2>/dev/null | grep -v "null" | tail -n 1)
+        export build_url="${BUILD_URL}api/json"
+        set +eo pipefail
+        LATEST_CAUSE=$(curl -s ${build_url} | tr '\n' ' ' | jq -r '.actions[].causes[].shortDescription' 2>/dev/null | grep -v "null" | head -n 1)
+        echo "latest cause $LATEST_CAUSE"
         if echo "$LATEST_CAUSE" | grep -iq "SCM"; then
             job_type="scm trigger"
         elif echo "$LATEST_CAUSE" | grep -iq "timer"; then
@@ -52,8 +54,8 @@ setup(){
         else
             job_type="unknown"
         fi
+        set -eo pipefail
     fi
-
     export job_type
     export UUID=$UUID
     # Elasticsearch Config
@@ -101,6 +103,7 @@ setup(){
         fi
         all=$((all + 1))
     done
+
 }
 
 get_ipsec_config(){


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Hitting an error when trying to get job details for jenkins
```
 echo $build_url | jq -r ".actions[0].causes[0].shortDescription"
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 2, column 14
```

Once I added in the "tr" of the new lines to spaces it passes 
```
 echo $build_url | tr '\n' ' ' | jq -r ".actions[0].causes[0].shortDescription" 
Started by user Paige Patton

```

The command to get the latest cause causes the whole file to fail and no indexing occurs

it passes when commenting out the **set -eo pipefail**
https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/kube-burner-ocp/2120/console

fails if not: 
https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/kube-burner-ocp/2121/console






## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Passing job: https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/kube-burner-ocp/2124/console