### PR TITLE
address ocp_virt_version: unbound variable

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -146,14 +146,12 @@ get_ocp_virt_config(){
 }
 
 get_ocp_virt_version_config(){
-    ocp_virt_version=""
     if result=$(kubectl get csv -n openshift-cnv -o jsonpath='{.items[0].spec.version}' 2> /dev/null); then
         ocp_virt_version=$result
     fi
 }
 
 get_ocp_virt_tuning_policy_config(){
-    ocp_virt_tuning_policy=""
     if result=$(kubectl get hyperconverged kubevirt-hyperconverged -n openshift-cnv -o jsonpath='{.spec.tuningPolicy}' 2> /dev/null); then
         ocp_virt_tuning_policy=$result
     fi
@@ -354,6 +352,9 @@ setup
 get_ipsec_config
 get_fips_config
 get_ocp_virt_config
+# address `ocp_virt_version: unbound variable when ocp_virt=false 
+ocp_virt_version=""
+ocp_virt_tuning_policy=""
 if [[ "$ocp_virt" == true ]]; then
     get_ocp_virt_version_config
     get_ocp_virt_tuning_policy_config


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Address the below error when `ocp_virt=false`: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/65072/rehearse-65072-periodic-ci-openshift-eng-ocp-qe-perfscale-ci-main-aws-4.19-nightly-x86-olmv1-benchmark-test/1927254013212889088/artifacts/olmv1-benchmark-test/olmv1-performance/build-log.txt
```shell
++ current_timestamp=2025-05-27T07:41:22Z
e2e-benchmarking/utils/index.sh: line 259: ocp_virt_version: unbound variable
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
