### PR TITLE
[ingress-perf] add GATEWAY_API env to enable gateway api

### DIFF
--- a/workloads/ingress-perf/run.sh
+++ b/workloads/ingress-perf/run.sh
@@ -9,13 +9,14 @@ LOG_LEVEL=${LOG_LEVEL:-info}
 if [ "$INGRESS_PERF_VERSION" = "default" ]; then
     unset INGRESS_PERF_VERSION
 fi
-INGRESS_PERF_VERSION=${INGRESS_PERF_VERSION:-0.4.3}
+INGRESS_PERF_VERSION=${INGRESS_PERF_VERSION:-0.5.0}
 CONFIG=${CONFIG:?}
 BASELINE_UUID=${BASELINE_UUID:-}
 BASELINE_INDEX=${BASELINE_INDEX:-ingress-performance-baseline}
 TOLERANCY=${TOLERANCY:-20}
 OS=$(uname -s)
 HARDWARE=$(uname -m)
+GATEWAY_API=${GATEWAY_API:-false}
 
 download_binary(){
   INGRESS_PERF_URL=https://github.com/cloud-bulldozer/ingress-perf/releases/download/v${INGRESS_PERF_VERSION}/ingress-perf-${OS}-v${INGRESS_PERF_VERSION}-${HARDWARE}.tar.gz
@@ -29,6 +30,9 @@ if [[ -n ${ES_SERVER} ]]; then
 fi
 if [[ -n ${BASELINE_UUID} ]]; then
   cmd+=" --baseline-uuid=${BASELINE_UUID} --baseline-index=${BASELINE_INDEX} --tolerancy=${TOLERANCY}"
+fi
+if [[ ${GATEWAY_API} = true ]]; then
+  cmd+=" --gateway-api=true"
 fi
 
 # Do not exit if ingress-perf fails, we need to capture the exit code.


### PR DESCRIPTION
## Description

[ingress-perf] add GATEWAY_API env to enable gateway api

## Related Tickets & Documents

- Related Issue # https://issues.redhat.com/browse/PERFSCALE-3653

## Testing
Passed job
https://jenkins-csb-openshift-qe-mastern.dno.corp.redhat.com/job/scale-ci/job/e2e-benchmarking-multibranch-pipeline/job/ingress-perf/583/ 
````
03-18 17:44:26.349  ./ingress-perf run --cfg config/standard.yml --loglevel=info --uuid d482deba-5496-41c9-9a73-74ba4892fc10 --es-server=https://ocp-qe:****@search-ocp-qe-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com --es-index=ingress-performance --gateway-api=true

03-18 17:44:28.230  time="2025-03-18 09:44:27" level=info msg="Gateway API mode enabled" file="runner.go:254"
````
