### PR TITLE
Handle cases when a periodic job is triggered via PR

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -36,6 +36,10 @@ setup(){
             # Indicates a rehearsel in PR against openshift/release repo
             job_type="rehearse"
         fi
+        # Handle cases where a periodic job iw triggered via pull request
+        if [[ ${job_type} == "periodic" ]] && [[ -n ${PULL_NUMBER} ]]; then
+          job_type="pull"
+        fi
 
     elif [[ -n $BUILD_ID ]]; then
         export ci="JENKINS"


### PR DESCRIPTION
## Type of change

- [x] Bug fix

## Description

Handle cases when a periodic job is triggered from a PR, similar to https://github.com/openshift/kubernetes/pull/2394#issuecomment-3189823480

This is causing false positives in orion as is considering it a payload job.

## Related Tickets & Documents

- Related Issues:
- https://github.com/openshift/kubernetes/pull/2394#issuecomment-3189823480 
- https://github.com/cloud-bulldozer/orion/pull/191
