### PR TITLE
Updates to override kube-burner-ocp binary URL

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/README.md
+++ b/workloads/kube-burner-ocp-wrapper/README.md
@@ -29,6 +29,8 @@ This wrapper supports some variables to tweak some basic parameters of the workl
 - **QPS** and **BURST**: Defines client-go QPS and BURST parameters for kube-burner. 20 by default
 - **GC**: Garbage collect created namespaces. true by default
 - **EXTRA_FLAGS**: Extra flags that will be appended to the underlying kube-burner-ocp command, by default empty.
+- **KUBE_BURNER_VERSION**: Defines the version of kube-burner-ocp to use. By default kube-burner-ocp is downloaded from the github releases.
+- **KUBE_BURNER_URL**: Defines the URL of the kube-burner-ocp binary to use. It has higher precedence than KUBE_BURNER_VERSION.
 
 ### Using the EXTRA_FLAGS variable
 

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -21,7 +21,9 @@ KUBE_DIR=${KUBE_DIR:-/tmp}
 ES_INDEX=${ES_INDEX:-ripsaw-kube-burner}
 
 download_binary(){
-  KUBE_BURNER_URL="https://github.com/kube-burner/kube-burner-ocp/releases/download/v${KUBE_BURNER_VERSION}/kube-burner-ocp-V${KUBE_BURNER_VERSION}-${OS}-${HARDWARE}.tar.gz"
+  if [[ -z ${KUBE_BURNER_URL} ]]; then
+    KUBE_BURNER_URL="https://github.com/kube-burner/kube-burner-ocp/releases/download/v${KUBE_BURNER_VERSION}/kube-burner-ocp-V${KUBE_BURNER_VERSION}-${OS}-${HARDWARE}.tar.gz"
+  fi
   curl --fail --retry 8 --retry-all-errors -sS -L "${KUBE_BURNER_URL}" | tar -xzC "${KUBE_DIR}/" kube-burner-ocp
 }
 


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

Download `kube-burner-ocp` from the url specified by the env var `KUBE_BURNER_URL` when is set, otherwise use the original logic. 


## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.
