### PR TITLE
custom config for cluster density

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -137,6 +137,15 @@ if [[ ${WORKLOAD} =~ "cluster-density" || ${WORKLOAD} =~ "udn-density-pods" || $
   ITERATIONS=${ITERATIONS:?}
   cmd+=" --iterations=${ITERATIONS} --churn=${CHURN}"
 fi
+if [[ ${WORKLOAD} =~ "kube-burner-ai" ]]; then
+  WORKLOAD="cluster-density"
+  numbers=(100 150 200 250 300 350 400 450 500)
+  array_length=${#numbers[@]}
+  random_index=$(( $RANDOM % array_length ))
+  ITERATIONS=${numbers[$random_index]}
+
+  cmd+=" --iterations=${ITERATIONS} --churn=${CHURN}"
+fi
 if [[ ${WORKLOAD} =~ ^(crd-scale|pvc-density|olm|udn-bgp)$ ]]; then
   ITERATIONS=${ITERATIONS:?}
   cmd+=" --iterations=${ITERATIONS}"


### PR DESCRIPTION
kube-burner AI needs CI runs for cdv2 job with different config options.

We want cdv2 to run with varibale iteration count to have different number of namespaces across test runs.

E2E also uses my private kube burner repo which for the cdv2, creates variable number of cluster resources in each test run instead of predefined number of them. Each iteration in the test run, choses a random number between the min and max provided for the resource.

Please don't review or merge this change as it is a temporary change for our CI runs.

## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

<!--- Describe your changes in detail -->

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
