### PR TITLE
disable pprof for index workload

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -128,6 +128,7 @@ if [[ ${WORKLOAD} =~ "index" ]]; then
   cmd="${KUBE_DIR}/kube-burner-ocp index --uuid=${UUID} --start=$START_TIME --end=$((END_TIME+600)) --log-level ${LOG_LEVEL}"
   JOB_START=$(date -u -d "@$START_TIME" +"%Y-%m-%dT%H:%M:%SZ")
   JOB_END=$(date -u -d "@$((END_TIME + 600))" +"%Y-%m-%dT%H:%M:%SZ")
+  PPROF=false # pporf is not supported for index job, it is not required for index executions.
 else
   cmd="${KUBE_DIR}/kube-burner-ocp ${WORKLOAD} --log-level=${LOG_LEVEL} --qps=${QPS} --burst=${BURST} --gc=${GC} --uuid ${UUID}"
 fi


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [x] Optimization
- [ ] Documentation Update

## Description

`kube-burner-ocp index` job won't accept `--pprof` argument as it is not necessary for such jobs, so overwriting it here to avoid failures.

