### PR TITLE
Revert "Remove unnecessary timestamp fields"

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -237,6 +237,8 @@ index_task(){
         "jobDuration":"'"$duration"'",
         "startDate":"'"$start_date"'",
         "endDate":"'"$end_date"'",
+        "startDateUnixTimestamp":"'"$start_date_unix_timestamp"'",
+        "endDateUnixTimestamp":"'"$end_date_unix_timestamp"'",
         "timestamp":"'"$current_timestamp"'",
         "ipsec":"'"$ipsec"'",
         "ipsecMode":"'"$ipsecMode"'",


### PR DESCRIPTION
This reverts commit 733e29b98cbe277bbe7bfee608dbaf646e60e2ae.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
NetObserv team used to read and compare timestamp fields to set boundaries for metrics capturing post workload run. It's currently breaking our jenkins pipelines since these fields are removed. I realize start and end ISO timestamps do exist, however having epoch timestamps in index_data.json was very useful and convenient, if it's not too much of a duplication, I propose to bring them back.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
