### PR TITLE
Replace `kube_deployment_labels` and `kube_replicaset_labels` with `k…

### DIFF
--- a/workloads/baseline-performance/metrics.yaml
+++ b/workloads/baseline-performance/metrics.yaml
@@ -95,7 +95,7 @@
 - query: count(kube_secret_info{})
   metricName: secretCount
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
 
 - query: count(kube_configmap_info{})

--- a/workloads/kube-burner-ocp-wrapper/metrics-profiles/aro/hosted-cluster-metrics.yml
+++ b/workloads/kube-burner-ocp-wrapper/metrics-profiles/aro/hosted-cluster-metrics.yml
@@ -39,13 +39,13 @@
 
 - query: (max(sum(irate(node_cpu_seconds_total{}[1m])) by (mode,instance) and on (instance) label_replace(bottomk(1, min_over_time(sum(irate(node_cpu_seconds_total{mode=~"idle"}[1m])) by (mode,instance)[{{ .elapsed }}:])), "instance", "$1", "instance", "(.+)")) by (mode)) > 0
   metricName: nodeCPU-MostUtilizedWorkers
-  
+
 - query: bottomk(1,min_over_time(node_memory_MemAvailable_bytes{}[{{ .elapsed }}:]))
   metricName: nodeMemoryAvailable-MostUtilizedWorker
 
 - query: avg(node_memory_MemTotal_bytes{} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
   metricName: nodeMemoryTotal-AggregatedWorkers
-  instant: true  
+  instant: true
 
 # Cluster metrics
 
@@ -59,7 +59,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 

--- a/workloads/kube-burner-ocp-wrapper/metrics-profiles/kepler/metrics.yaml
+++ b/workloads/kube-burner-ocp-wrapper/metrics-profiles/kepler/metrics.yaml
@@ -97,7 +97,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 
@@ -119,7 +119,7 @@
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
 
-- query: count(kube_replicaset_labels{})
+- query: count(kube_replicaset_spec_replicas{})
   metricName: replicaSetCount
   instant: true
 

--- a/workloads/kube-burner-ocp-wrapper/metrics-profiles/metrics-aggregated.yml
+++ b/workloads/kube-burner-ocp-wrapper/metrics-profiles/metrics-aggregated.yml
@@ -106,7 +106,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 
@@ -128,7 +128,7 @@
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
 
-- query: count(kube_replicaset_labels{})
+- query: count(kube_replicaset_spec_replicas{})
   metricName: replicaSetCount
   instant: true
 

--- a/workloads/kube-burner-ocp-wrapper/metrics-profiles/metrics.yml
+++ b/workloads/kube-burner-ocp-wrapper/metrics-profiles/metrics.yml
@@ -97,7 +97,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 
@@ -119,7 +119,7 @@
 - query: sum(kube_node_status_condition{status="true"}) by (condition)
   metricName: nodeStatus
 
-- query: count(kube_replicaset_labels{})
+- query: count(kube_replicaset_spec_replicas{})
   metricName: replicaSetCount
   instant: true
 

--- a/workloads/kube-burner-ocp-wrapper/metrics-profiles/rosa/hosted-cluster-metrics.yml
+++ b/workloads/kube-burner-ocp-wrapper/metrics-profiles/rosa/hosted-cluster-metrics.yml
@@ -39,13 +39,13 @@
 
 - query: (max(sum(irate(node_cpu_seconds_total{}[1m])) by (mode,instance) and on (instance) label_replace(bottomk(1, min_over_time(sum(irate(node_cpu_seconds_total{mode=~"idle"}[1m])) by (mode,instance)[{{ .elapsed }}:])), "instance", "$1", "instance", "(.+)")) by (mode)) > 0
   metricName: nodeCPU-MostUtilizedWorkers
-  
+
 - query: bottomk(1,min_over_time(node_memory_MemAvailable_bytes{}[{{ .elapsed }}:]))
   metricName: nodeMemoryAvailable-MostUtilizedWorker
 
 - query: avg(node_memory_MemTotal_bytes{} and on (instance) label_replace(kube_node_role{role="worker"}, "instance", "$1", "node", "(.+)"))
   metricName: nodeMemoryTotal-AggregatedWorkers
-  instant: true  
+  instant: true
 
 # Cluster metrics
 
@@ -59,7 +59,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 

--- a/workloads/kube-burner/metrics-profiles/acs-metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/acs-metrics.yaml
@@ -166,7 +166,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 

--- a/workloads/kube-burner/metrics-profiles/hypershift-metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/hypershift-metrics.yaml
@@ -186,7 +186,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"})
+- query: count(kube_deployment_spec_replicas{openshift_cluster_name=~"${HOSTED_CLUSTER_NAME}"})
   metricName: deploymentCount
   instant: true
 

--- a/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics-aggregated.yaml
@@ -103,7 +103,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 
@@ -125,6 +125,6 @@
   metricName: clusterVersion
   instant: true
 
-- query: count(kube_replicaset_labels{})
+- query: count(kube_replicaset_spec_replicas{})
   metricName: replicaSetCount
   instant: true

--- a/workloads/kube-burner/metrics-profiles/metrics-ovn.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics-ovn.yaml
@@ -114,7 +114,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 

--- a/workloads/kube-burner/metrics-profiles/metrics.yaml
+++ b/workloads/kube-burner/metrics-profiles/metrics.yaml
@@ -66,7 +66,7 @@
 
 - query: (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) and on (instance) label_replace(kube_node_role{role="master"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryUtilization-Masters
-  
+
 - query: node_memory_MemAvailable_bytes and on (instance) label_replace(kube_node_role{role="infra"}, "instance", "$1", "node", "(.+)")
   metricName: nodeMemoryAvailable-Infra
 
@@ -109,7 +109,7 @@
   metricName: secretCount
   instant: true
 
-- query: count(kube_deployment_labels{})
+- query: count(kube_deployment_spec_replicas{})
   metricName: deploymentCount
   instant: true
 
@@ -134,6 +134,6 @@
   metricName: clusterVersion
   instant: true
 
-- query: count(kube_replicaset_labels{})
+- query: count(kube_replicaset_spec_replicas{})
   metricName: replicaSetCount
   instant: true


### PR DESCRIPTION
…ube_deployment_spec_replicas` and `kube_replicaset_spec_replicas`

## Type of change

- Bug fix

## Description

Both metrics `kube_deployment_labels` and `kube_replicaset_labels` are no longer available in OCP prometheus, instead we can get the counts of deployments from `kube_deployment_spec_replicas` and the counts of ReplicaSets from `kube_replicaset_spec_replicas`

