### PR TITLE
Remove PPROF env var

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -11,8 +11,6 @@ fi
 KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-1.7.2}
 PERFORMANCE_PROFILE=${PERFORMANCE_PROFILE:-default}
 CHURN=${CHURN:-true}
-PPROF=${PPROF:-true}
-ARCHIVE=${ARCHIVE:-true}
 WORKLOAD=${WORKLOAD:?}
 QPS=${QPS:-20}
 BURST=${BURST:-20}
@@ -164,11 +162,6 @@ if [[ -n ${PERFORMANCE_PROFILE} && ${WORKLOAD} =~ "rds-core" ]]; then
   cmd+=" --perf-profile=${PERFORMANCE_PROFILE}"
 fi
 
-# Enable pprof collection
-if $PPROF; then
-  cmd+=" --pprof"
-fi
-
 # Capture the exit code of the run, but don't exit the script if it fails.
 set +e
 
@@ -186,13 +179,5 @@ env JOB_START="$JOB_START" JOB_END="$JOB_END" JOB_STATUS="$JOB_STATUS" UUID="$UU
 
 if [[ ${WORKLOAD} =~ "egressip" ]]; then
     cleanup_egressip_external_server
-fi
-if $ARCHIVE; then
-  if $PPROF; then
-    if [[ -z "${ARTIFACT_DIR}" ]]; then
-        ARTIFACT_DIR="/tmp"
-    fi
-    cp -r pprof-data "${ARTIFACT_DIR}/"
-  fi
 fi
 exit $exit_code


### PR DESCRIPTION
## Type of change

- [x] Optimization

## Description

Remove PPROF env var logic, this logic will be handled from openshfit/release side as the env var does not work anymore (it's interpreted as string, and that makes the [kube-burner template](https://github.com/kube-burner/kube-burner-ocp/blob/main/cmd/config/node-density/node-density.yml#L11) conditional true)

