### PR TITLE
Wrapper for k8s-io

### DIFF
--- a/workloads/k8s-io/README.md
+++ b/workloads/k8s-io/README.md
@@ -1,0 +1,40 @@
+# k8s-io FIO
+
+Wrapper for [k8s-io](https://github.com/jtaleric/k8s-io), a lightweight CLI tool for running distributed FIO benchmarks on Kubernetes/OpenShift clusters.
+
+## Running from CLI
+
+```sh
+$ ./run.sh
+```
+
+This runs the smoke test (`smoke.yaml`) — a single FIO server, 1 sample, read-only with 4KiB block size.
+
+```sh
+$ CONFIG=full-run.yaml ./run.sh
+```
+
+This runs a comprehensive FIO benchmark with multiple job types (read, write, randread, randwrite), block sizes (4KiB, 8KiB, 16KiB), 3 servers, and 3 samples.
+
+### Custom configuration
+
+Point `CONFIG` to any k8s-io FIO config file:
+
+```sh
+$ CONFIG=/path/to/my-config.yaml ./run.sh
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| CLEANUP | Clean up resources created by k8s-io after the benchmark | `true` |
+| CONFIG | k8s-io YAML configuration file | `smoke.yaml` |
+| ES_SERVER | Elasticsearch/OpenSearch endpoint for CI metadata indexing | unset |
+| ES_INDEX | Elasticsearch/OpenSearch index name | `ripsaw-fio` |
+| K8S_IO_BRANCH | Git branch/tag to build from source | `main` |
+| K8S_IO_REPO | Git repository URL for k8s-io | `https://github.com/jtaleric/k8s-io.git` |
+| K8S_IO_URL | URL to a pre-built k8s-io binary (skips build from source) | unset |
+| TEST_TIMEOUT | Timeout for the benchmark in seconds | `14400` |
+| UUID | UUID for the workload run | `uuidgen` |
+| WORKLOAD | Workload name used for indexing | `k8s-io` |

--- a/workloads/k8s-io/README.md
+++ b/workloads/k8s-io/README.md
@@ -32,9 +32,9 @@ $ CONFIG=/path/to/my-config.yaml ./run.sh
 | CONFIG | k8s-io YAML configuration file | `smoke.yaml` |
 | ES_SERVER | Elasticsearch/OpenSearch endpoint for CI metadata indexing | unset |
 | ES_INDEX | Elasticsearch/OpenSearch index name | `ripsaw-fio` |
-| K8S_IO_BRANCH | Git branch/tag to build from source | `main` |
-| K8S_IO_REPO | Git repository URL for k8s-io | `https://github.com/jtaleric/k8s-io.git` |
-| K8S_IO_URL | URL to a pre-built k8s-io binary (skips build from source) | unset |
+| K8S_IO_URL | URL to download k8s-io | `https://github.com/jtaleric/k8s-io/releases/download/${K8S_IO_VERSION}/k8s-io_${OS}_${K8S_IO_VERSION}_${ARCH}.tar.gz` |
+| K8S_IO_VERSION | k8s-io tag/version | `v0.1.0` |
+| OS | System to run k8s-io | `Linux` |
 | TEST_TIMEOUT | Timeout for the benchmark in seconds | `14400` |
 | UUID | UUID for the workload run | `uuidgen` |
 | WORKLOAD | Workload name used for indexing | `k8s-io` |

--- a/workloads/k8s-io/env.sh
+++ b/workloads/k8s-io/env.sh
@@ -2,10 +2,15 @@
 export UUID=${UUID:-$(uuidgen)}
 export CLEANUP=${CLEANUP:-true}
 
-# k8s-io build/download
-export K8S_IO_REPO=${K8S_IO_REPO:-https://github.com/jtaleric/k8s-io.git}
-export K8S_IO_BRANCH=${K8S_IO_BRANCH:-main}
-export K8S_IO_URL=${K8S_IO_URL:-}
+# k8s-io version
+if [ "${K8S_IO_VERSION}" = "default" ]; then
+    unset K8S_IO_VERSION
+fi
+export K8S_IO_FILENAME=${K8S_IO_FILENAME:-k8s-io}
+export K8S_IO_VERSION=${K8S_IO_VERSION:-v0.1.0}
+export OS=${OS:-Linux}
+export ARCH=$(uname -m)
+export K8S_IO_URL=${K8S_IO_URL:-https://github.com/jtaleric/k8s-io/releases/download/${K8S_IO_VERSION}/k8s-io_${OS}_${K8S_IO_VERSION}_${ARCH}.tar.gz}
 
 # Elasticsearch
 export ES_SERVER=${ES_SERVER:-}

--- a/workloads/k8s-io/env.sh
+++ b/workloads/k8s-io/env.sh
@@ -1,0 +1,17 @@
+# Common
+export UUID=${UUID:-$(uuidgen)}
+export CLEANUP=${CLEANUP:-true}
+
+# k8s-io build/download
+export K8S_IO_REPO=${K8S_IO_REPO:-https://github.com/jtaleric/k8s-io.git}
+export K8S_IO_BRANCH=${K8S_IO_BRANCH:-main}
+export K8S_IO_URL=${K8S_IO_URL:-}
+
+# Elasticsearch
+export ES_SERVER=${ES_SERVER:-}
+export ES_INDEX=${ES_INDEX:-ripsaw-fio}
+
+# Workload
+export CONFIG=${CONFIG:-smoke.yaml}
+export WORKLOAD=${WORKLOAD:-k8s-io}
+export TEST_TIMEOUT=${TEST_TIMEOUT:-14400}

--- a/workloads/k8s-io/full-run.yaml
+++ b/workloads/k8s-io/full-run.yaml
@@ -1,0 +1,38 @@
+namespace: "fio-test"
+workload:
+  name: "fio"
+  args:
+    kind: "pod"
+    servers: 3
+    samples: 3
+    jobs: ["read", "write", "randread", "randwrite"]
+    bs: ["4KiB", "8KiB", "16KiB"]
+    numjobs: [1]
+    iodepth: 4
+    filesize: "1G"
+    read_runtime: 60
+    read_ramp_time: 10
+    write_runtime: 60
+    write_ramp_time: 10
+    prefill: true
+    prefill_bs: "1024KiB"
+    post_prefill_sleep: 30
+    image: "quay.io/jtaleric/fio:latest"
+
+job_params:
+  - jobname_match: write
+    params:
+      - time_based=1
+      - fsync_on_close=1
+      - create_on_open=1
+  - jobname_match: read
+    params:
+      - time_based=1
+  - jobname_match: randwrite
+    params:
+      - time_based=1
+      - fsync_on_close=1
+      - create_on_open=1
+  - jobname_match: randread
+    params:
+      - time_based=1

--- a/workloads/k8s-io/run.sh
+++ b/workloads/k8s-io/run.sh
@@ -4,32 +4,22 @@ set -e
 source ./env.sh
 source ../../utils/common.sh
 
-K8S_IO_BINARY=./k8s-io
-K8S_IO_DIR=/tmp/k8s-io-build
-
-download_binary() {
-  echo "Downloading k8s-io binary from ${K8S_IO_URL}"
-  curl --fail --retry 8 --retry-all-errors -sS -L "${K8S_IO_URL}" -o ${K8S_IO_BINARY}
-  chmod +x ${K8S_IO_BINARY}
+# Download k8s-io function
+download_k8s_io() {
+  echo $1
+  curl --fail --retry 8 --retry-all-errors -sS -L ${K8S_IO_URL} | tar -xz ${K8S_IO_FILENAME}
 }
 
-build_binary() {
-  echo "Building k8s-io from source (${K8S_IO_REPO}@${K8S_IO_BRANCH})"
-  if [ -d "${K8S_IO_DIR}" ]; then
-    rm -rf "${K8S_IO_DIR}"
+# Download and extract k8s-io if we haven't already
+if [ -f "${K8S_IO_FILENAME}" ]; then
+  cmd_version=$(./${K8S_IO_FILENAME} --version | awk '/^Version:/{print $2}')
+  if [[ "${K8S_IO_VERSION}" == *"${cmd_version}"* ]]; then
+    echo "We already have the specified version available."
+  else
+    download_k8s_io "Switching k8s-io version."
   fi
-  git clone --depth 1 --branch "${K8S_IO_BRANCH}" "${K8S_IO_REPO}" "${K8S_IO_DIR}"
-  pushd "${K8S_IO_DIR}"
-  go build -o k8s-io .
-  popd
-  cp "${K8S_IO_DIR}/k8s-io" ${K8S_IO_BINARY}
-  rm -rf "${K8S_IO_DIR}"
-}
-
-if [ -n "${K8S_IO_URL}" ]; then
-  download_binary
 else
-  build_binary
+  download_k8s_io "Downloading k8s-io."
 fi
 
 log "###############################################"
@@ -38,15 +28,12 @@ log "UUID: ${UUID}"
 log "Config: ${CONFIG}"
 log "###############################################"
 
+# Capture exit code of k8s-io
 set +e
 
 JOB_START=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-cmd="timeout ${TEST_TIMEOUT} ${K8S_IO_BINARY} -config ${CONFIG}"
-
-if [ "${CLEANUP}" = "true" ]; then
-  cmd+=" -cleanup"
-fi
+cmd="timeout ${TEST_TIMEOUT} ./${K8S_IO_FILENAME} -config ${CONFIG}"
 
 echo "Executing command: $cmd"
 eval "$cmd"
@@ -54,7 +41,12 @@ run=$?
 
 JOB_END=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-log "Finished workload ${WORKLOAD}, exit code ($run)"
+if [ "${CLEANUP}" = "true" ]; then
+  echo "Cleaning up resources..."
+  ./${K8S_IO_FILENAME} -config ${CONFIG} -cleanup
+fi
+
+log "Finished workload ${0} ${CONFIG}, exit code ($run)"
 
 if [ $run -eq 0 ]; then
   JOB_STATUS="success"

--- a/workloads/k8s-io/run.sh
+++ b/workloads/k8s-io/run.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -e
+
+source ./env.sh
+source ../../utils/common.sh
+
+K8S_IO_BINARY=./k8s-io
+K8S_IO_DIR=/tmp/k8s-io-build
+
+download_binary() {
+  echo "Downloading k8s-io binary from ${K8S_IO_URL}"
+  curl --fail --retry 8 --retry-all-errors -sS -L "${K8S_IO_URL}" -o ${K8S_IO_BINARY}
+  chmod +x ${K8S_IO_BINARY}
+}
+
+build_binary() {
+  echo "Building k8s-io from source (${K8S_IO_REPO}@${K8S_IO_BRANCH})"
+  if [ -d "${K8S_IO_DIR}" ]; then
+    rm -rf "${K8S_IO_DIR}"
+  fi
+  git clone --depth 1 --branch "${K8S_IO_BRANCH}" "${K8S_IO_REPO}" "${K8S_IO_DIR}"
+  pushd "${K8S_IO_DIR}"
+  go build -o k8s-io .
+  popd
+  cp "${K8S_IO_DIR}/k8s-io" ${K8S_IO_BINARY}
+  rm -rf "${K8S_IO_DIR}"
+}
+
+if [ -n "${K8S_IO_URL}" ]; then
+  download_binary
+else
+  build_binary
+fi
+
+log "###############################################"
+log "Workload: ${WORKLOAD}"
+log "UUID: ${UUID}"
+log "Config: ${CONFIG}"
+log "###############################################"
+
+set +e
+
+JOB_START=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+cmd="timeout ${TEST_TIMEOUT} ${K8S_IO_BINARY} -config ${CONFIG}"
+
+if [ "${CLEANUP}" = "true" ]; then
+  cmd+=" -cleanup"
+fi
+
+echo "Executing command: $cmd"
+eval "$cmd"
+run=$?
+
+JOB_END=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+log "Finished workload ${WORKLOAD}, exit code ($run)"
+
+if [ $run -eq 0 ]; then
+  JOB_STATUS="success"
+else
+  JOB_STATUS="failure"
+fi
+env JOB_START="${JOB_START}" JOB_END="${JOB_END}" JOB_STATUS="${JOB_STATUS}" UUID="${UUID}" WORKLOAD="${WORKLOAD}" ES_SERVER="${ES_SERVER}" ../../utils/index.sh
+exit $run

--- a/workloads/k8s-io/smoke.yaml
+++ b/workloads/k8s-io/smoke.yaml
@@ -1,0 +1,18 @@
+namespace: "fio-test"
+workload:
+  name: "fio"
+  args:
+    kind: "pod"
+    servers: 1
+    samples: 1
+    jobs: ["read"]
+    bs: ["4KiB"]
+    numjobs: [1]
+    iodepth: 1
+    filesize: "256M"
+    read_runtime: 30
+    read_ramp_time: 5
+    write_runtime: 30
+    write_ramp_time: 5
+    prefill: false
+    image: "quay.io/jtaleric/fio:latest"


### PR DESCRIPTION
Tested in OCP 4.20.18:
```
$ ES_SERVER="" ./run.sh
We already have the specified version available.
Thu 30 Apr 07:39:00 UTC 2026 ###############################################
Thu 30 Apr 07:39:00 UTC 2026 Workload: k8s-io
Thu 30 Apr 07:39:00 UTC 2026 UUID: bc65ebc9-d594-4a41-9e6b-ca98c9925be1
Thu 30 Apr 07:39:00 UTC 2026 Config: smoke.yaml
Thu 30 Apr 07:39:00 UTC 2026 ###############################################
Executing command: timeout 14400 ./k8s-io -config smoke.yaml
2026/04/30 09:39:00 Starting K8s-IO benchmark tool...
2026/04/30 09:39:00 Loaded configuration for workload: fio
2026/04/30 09:39:00 Created fio workload
2026/04/30 09:39:01 Creating namespace: fio-test
2026/04/30 09:39:01 Starting fio benchmark...
2026/04/30 09:39:01 Starting FIO distributed benchmark execution...
2026/04/30 09:39:01 Deploying infrastructure...
2026/04/30 09:39:02 Waiting for 1 FIO servers to be ready...
2026/04/30 09:39:02 Waiting for pods: 0/1 ready (selector: app=fio-benchmark-17775347)
2026/04/30 09:39:07 Waiting for pods: 0/1 ready (selector: app=fio-benchmark-17775347)
2026/04/30 09:39:12 Waiting for pods: 0/1 ready (selector: app=fio-benchmark-17775347)
2026/04/30 09:39:17 Waiting for pods: 0/1 ready (selector: app=fio-benchmark-17775347)
2026/04/30 09:39:22 Waiting for pods: 0/1 ready (selector: app=fio-benchmark-17775347)
2026/04/30 09:39:27 Waiting for pods: 0/1 ready (selector: app=fio-benchmark-17775347)
2026/04/30 09:39:32 Waiting for pods: 0/1 ready (selector: app=fio-benchmark-17775347)
2026/04/30 09:39:37 Waiting for pods: 0/1 ready (selector: app=fio-benchmark-17775347)
2026/04/30 09:39:42 All 1 servers are ready
2026/04/30 09:39:42 Creating hosts configmap...
2026/04/30 09:39:43 Job fio-check-17775347 still running (succeeded: 0, failed: 0, active: 1)
2026/04/30 09:40:43 Job fio-check-17775347 completed successfully
2026/04/30 09:40:43 Starting benchmark client...
2026/04/30 09:40:44 Benchmark client started
2026/04/30 09:40:44 Waiting for benchmark to complete...
2026/04/30 09:40:44 Job fio-client-17775347 still running (succeeded: 0, failed: 0, active: 1)
2026/04/30 09:41:44 Job fio-client-17775347 completed successfully
2026/04/30 09:41:44 Capturing benchmark results...
Found 1 FIO result(s)

=== FIO Benchmark Results ===
Test ID               Sample  Job   Hostname     Read IOPS  Read BW (KB/s)  Write IOPS  Write BW (KB/s)  Read Lat P50 (μs)  Read Lat P95 (μs)  Write Lat P50 (μs)  Write Lat P95 (μs)  Runtime (s)
-------               ------  ---   --------     ---------  -----------     ----------  ------------     --------------     --------------     ---------------     ---------------     -----------
17775347_read_4KiB_1  1       read  10.131.0.30  44389.2    177556          0.0         0                18.8               20.9               0.0                 0.0                 1

Results exported to: fio-results-17775347_read_4KiB_1-20260430-094145.csv
2026/04/30 09:41:45 Benchmark completed successfully!
2026/04/30 09:41:45 Benchmark completed successfully!
Cleaning up resources...
2026/04/30 09:41:45 Starting K8s-IO benchmark tool...
2026/04/30 09:41:45 Loaded configuration for workload: fio
2026/04/30 09:41:45 Created fio workload
2026/04/30 09:41:45 Cleaning up resources...
2026/04/30 09:41:45 Cleaning up benchmark resources...
W0430 09:41:45.793851  391549 warnings.go:70] child pods are preserved by default when jobs are deleted; set propagationPolicy=Background to remove them or set propagationPolicy=Orphan to suppress this warning
W0430 09:41:46.428514  391549 warnings.go:70] child pods are preserved by default when jobs are deleted; set propagationPolicy=Background to remove them or set propagationPolicy=Orphan to suppress this warning
2026/04/30 09:41:46 Cleanup completed
2026/04/30 09:41:46 Cleanup completed successfully!
Thu 30 Apr 07:41:46 UTC 2026 Finished workload ./run.sh smoke.yaml, exit code (0)
Not a CI run. Skipping CI metrics to be indexed
```