### PR TITLE
Updaing dockerfile to be inline with openshift CI

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -3,8 +3,13 @@ FROM quay.io/openshifttest/python:3.9
 LABEL vendor="Red Hat Inc." maintainer="OCP Perfscale Team"
 
 RUN curl -sSL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux-amd64-rhel8.tar.gz | tar -xvzf - &&\
-    mv oc /bin && mv kubectl /bin && apt-get update && apt-get install -y gettext-base uuid-runtime jq && \
+    mv oc /bin && mv kubectl /bin && apt-get update && apt-get install -y gettext-base uuid-runtime jq openssh-client sshpass && \
     ln -s /bin/bash /usr/bin/bash && /usr/local/bin/python -m pip install --upgrade pip && pip install virtualenv jq
+
+RUN curl -sSL $(curl -sSL https://api.github.com/repos/openshift/rosa/releases/latest | jq -r ".assets[] | select(.name == \"rosa_Linux_x86_64.tar.gz\") | .browser_download_url") | tar xvzf - &&\
+    mv rosa /bin && chmod 777 /bin/rosa
+
+RUN curl -sSL $(curl -sSL https://api.github.com/repos/openshift-online/ocm-cli/releases/latest | jq -r ".assets[] | select(.name == \"ocm-linux-amd64\") | .browser_download_url") --output /bin/ocm && chmod 777 /bin/ocm
 
 WORKDIR /e2e
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description
Keeping Dockerfile inline with openshift CI: https://github.com/openshift-qe/ocp-qe-perfscale-ci/blob/main/prow/Dockerfile so that we can run all our e2e CI tests.

## Related Tickets & Documents

- Related Issue # https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/62205/rehearse-62205-pull-ci-cloud-bulldozer-e2e-benchmarking-master-e2e-egressip-single-node/1895452047755448320

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
Will verify through e2e tests in this PR.
