### PR TITLE
remove the iteration var for netpol workload as it is set in extra flags

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -136,7 +136,7 @@ if [[ ${WORKLOAD} =~ "cluster-density" || ${WORKLOAD} =~ "udn-density-pods" || $
   ITERATIONS=${ITERATIONS:?}
   cmd+=" --iterations=${ITERATIONS} --churn=${CHURN}"
 fi
-if [[ ${WORKLOAD} =~ ^(crd-scale|pvc-density|network-policy)$ ]]; then
+if [[ ${WORKLOAD} =~ ^(crd-scale|pvc-density)$ ]]; then
   ITERATIONS=${ITERATIONS:?}
   cmd+=" --iterations=${ITERATIONS}"
 fi


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [.] Bug fix
- [ ] Optimization
- [ ] Documentation Update

remove the iteration var for netpol workload as it is set in extra flags

avoids prwo error
```
+ [[ network-policy =~ ^(crd-scale|pvc-density|network-policy)$ ]]
./run.sh: line 140: ITERATIONS: parameter null or not set
```