### PR TITLE
Combine Kube-burner workload config with metadata document

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -334,8 +334,16 @@ index_task(){
         ADDITIONAL_PARAMS='{}' # Default to empty JSON if not set
     fi
 
-    # Merge base_json with ADDITIONAL_PARAMS
-    merged_json=$(jq -n --argjson base "$base_json" --argjson extra "$ADDITIONAL_PARAMS" '$base + $extra')
+    # Merge base_json with ADDITIONAL_PARAMS and KUBE_BURNER_WORKLOAD_CONFIG
+    if [[ -n "$KUBE_BURNER_WORKLOAD_CONFIG" ]]; then
+        if ! echo "$KUBE_BURNER_WORKLOAD_CONFIG" | jq . >/dev/null 2>&1; then
+            echo "Error: KUBE_BURNER_WORKLOAD_CONFIG is not valid JSON."
+            exit 1
+        fi
+    else
+        KUBE_BURNER_WORKLOAD_CONFIG='{}'
+    fi
+    merged_json=$(jq -n --argjson base "$base_json" --argjson extra "$ADDITIONAL_PARAMS" --argjson kbcfg "$KUBE_BURNER_WORKLOAD_CONFIG" '$base + $extra + $kbcfg')
 
     # Save and send the merged JSON
     echo "$merged_json" >> $uuid_dir/index_data.json

--- a/workloads/kube-burner-ocp-wrapper/run.sh
+++ b/workloads/kube-burner-ocp-wrapper/run.sh
@@ -201,7 +201,20 @@ if [ $exit_code -eq 0 ]; then
 else
   JOB_STATUS="failure"
 fi
-env JOB_START="$JOB_START" JOB_END="$JOB_END" JOB_STATUS="$JOB_STATUS" UUID="$UUID" WORKLOAD="$WORKLOAD" ES_SERVER="$ES_SERVER" ../../utils/index.sh
+
+KUBE_BURNER_WORKLOAD_CONFIG='{}'
+if [[ -n ${ES_SERVER} ]]; then
+  # Just pick the value of the field workloadFlags from the first jobSummary entry
+  WORKLOAD_FLAGS=$(curl -sS --insecure "${ES_SERVER}/${ES_INDEX}/_search" \
+    -H "Content-Type: application/json" \
+    -d '{"size":1,"query":{"bool":{"must":[{"term":{"uuid.keyword":"'"${UUID}"'"}},{"term":{"metricName.keyword":"jobSummary"}}]}}}'  2>/dev/null \
+    | jq -r '.hits.hits[0]._source.workloadFlags // empty')
+  if [[ -n ${WORKLOAD_FLAGS} ]]; then
+    KUBE_BURNER_WORKLOAD_CONFIG=$(jq -n --argjson wf "$WORKLOAD_FLAGS" '{"kbCfg": $wf}')
+  fi
+fi
+
+env JOB_START="$JOB_START" JOB_END="$JOB_END" JOB_STATUS="$JOB_STATUS" UUID="$UUID" WORKLOAD="$WORKLOAD" ES_SERVER="$ES_SERVER" KUBE_BURNER_WORKLOAD_CONFIG="$KUBE_BURNER_WORKLOAD_CONFIG" ../../utils/index.sh
 
 if [[ ${WORKLOAD} =~ "egressip" ]]; then
     cleanup_egressip_external_server


### PR DESCRIPTION
## Summary
- Fetches `workloadFlags` from the kube-burner `jobSummary` document in Elasticsearch and includes it in the indexed metadata as `kbCfg`
- Extends `utils/index.sh` to merge the new `KUBE_BURNER_WORKLOAD_CONFIG` JSON into the indexed document alongside `ADDITIONAL_PARAMS`
- Validates `KUBE_BURNER_WORKLOAD_CONFIG` is valid JSON before merging

## Test plan
- [x] Run a kube-burner workload with ES indexing enabled and verify the `kbCfg` field appears in the metadata document

<details>

Ignore the empty fields, I ran this locally, not from prow

```json
{
  "_index": "perf_scale_ci",
  "_id": "/test-prow-id//6233ebae-05b7-4222-a190-407383252d3c",
  "_version": 1,
  "_score": null,
  "_source": {
    "ciSystem": "PROW",
    "uuid": "6233ebae-05b7-4222-a190-407383252d3c",
    "releaseStream": "4.20.4",
    "platform": "External",
    "clusterType": "self-managed",
    "benchmark": "cluster-density-v2",
    "masterNodesCount": 3,
    "workerNodesCount": 3,
    "infraNodesCount": 0,
    "masterNodesType": "BM.Optimized3.36",
    "workerNodesType": "",
    "infraNodesType": "",
    "totalNodesCount": 3,
    "clusterName": "ci-dg8ms",
    "ocpVersion": "4.20.4",
    "stream": "",
    "osImage": "",
    "ocpVirt": "",
    "ocpVirtVersion": "",
    "ocpVirtTuningPolicy": "",
    "networkType": "OVNKubernetes",
    "ovnVersion": "",
    "buildTag": "",
    "jobStatus": "failure",
    "jobType": "",
    "buildUrl": "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs//",
    "upstreamJob": "",
    "upstreamJobBuild": "test-prow-id",
    "executionDate": "2026-05-12T08:17:44Z",
    "jobDuration": "9",
    "startDate": "2026-05-12T08:17:44Z",
    "endDate": "2026-05-12T08:17:53Z",
    "timestamp": "2026-05-12T08:18:14Z",
    "ipsec": "",
    "ipsecMode": "",
    "fips": "",
    "encrypted": "",
    "encryptionType": "",
    "publish": "",
    "computeArch": "",
    "controlPlaneArch": "",
    "pullNumber": "0",
    "organization": "",
    "repository": "",
    "kbCfg": {
      "churnCycles": "0",
      "churnDelay": "2m0s",
      "churnDuration": "0s",
      "churnMode": "namespaces",
      "churnPercent": "10",
      "deletionStrategy": "default",
      "iterations": "2",
      "metricsProfile": "[metrics.yml]",
      "podReadyThreshold": "0s",
      "pprof": "false",
      "pprofInterval": "0s",
      "serviceLatency": "false"
    }
  },
  "fields": {
    "timestamp": [
      "2026-05-12T08:18:14.000Z"
    ]
  },
  "sort": [
    1778573894000
  ]
}
```
</details>

- [x] Verify invalid JSON in `KUBE_BURNER_WORKLOAD_CONFIG` is caught and exits with an error
<details>
Document generated after a failed run, kbCfg not present, ignore the empty fields, I ran this locally, not from prow

```JSON
{
  "_index": "perf_scale_ci",
  "_id": "//08263faa-50b4-4d94-a1cf-a2eb0c983f3b",
  "_version": 1,
  "_score": null,
  "_source": {
    "ciSystem": "PROW",
    "uuid": "08263faa-50b4-4d94-a1cf-a2eb0c983f3b",
    "releaseStream": "4.20.4",
    "platform": "External",
    "clusterType": "self-managed",
    "benchmark": "cluster-density-v2",
    "masterNodesCount": 3,
    "workerNodesCount": 3,
    "infraNodesCount": 0,
    "masterNodesType": "BM.Optimized3.36",
    "workerNodesType": "",
    "infraNodesType": "",
    "totalNodesCount": 3,
    "clusterName": "ci-dg8ms",
    "ocpVersion": "4.20.4",
    "stream": "",
    "osImage": "",
    "ocpVirt": "",
    "ocpVirtVersion": "",
    "ocpVirtTuningPolicy": "",
    "networkType": "OVNKubernetes",
    "ovnVersion": "",
    "buildTag": "",
    "jobStatus": "failure",
    "jobType": "",
    "buildUrl": "https://prow.ci.openshift.org/view/gs/origin-ci-test/logs//",
    "upstreamJob": "",
    "upstreamJobBuild": "test-prow-id",
    "executionDate": "2026-05-12T08:27:07Z",
    "jobDuration": "8",
    "startDate": "2026-05-12T08:27:07Z",
    "endDate": "2026-05-12T08:27:15Z",
    "timestamp": "2026-05-12T08:27:36Z",
    "ipsec": "",
    "ipsecMode": "",
    "fips": "",
    "encrypted": "",
    "encryptionType": "",
    "publish": "",
    "computeArch": "",
    "controlPlaneArch": "",
    "pullNumber": "0",
    "organization": "",
    "repository": ""
  },
  "fields": {
    "timestamp": [
      "2026-05-12T08:27:36.000Z"
    ]
  },
  "sort": [
    1778574456000
  ]
}
</details>
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Workload configuration is now automatically retrieved from Elasticsearch and merged into the indexing process when available.
  * Added validation that ensures invalid workload configurations are detected and cause the process to fail safely before indexing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/e2e-benchmarking/pull/851)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->