### PR TITLE
changes to adopt to recent kube-burner v1.6.9

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -146,14 +146,16 @@ if [[ ${WORKLOAD} =~ "egressip" ]]; then
   ITERATIONS=${ITERATIONS:?}
   cmd+=" --iterations=${ITERATIONS} --external-server-ip=${EGRESSIP_EXTERNAL_SERVER_IP}"
 fi
+# if ES_SERVER is specified and for hypershift clusters
 if [[ -n ${MC_KUBECONFIG} ]] && [[ -n ${ES_SERVER} ]]; then
   cmd+=" --metrics-endpoint=metrics-endpoint.yml"
   hypershift
-fi
-# If ES_SERVER is specified
-if [[ -n ${ES_SERVER} ]]; then
+# for non-hypershift cluster
+elif [[ -n ${ES_SERVER} ]]; then
   curl -k -sS -X POST -H "Content-type: application/json" ${ES_SERVER}/ripsaw-kube-burner/_doc -d "${METADATA}" -o /dev/null
   cmd+=" --es-server=${ES_SERVER} --es-index=ripsaw-kube-burner"
+else
+  echo "ES_SERVER is not set, not indexing the results"
 fi
 # If PERFORMANCE_PROFILE is specified
 if [[ -n ${PERFORMANCE_PROFILE} && ${WORKLOAD} =~ "rds-core" ]]; then


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

With recent KB-OCP v1.6.9 release, `--metric-endpoint` and `--es-server` are mutually exclusive, they can't be set together. 
Adding a conditional check in e2e to set `--es-server` only for regular clusters.

Kube-burner-ocp error on setting both of these,
```
Error: if any flags in the group [es-server metrics-endpoint] are set none of the others can be; [es-server metrics-endpoint] were all set
```

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
