### PR TITLE
write uuid to a file

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -252,6 +252,7 @@ index_task(){
     url=$1
     uuid_dir=/tmp/$UUID
     mkdir -p "$uuid_dir"
+    echo "$UUID" >> "/tmp/$WORKLOAD-uuid.txt"
 
     start_date_unix_timestamp=$(date "+%s" -d "${start_date}")
     end_date_unix_timestamp=$(date "+%s" -d "${end_date}")


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [ ] Bug fix
- [X] Optimization
- [ ] Documentation Update

## Description
Currently UUID is only available in workload logs file, writing to a file would help us identify UUID for specific workloads without relying on log parsing.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
