### PR TITLE
add iterations for olm workload

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -146,6 +146,11 @@ if [[ ${WORKLOAD} =~ "egressip" ]]; then
   ITERATIONS=${ITERATIONS:?}
   cmd+=" --iterations=${ITERATIONS} --external-server-ip=${EGRESSIP_EXTERNAL_SERVER_IP}"
 fi
+if [[ ${WORKLOAD} =~ "olm" ]]; then
+  ITERATIONS=${ITERATIONS:?"ERROR: ITERATIONS must be set when WORKLOAD includes 'olm'"}
+  cmd+=" --iterations=${ITERATIONS}"
+fi
+
 # if ES_SERVER is specified and for hypershift clusters
 if [[ -n ${MC_KUBECONFIG} ]] && [[ -n ${ES_SERVER} ]]; then
   cmd+=" --metrics-endpoint=metrics-endpoint.yml"


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Address the below error introduced by https://github.com/openshift/release/pull/65072, full log: https://gcsweb-qe-private-deck-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/qe-private-deck/pr-logs/pull/openshift_release/65072/rehearse-65072-periodic-ci-openshift-openshift-tests-private-release-4.20-amd64-nightly-olmv1-benchmark-test/1941080918672281600/artifacts/olmv1-benchmark-test/olmv1-performance/build-log.txt
```console
+ /tmp/kube-burner-ocp olm --log-level=debug --qps=20 --burst=20 --gc=true --uuid 778b69c7-577d-4e24-8b6a-d3470d2b7f59 --churn-duration=5m --timeout=30m --metrics-profile=/tmp/olm-metrics.yml,/tmp/extended-metrics.yml --gc-metrics=false --profile-type=both --es-server=https://XXXXXX:XXXXXXXXXXXXXXXXXXXXXX@search-XXXXXX-perf-scale-test-elk-hcm7wtsqpxy7xogbu72bor4uve.us-east-1.es.amazonaws.com --es-index=ripsaw-kube-burner --pprof
time="2025-07-04 11:25:32" level=info msg="❤️ Checking for Cluster Health" file="cluster_health.go:46"
time="2025-07-04 11:25:32" level=info msg="Cluster is Healthy" file="cluster_health.go:54"
Error: required flag(s) "iterations" not set
Usage:
  kube-burner-ocp olm [flags]
```

## Related Tickets & Documents

- Related Issue # https://github.com/openshift/release/pull/65072
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
