### PR TITLE
Add ability to test PRs from kube-burner-ocp repositories instead of only using release versions

### DIFF
--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -11,8 +11,6 @@ RUN curl -sSL $(curl -sSL https://api.github.com/repos/openshift/rosa/releases/l
 
 RUN curl -sSL $(curl -sSL https://api.github.com/repos/openshift-online/ocm-cli/releases/latest | jq -r ".assets[] | select(.name == \"ocm-linux-amd64\") | .browser_download_url") --output /bin/ocm && chmod 777 /bin/ocm
 
-RUN git config --global user.name "Tu Nombre" && git config --global user.email "tu.email@example.com"
-
 WORKDIR /e2e
 
 RUN chown -R 777 /e2e

--- a/prow/Dockerfile
+++ b/prow/Dockerfile
@@ -11,6 +11,8 @@ RUN curl -sSL $(curl -sSL https://api.github.com/repos/openshift/rosa/releases/l
 
 RUN curl -sSL $(curl -sSL https://api.github.com/repos/openshift-online/ocm-cli/releases/latest | jq -r ".assets[] | select(.name == \"ocm-linux-amd64\") | .browser_download_url") --output /bin/ocm && chmod 777 /bin/ocm
 
+RUN git config --global user.name "Tu Nombre" && git config --global user.email "tu.email@example.com"
+
 WORKDIR /e2e
 
 RUN chown -R 777 /e2e

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -74,10 +74,6 @@ build_from_pr(){
   git clone https://github.com/kube-burner/kube-burner-ocp.git "${REPO_DIR}"
   cd "${REPO_DIR}"
 
-  # Update GIT Global user settings
-  git config --global user.name "Tu Nombre"
-  git config --global user.email "tu.email@example.com"
-
   # Fetch the PR and checkout
   git pull origin pull/${KUBEBURNER_OCP_PR}/head:${KUBEBURNER_OCP_PR} --rebase
   git switch ${KUBEBURNER_OCP_PR}

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -74,9 +74,12 @@ build_from_pr(){
   git clone https://github.com/kube-burner/kube-burner-ocp.git "${REPO_DIR}"
   cd "${REPO_DIR}"
 
+  # Update GIT Global user settings
+  git config --global user.name "Tu Nombre"
+  git config --global user.email "tu.email@example.com"
+
   # Fetch the PR and checkout
-  git fetch origin pull/${KUBEBURNER_OCP_PR}/head:${KUBEBURNER_OCP_PR}
-  git rebase ${KUBEBURNER_OCP_PR}
+  git pull origin pull/${KUBEBURNER_OCP_PR}/head:${KUBEBURNER_OCP_PR} --rebase 
   git switch ${KUBEBURNER_OCP_PR}
   
   # Build the binary

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -11,6 +11,9 @@ fi
 KUBE_BURNER_VERSION=${KUBE_BURNER_VERSION:-1.8.0}
 OS=$(uname -s)
 HARDWARE=$(uname -m)
+# Detect architecture for different use cases
+BIN_ARCH=${BIN_ARCH:-$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)}
+GO_ARCH=${GO_ARCH:-$(uname -s | awk '{print tolower($0)}')-${BIN_ARCH}}
 PERFORMANCE_PROFILE=${PERFORMANCE_PROFILE:-default}
 CHURN=${CHURN:-true}
 WORKLOAD=${WORKLOAD:?}
@@ -22,15 +25,46 @@ UUID=${UUID:-$(uuidgen)}
 KUBE_DIR=${KUBE_DIR:-/tmp}
 ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
 KUBEBURNER_OCP_PR=${KUBEBURNER_OCP_PR:-}
+GO_VERSION=${GO_VERSION:-1.23.4}
 
 download_binary(){
   KUBE_BURNER_URL="https://github.com/kube-burner/kube-burner-ocp/releases/download/v${KUBE_BURNER_VERSION}/kube-burner-ocp-V${KUBE_BURNER_VERSION}-${OS}-${HARDWARE}.tar.gz"
   curl --fail --retry 8 --retry-all-errors -sS -L "${KUBE_BURNER_URL}" | tar -xzC "${KUBE_DIR}/" kube-burner-ocp
 }
 
+install_go(){
+  INSTALL_GO=false
+  
+  # Check if go is installed
+  if ! command -v go &> /dev/null; then
+    echo "Go is not installed. Installing Go ${GO_VERSION}..."
+    INSTALL_GO=true
+  else
+    # Check if installed version is sufficient
+    INSTALLED_GO_VERSION=$(go version | awk '{print $3}' | sed 's/go//')
+    REQUIRED_GO_VERSION="${GO_VERSION}"
+    
+    if [ "$(printf '%s\n' "$REQUIRED_GO_VERSION" "$INSTALLED_GO_VERSION" | sort -V | head -n1)" != "$REQUIRED_GO_VERSION" ]; then
+      echo "Go version $INSTALLED_GO_VERSION is too old (requires >= $REQUIRED_GO_VERSION). Installing Go ${GO_VERSION}..."
+      INSTALL_GO=true
+    else
+      echo "Go version $INSTALLED_GO_VERSION is sufficient."
+    fi
+  fi
+  
+  if [ "$INSTALL_GO" = true ]; then
+    GO_TARBALL="go${GO_VERSION}.${GO_ARCH}.tar.gz"
+    curl -L https://go.dev/dl/${GO_TARBALL} -o ${GO_TARBALL}
+    tar -C ${KUBE_DIR}/ -xzf ${GO_TARBALL}
+    export PATH=${KUBE_DIR}/go/bin:$PATH
+    rm -f ${GO_TARBALL}
+    echo "Go ${GO_VERSION} installed successfully."
+  fi
+}
+
 build_from_pr(){
   echo "Building kube-burner-ocp from PR #${KUBEBURNER_OCP_PR}"
-  BIN_ARCH=$(uname -m | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
+  install_go
   # Clone the repository
   REPO_DIR="${KUBE_DIR}/kube-burner-ocp-repo"
   if [ -d "${REPO_DIR}" ]; then

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -39,7 +39,11 @@ build_from_pr(){
   
   git clone https://github.com/kube-burner/kube-burner-ocp.git "${REPO_DIR}"
   cd "${REPO_DIR}"
-  
+
+  # Update GIT Global user settings
+  git config --global user.name "Tu Nombre"
+  git config --global user.email "tu.email@example.com"
+
   # Fetch the PR and checkout
   git pull origin pull/${KUBEBURNER_OCP_PR}/head:${KUBEBURNER_OCP_PR} --rebase
   git switch ${KUBEBURNER_OCP_PR}

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -75,7 +75,8 @@ build_from_pr(){
   cd "${REPO_DIR}"
 
   # Fetch the PR and checkout
-  git pull origin pull/${KUBEBURNER_OCP_PR}/head:${KUBEBURNER_OCP_PR} --rebase
+  git fetch origin pull/${KUBEBURNER_OCP_PR}/head:${KUBEBURNER_OCP_PR}
+  git rebase ${KUBEBURNER_OCP_PR}
   git switch ${KUBEBURNER_OCP_PR}
   
   # Build the binary

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -75,8 +75,8 @@ build_from_pr(){
   cd "${REPO_DIR}"
 
   # Update GIT Global user settings
-  git config --global user.name "Tu Nombre"
-  git config --global user.email "tu.email@example.com"
+  git config --global user.name "RedHat Performance"
+  git config --global user.email "redhat-performance@redhat.com"
 
   # Fetch the PR and checkout
   git pull origin pull/${KUBEBURNER_OCP_PR}/head:${KUBEBURNER_OCP_PR} --rebase 


### PR DESCRIPTION
## Type of change

- [ ] New feature

## Description

- Add KUBEBURNER_OCP_PR env var (empty by default)
- Add build_from_pr() function to clone, build, and use PR code
- Include architecture detection for arm64/amd64 builds
- Maintain backward compatibility with download_binary() as default

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
