### PR TITLE
Add Prometheus PVC available space metric to ROSA hosted cluster profil

### DIFF
--- a/workloads/kube-burner-ocp-wrapper/metrics-profiles/rosa/hosted-cluster-metrics.yml
+++ b/workloads/kube-burner-ocp-wrapper/metrics-profiles/rosa/hosted-cluster-metrics.yml
@@ -104,3 +104,8 @@
 
 - query: sum(irate(apiserver_request_total{verb!="WATCH"}[2m])) by (verb,resource,instance) > 0
   metricName: APIRequestRate
+
+# Prometheus PVC available space
+
+- query: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"prometheus-data-prometheus-k8s-[0,1]"} / kubelet_volume_stats_capacity_bytes
+  metricName: prometheusPVCAvailableRatio


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [X] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Captures Prometheus PVC usage as the ratio of available to capacity bytes for prometheus-data-prometheus-k8s-[0,1] persistent volume claims.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [X] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Prometheus persistent volume (PVC) available-space metric to the hosted-cluster metrics profile, enabling monitoring of Prometheus storage utilization and capacity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/e2e-benchmarking/pull/854)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->