### PR TITLE
network-perf-v2: support MicroShift runs

### DIFF
--- a/utils/index.sh
+++ b/utils/index.sh
@@ -73,6 +73,102 @@ setup(){
     export ES_SERVER=$ES_SERVER
     export WORKLOAD=$WORKLOAD
     export ES_INDEX=$ES_INDEX
+
+    if [[ "${PLATFORM:-openshift}" == "microshift" ]]; then
+        # MicroShift does not expose many OpenShift config APIs. Keep this
+        # metadata path limited to Kubernetes resources and the
+        # microshift-version ConfigMap.
+        cluster_name=${MICROSHIFT_CLUSTER_NAME:-$(kubectl get ns kube-system -o jsonpath='{.metadata.uid}' 2>/dev/null || hostname -s 2>/dev/null || echo "microshift")}
+        # Prefer the microshift-version CM (carries the 4.y release); fall
+        # back to oc version (Kubernetes gitVersion) only if the CM is absent.
+        if mscm=$(kubectl get cm -n kube-public microshift-version -o json 2>/dev/null); then
+            cluster_version=$(echo "$mscm" | jq -r '.data.version // "unknown"')
+            RELEASE_STREAM=$(echo "$mscm" | jq -r '"\(.data.major).\(.data.minor)"')
+            export RELEASE_STREAM
+        else
+            cluster_version=$(oc version -o json 2>/dev/null | jq -r '.serverVersion.gitVersion // "unknown"' 2>/dev/null || echo "unknown")
+            RELEASE_STREAM=$(echo "$cluster_version" | sed -E 's/^v?([0-9]+\.[0-9]+).*/\1/')
+            export RELEASE_STREAM
+        fi
+        network_type="unknown"
+        ovn_version=""
+        ovn_namespace="openshift-ovn-kubernetes"
+        if kubectl get namespace "$ovn_namespace" >/dev/null 2>&1; then
+            network_type="OVNKubernetes"
+            ovn_pod=$(kubectl get pod -n "$ovn_namespace" -l app=ovnkube-node -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+            if [[ -z "$ovn_pod" ]]; then
+                ovn_pod=$(kubectl get pod -n "$ovn_namespace" --no-headers -o custom-columns=:.metadata.name 2>/dev/null | awk '/^ovnkube-node/{print; exit}' || true)
+            fi
+            if [[ -n "$ovn_pod" ]]; then
+                ovn_version=$(kubectl exec -n "$ovn_namespace" "$ovn_pod" -- ovn-controller --version 2>/dev/null | awk '/^ovn-controller/{print $2; exit}' || true)
+            fi
+        fi
+        # platform mirrors the cloud-platform field used in the OCP path
+        # (AWS/Azure/BareMetal/None); MicroShift carries its distinction via
+        # cluster_type and stream so dashboards filtering on platform still match.
+        platform="None"
+        cluster_type="microshift"
+        stream="microshift"
+
+        masters=0
+        infra=0
+        workers=0
+        all=0
+        master_type=""
+        infra_type=""
+        worker_type=""
+        osimage=""
+
+        # Role counts mirror the OpenShift path's taint-aware logic: an
+        # untainted master with the worker label is counted as both, so on a
+        # default single-node MicroShift masters=workers=1. Role counts are
+        # not a partition of `all`.
+        for node in $(kubectl get nodes --ignore-not-found --no-headers -o custom-columns=:.metadata.name || true); do
+            labels=$(kubectl get node "$node" -o jsonpath='{.metadata.labels}' 2>/dev/null || true)
+            node_type=$(kubectl get node "$node" -o jsonpath='{.metadata.labels.beta\.kubernetes\.io/instance-type}' 2>/dev/null || true)
+            if [[ -z "$node_type" ]]; then
+                node_type=$(kubectl get node "$node" -o jsonpath='{.metadata.labels.node\.kubernetes\.io/instance-type}' 2>/dev/null || true)
+            fi
+            if [[ -z "$osimage" ]]; then
+                osimage=$(kubectl get node "$node" -o jsonpath='{.status.nodeInfo.osImage}' 2>/dev/null || true)
+            fi
+            if [[ $labels == *"node-role.kubernetes.io/master"* || $labels == *"node-role.kubernetes.io/control-plane"* ]]; then
+                masters=$((masters + 1))
+                master_type=$node_type
+                taints=$(kubectl get node "$node" -o jsonpath='{.spec.taints}' 2>/dev/null || true)
+                if [[ $labels == *"node-role.kubernetes.io/worker"* && $taints == "" ]]; then
+                    workers=$((workers + 1))
+                    worker_type=$node_type
+                fi
+            elif [[ $labels == *"node-role.kubernetes.io/infra"* ]]; then
+                infra=$((infra + 1))
+                infra_type=$node_type
+            elif [[ $labels == *"node-role.kubernetes.io/worker"* ]]; then
+                workers=$((workers + 1))
+                worker_type=$node_type
+            fi
+            all=$((all + 1))
+        done
+
+        compute_arch=$(kubectl get nodes -o jsonpath='{.items[0].status.nodeInfo.architecture}' 2>/dev/null || true)
+        if [[ -z "$compute_arch" ]]; then
+            compute_arch=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.kubernetes\.io/arch}' 2>/dev/null || true)
+        fi
+        control_plane_arch=$compute_arch
+
+        ocp_virt=false
+        ocp_virt_version=""
+        ocp_virt_tuning_policy=""
+        # ipsec/fips are not exposed via API on MicroShift; left as defaults.
+        ipsec=false
+        ipsecMode="Disabled"
+        fips=false
+        encrypted=false
+        encryption=""
+        publish=""
+        return
+    fi
+
     # Get OpenShift cluster details
     cluster_name=$(oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}') || echo "Cluster Install Failed"
     cluster_version=$(oc version -o json | jq -r '.openshiftVersion') || echo "Cluster Install Failed"
@@ -419,6 +515,10 @@ fi
 ES_INDEX=${ES_METADATA_INDEX:-perf_scale_ci}
 
 setup
+if [[ "${PLATFORM:-openshift}" == "microshift" ]]; then
+    index_tasks
+    exit 0
+fi
 get_ipsec_config
 get_fips_config
 get_osimage_config

--- a/workloads/network-perf-v2/README.md
+++ b/workloads/network-perf-v2/README.md
@@ -1,10 +1,10 @@
 # Network Scripts v2
 
-The purpose of the network scripts is to run netperf workload on the Openshift Cluster.
+The purpose of the network scripts is to run the k8s-netperf workload against an OpenShift or MicroShift cluster.
 
 There are 4 types of network tests k8s-netperf will run through:
 
-1. Pod to Pod using SDN
+1. Pod to pod using the cluster pod network
 2. Pod to Pod using HostNetwork
 3. Pod to Service
 4. Pod to External Server provided by the user
@@ -14,47 +14,69 @@ Running from CLI:
 ```sh
 $ ./run.sh
 ```
-This will orchestrate the smoke test, to confirm connectivity, and that the benchmark can 
-execute against the cloud.
+This will orchestrate the smoke test, to confirm connectivity, and that the benchmark can
+execute against the cluster.
 
 ```sh
 $ WORKLOAD=full-run.yaml ./run.sh
 ```
-This will orchestrate multiple network performance tests. 
+This will orchestrate multiple network performance tests.
 
-| Test | Iterations | Duration | 
-|------|------------|----------|
-|TCP Stream| 3| 30 |
-|UDP Stream| 3| 30 |
-|TCP RR| 3| 30 |
-|TCP CRR| 3| 10 |
+| Test | Parallelism | MessageSize | Samples | Duration |
+|------|-------------|-------------|---------|----------|
+| TCP Stream | 1, 2 | 64, 1024, 4096, 8192 | 5 | 30 |
+| UDP Stream | 1, 2 | 64, 1024, 4096, 8192 | 5 | 30 |
+| TCP RR | 1, 2 | 1024 | 5 | 30 |
+| TCP CRR | 1 | 1024 | 5 | 10 |
+| TCP Stream (service) | 1 | 64, 1024, 4096, 8192 | 5 | 30 |
+| UDP Stream (service) | 1 | 64, 1024, 4096, 8192 | 5 | 30 |
+| TCP RR (service) | 1 | 1024 | 5 | 30 |
+| TCP CRR (service) | 1 | 1024 | 5 | 10 |
 
 ```sh
 $ WORKLOAD=ossm.yaml ./run.sh
 ```
 This will orchestrate multiple network performance tests for OpenShift ServiceMesh.
 
-| Test | Parallelism | MessageSize | Iterations | Duration | 
-|------|------------|------------|----------|
-|TCP Stream| 1 - 2 - 4 | 64 - 1024 - 8192 | 2 | 30 |
-|TCP RR| 1 | 64 - 1024 - 8192 | 2 | 30 |
+| Test | Parallelism | MessageSize | Samples | Duration |
+|------|-------------|-------------|---------|----------|
+| TCP Stream | 1, 2, 4 | 64, 1024, 8192 | 2 | 30 |
+| TCP RR | 1 | 64, 1024, 8192 | 2 | 30 |
 
-### Environment Variables
+## MicroShift
+
+Set `PLATFORM=microshift` to run against a single-node MicroShift cluster:
+
+```sh
+$ PLATFORM=microshift WORKLOAD=full-run.yaml ./run.sh
+```
+
+When `PLATFORM=microshift`, `LOCAL` defaults to `true` and `METRICS` defaults to `false` because MicroShift has no in-cluster Prometheus. `LOCAL=true` is a hard requirement on MicroShift today — `run.sh` exits immediately if `PLATFORM=microshift` is set with `LOCAL=false`. To collect metrics on MicroShift, set `METRICS=true` and point `PROMETHEUS_URL` at an external Prometheus.
+
+## Environment Variables
 
 | Variable                | Description              | Default |
 |-------------------------|--------------------------|---------|
 | ALL_SCENARIOS | Run all test scenarios (hostNetwork & podNetwork) | true |
 | CLEAN_UP | Clean-up resources created by k8s-netperf | true |
-| DEBUG | Enable debug log levevl for k8s-netperf | true |
+| DEBUG | Enable debug log level for k8s-netperf | true |
 | ES_SERVER | Server to send results | `None` (Please set your own that resembles https://USER:PASSWORD@HOSTNAME:443) |
-| LOCAL | Run network performance test pods on the same node | false |
-| METRICS | Enable collection of metrics by k8s-netperf | true |
+| EXTERNAL_SERVER_ADDRESS | IP address where the external server is running. User has to configure the external server with the required k8s-netperf driver | unset |
+| LOCAL | Run network performance test pods on the same node | `true` when `PLATFORM=microshift`, otherwise `false` |
+| METRICS | Enable collection of metrics by k8s-netperf | `false` when `PLATFORM=microshift`, otherwise `true` |
+| NETPERF_FILENAME | Filename of the k8s-netperf binary that run.sh executes | k8s-netperf |
 | NETPERF_URL | URL to download k8s-netperf | https://github.com/cloud-bulldozer/k8s-netperf/releases/download/${NETPERF_VERSION}/k8s-netperf_${OS}_${NETPERF_VERSION}_${ARCH}.tar.gz |
-| NETPERF_VERSION | k8s-netperf tag/version | v0.1.20 |
+| NETPERF_VERSION | k8s-netperf tag/version | v0.1.41 |
 | OS | System to run k8s-netperf | Linux |
+| PLATFORM | Target platform (`openshift` or `microshift`) | openshift |
+| POD | Run pod-network scenarios | true |
 | PROMETHEUS_URL | URL for external Prometheus | unset |
 | TEST_TIMEOUT | Timeout for k8s-netperf | 14400 |
 | TOLERANCE | Tolerance when comparing hostNetwork to podNetwork | 70 |
+| UDNL2 | Run User-Defined Network (L2) scenarios | false |
+| UDNL3 | Run User-Defined Network (L3) scenarios | false |
+| USE_VIRTCTL | When `VM=true`, pass `--use-virtctl` to k8s-netperf so it uses `virtctl` to interact with the VMs | unset |
 | UUID | UUID which will be used for the workload | uuidgen |
+| VM | Run scenarios using KubeVirt VMs | false |
 | WORKLOAD | Config definition for k8s-netperf | smoke.yaml |
-| EXTERNAL_SERVER_ADDRESS | IP address where the external server is running. User has to configure the external server with the required k8s-netperf driver | unset |
+| WORKLOAD_NAME | Workload name passed to indexing as the `WORKLOAD` field | k8s-netperf |

--- a/workloads/network-perf-v2/env.sh
+++ b/workloads/network-perf-v2/env.sh
@@ -1,7 +1,17 @@
 # Common
 export UUID=${UUID:-$(uuidgen)}
 export CLEAN_UP=${CLEAN_UP:-true}
-export LOCAL=${LOCAL:-false}
+export PLATFORM=${PLATFORM:-openshift}
+
+if [[ "${PLATFORM}" == "microshift" ]]; then
+    export LOCAL=${LOCAL:-true}
+    # MicroShift has no in-cluster Prometheus; opt out by default so a
+    # default run does not fail the PROMETHEUS_URL guard in run.sh.
+    export METRICS=${METRICS:-false}
+else
+    export LOCAL=${LOCAL:-false}
+    export METRICS=${METRICS:-true}
+fi
 
 # k8s-netperf version
 if [ "${NETPERF_VERSION}" = "default" ]; then
@@ -9,15 +19,14 @@ if [ "${NETPERF_VERSION}" = "default" ]; then
 fi
 export ALL_SCENARIOS=${ALL_SCENARIOS:-true}
 export DEBUG=${DEBUG:-true}
-export METRICS=${METRICS:-true}
 export VM=${VM:-false}
 export POD=${POD:-true}
 export UDNL2=${UDNL2:-false}
 export UDNL3=${UDNL3:-false}
 export NETPERF_FILENAME=${NETPERF_FILENAME:-k8s-netperf}
-export NETPERF_VERSION=${NETPERF_VERSION:-v0.1.39}
+export NETPERF_VERSION=${NETPERF_VERSION:-v0.1.41}
 export OS=${OS:-Linux}
-export PROMETHEUS_URL=
+export PROMETHEUS_URL=${PROMETHEUS_URL:-}
 export ARCH=$(uname -m)
 export NETPERF_URL=${NETPERF_URL:-https://github.com/cloud-bulldozer/k8s-netperf/releases/download/${NETPERF_VERSION}/k8s-netperf_${OS}_${NETPERF_VERSION}_${ARCH}.tar.gz}
 

--- a/workloads/network-perf-v2/run.sh
+++ b/workloads/network-perf-v2/run.sh
@@ -4,6 +4,16 @@ set -e
 source ./env.sh
 source ../../utils/common.sh
 
+if [[ "${PLATFORM}" == "microshift" && "${LOCAL}" != "true" ]]; then
+  echo "ERROR: PLATFORM=microshift currently requires LOCAL=true"
+  exit 1
+fi
+
+if [[ "${PLATFORM}" == "microshift" && "${METRICS}" == "true" && -z "${PROMETHEUS_URL}" ]]; then
+  echo "ERROR: PLATFORM=microshift with METRICS=true requires PROMETHEUS_URL"
+  exit 1
+fi
+
 # Download k8s-netperf function
 download_netperf() {
   echo $1
@@ -33,15 +43,30 @@ set +e
 JOB_START=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Initialize the command var
-cmd="timeout ${TEST_TIMEOUT} ./k8s-netperf"
+cmd=(timeout "${TEST_TIMEOUT}" "./${NETPERF_FILENAME}")
 
 # Function to add flags conditionally
 add_flag() {
   local flag_name="$1"
   local flag_value="$2"
   if [ -n "$flag_value" ]; then
-    cmd+=" --$flag_name=$flag_value"
+    cmd+=("--$flag_name=$flag_value")
   fi
+}
+
+print_command() {
+  local redacted_cmd=()
+  local arg
+  for arg in "${cmd[@]}"; do
+    case "$arg" in
+      --search=*) redacted_cmd+=("--search=<redacted>") ;;
+      --prom=*) redacted_cmd+=("--prom=<redacted>") ;;
+      *) redacted_cmd+=("$arg") ;;
+    esac
+  done
+  printf 'Executing command:'
+  printf ' %q' "${redacted_cmd[@]}"
+  printf '\n'
 }
 
 if [ -n "${EXTERNAL_SERVER_ADDRESS}" ]; then
@@ -50,13 +75,16 @@ if [ -n "${EXTERNAL_SERVER_ADDRESS}" ]; then
 fi
 
 if [ "${LOCAL}" = "true" ]; then
-  echo "LOCAL mode enabled — removing infra label from worker nodes"
-  for node in $(oc get nodes -l node-role.kubernetes.io/infra -o name); do
-    oc label "$node" node-role.kubernetes.io/infra- || true
-  done
+  echo "LOCAL mode enabled"
+  if [[ "${PLATFORM}" != "microshift" ]]; then
+    echo "Removing infra label from worker nodes"
+    for node in $(oc get nodes -l node-role.kubernetes.io/infra -o name); do
+      oc label "$node" node-role.kubernetes.io/infra- || true
+    done
+  fi
 else
   echo "Labeling client and server nodes for consistency"
-  WORKERS=$(kubectl get nodes -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!= --no-headers  | awk '{print $1}')
+  WORKERS=$(kubectl get nodes -l node-role.kubernetes.io/worker,node-role.kubernetes.io/infra!= --no-headers | awk '{print $1}')
   CLIENT_NODE=$(echo "$WORKERS" | head -1)
   SERVER_NODE=$(echo "$WORKERS" | sed -n '2p')
   if [ -z "$CLIENT_NODE" ] || [ -z "$SERVER_NODE" ]; then
@@ -68,7 +96,11 @@ else
 fi
 
 # Add flags based on conditions
-[ ! ${LOCAL} = true ] && add_flag "all" "${ALL_SCENARIOS}" || echo "LOCAL=true, not setting --all"
+if [[ "${LOCAL}" != "true" ]]; then
+  add_flag "all" "${ALL_SCENARIOS}"
+else
+  echo "LOCAL=true, not setting --all"
+fi
 add_flag "clean" "${CLEAN_UP}"
 add_flag "config" "${WORKLOAD}"
 add_flag "debug" "${DEBUG}"
@@ -89,12 +121,12 @@ if [ "${VM}" = true ]; then
 fi
 
 # Execute the constructed command
-echo "Executing command: $cmd"
-eval "$cmd"
+print_command
+"${cmd[@]}"
 run=$?
 echo "Removing client/server labels"
-kubectl label nodes -l netperf=client netperf-
-kubectl label nodes -l netperf=server netperf-
+kubectl label nodes -l netperf=client netperf- || true
+kubectl label nodes -l netperf=server netperf- || true
 JOB_END=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
 # Add debugging info (will be captured in each execution output)
@@ -113,5 +145,5 @@ if [ $run -eq 0 ]; then
 else
   JOB_STATUS="failure"
 fi
-env JOB_START="${JOB_START}" JOB_END="${JOB_END}" JOB_STATUS="${JOB_STATUS}" UUID="${UUID}" WORKLOAD="${WORKLOAD_NAME}" ES_SERVER="${ES_SERVER}" ../../utils/index.sh
+env JOB_START="${JOB_START}" JOB_END="${JOB_END}" JOB_STATUS="${JOB_STATUS}" UUID="${UUID}" WORKLOAD="${WORKLOAD_NAME}" ES_SERVER="${ES_SERVER}" PLATFORM="${PLATFORM}" ../../utils/index.sh
 exit $run


### PR DESCRIPTION
- Skip OpenShift-only metadata helpers in utils/index.sh and synthesize the fields index_task() needs from Kubernetes resources, the microshift-version ConfigMap, and node labels.
- Drop eval in run.sh in favor of an argv array; safer handling of values containing shell metacharacters.
- env.sh: PLATFORM=microshift defaults LOCAL=true and METRICS=false so a default run does not trip the PROMETHEUS_URL guard.
- README.md: document PLATFORM, MicroShift workflow / LOCAL=true requirement, refresh the env-vars table (adds POD, UDNL2, UDNL3, USE_VIRTCTL, VM, NETPERF_FILENAME, WORKLOAD_NAME), correct the full-run/OSSM coverage tables, fix a broken OSSM table separator and a `levevl` typo.
- env.sh: bump default NETPERF_VERSION to v0.1.41 (the latest upstream release that includes the MicroShift archive metadata fixes).

## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [x] Documentation Update

## Description

Enables the `network-perf-v2` workload to run against MicroShift clusters in addition to OpenShift, so the same continuous performance pipelines we run against OpenShift in prow CI can also be exercised against MicroShift.

MicroShift has no in-cluster Prometheus and no machine-config / cluster-version / infrastructure CRs, so the workload previously failed at two points: (1) the `PROMETHEUS_URL` guard in `run.sh` rejected the run, and (2) `utils/index.sh::index_task()` called `oc` helpers that assume OpenShift APIs are present. This PR adapts both code paths:

- `utils/index.sh` adds a MicroShift branch that reads the `microshift-version` ConfigMap, node labels, and basic Kubernetes resources to synthesize the same `perf_scale_ci` metadata fields `index_task()` writes for OpenShift (`ocpVersion`, `releaseStream`, `platform`, `clusterType`, node counts/types, `networkType`, `ovnVersion`, `computeArch`, `controlPlaneArch`).
- `run.sh` replaces `eval` with an argv array (`cmd=(...)` + `add_flag`), which is also a hardening step regardless of platform — values containing shell metacharacters are now safely quoted.
- `env.sh` keys `LOCAL` and `METRICS` defaults off `PLATFORM`. Default MicroShift runs go `LOCAL=true` / `METRICS=false`, so the existing `PROMETHEUS_URL` guard isn't hit when no Prometheus is configured. Existing `PLATFORM=openshift` behavior is unchanged.
- `README.md` is refreshed alongside: new MicroShift section, updated env-vars table that includes the variables already in `env.sh` but missing from the docs, and corrected coverage tables for `full-run.yaml` and `ossm.yaml`.

## Related Tickets & Documents

- Related Jira: [USHIFT-6964](https://issues.redhat.com/browse/USHIFT-6964) — *Add MicroShift support to e2e-benchmarking network-perf-v2 workload*

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing

**System Under Test:**
- MicroShift 4.22.0~rc.2 on RHEL 9.8 Beta (Plow)
- Kubernetes v1.35.3, kernel 5.14.0-687.5.1.el9_8.x86_64
- Single-node bare metal (`masterNodesType: rhde`)
- k8s-netperf v0.1.42 (driver: netperf)

**Steps:**
1. `cd workloads/network-perf-v2`
2. `export PLATFORM=microshift WORKLOAD=full-run.yaml ES_SERVER=<url> NETPERF_VERSION=v0.1.42`
3. `./run.sh`

**Verification:**

Run UUID `3ca0e34b-fbe2-4d4c-96a5-688fb648ee30`. Queried Elasticsearch `k8s-netperf` index after the run:

- **29/29** documents indexed (matches `created=29` from k8s-netperf log)
- Coverage matrix complete: `TCP_STREAM`×12, `UDP_STREAM`×12, `TCP_RR`×3, `TCP_CRR`×2 across message sizes 64/1024/4096/8192
- MicroShift metadata populated uniformly on all 29 docs:
  - `metadata.distribution=microshift`
  - `metadata.microshift=true`
  - `metadata.microshiftVersion=4.22.0~rc.2`
  - `metadata.microshiftMajorVersion=4.22`
  - `metadata.k8sVersion=v1.35.3`
  - `metadata.kernel=5.14.0-687.5.1.el9_8.x86_64`
  - `metadata.masterNodesType=rhde`
  - `metadata.totalNodes=1`
- Data sanity: no zero/negative `throughput` or `latency`; all measured throughputs fall inside their reported `confidence:[lo,hi]` interval (0 violations across 29 docs).
- Throughput shape matches loopback expectations on single-node netperf (TCP_STREAM 1.5–28 Gb/s, UDP_STREAM 0.26–22 Gb/s, TCP_RR ~9 µs latency, TCP_CRR ~10× slower than RR — all consistent with expected behavior).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MicroShift support for network performance testing with platform-aware defaults and validations (PLATFORM, LOCAL, METRICS, NETPERF_VERSION bump).
  * Enforced MicroShift-specific run constraints (LOCAL/METRICS/PROMETHEUS checks) and safer CLI construction/execution with sensitive-argument redaction.

* **Documentation**
  * README updated with MicroShift guidance, revised workload examples, matrices, environment variable table, and collection instructions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cloud-bulldozer/e2e-benchmarking/pull/855?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->