### PR TITLE
Make additional Virt metadata capturing optional

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -344,8 +344,10 @@ setup
 get_ipsec_config
 get_fips_config
 get_ocp_virt_config
-get_ocp_virt_version_config
-get_ocp_virt_tuning_policy_config
+if [[ "$ocp_virt" == true ]]; then
+    get_ocp_virt_version_config
+    get_ocp_virt_tuning_policy_config
+fi
 get_encryption_config
 get_publish_config
 get_architecture_config


### PR DESCRIPTION
No point checking for additional stuff when CNV operator itself is not installed. Otherwise, the error logs in Prow are an eyesore.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [X] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->
The Prow build logs are an eyesore when we keep checking for CNV related stuff even when the oeprator itself doesn't exist on the cluster: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/62845/rehearse-62845-periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-nightly-x86-control-plane-120nodes/1902075016258785280/artifacts/control-plane-120nodes/openshift-qe-cluster-density-v2/build-log.txt

```
error: error executing jsonpath "{.items[0].spec.version}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
	template was:
		{.items[0].spec.version}
	object given to jsonpath engine was:
		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":""}}
```


## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.
