### PR TITLE
Only rds-core workload supports the perf-profile flag

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -156,7 +156,7 @@ if [[ -n ${ES_SERVER} ]]; then
   cmd+=" --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
 fi
 # If PERFORMANCE_PROFILE is specified
-if [[ -n ${PERFORMANCE_PROFILE} ]]; then
+if [[ -n ${PERFORMANCE_PROFILE} && ${WORKLOAD} =~ "rds-core" ]]; then
   cmd+=" --perf-profile=${PERFORMANCE_PROFILE}"
 fi
 


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [X] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Looks like we add --perf-profile flag to all workloads while it is only supported by rds-core

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

s.
