### PR TITLE
[PERFSCALE-4876] Enable SRIOV and MACVLAN networking modes 

### DIFF
--- a/workloads/network-perf-v2/run.sh
+++ b/workloads/network-perf-v2/run.sh
@@ -123,6 +123,16 @@ if [ "${VM}" = true ]; then
   add_flag "use-virtctl" "${USE_VIRTCTL}"
 fi
 
+# Add sriov flag if SRIOV mode is enabled
+if [ "${SRIOV_MODE}" = true ]; then
+  add_flag "sriov" "${SRIOV_PF_INTERFACE}"
+fi
+
+# Add macvlan flag if MACVLAN mode is enabled
+if [ "${MACVLAN_MODE}" = true ]; then
+  add_flag "macvlan" "${MACVLAN_PF_INTERFACE}"
+fi
+
 # Execute the constructed command
 print_command
 "${cmd[@]}"

--- a/workloads/network-perf-v2/telco-dataplane.yaml
+++ b/workloads/network-perf-v2/telco-dataplane.yaml
@@ -1,0 +1,9 @@
+---
+# TCP Workloads
+tests:
+  - TCPStream:
+    parallelism: 1
+    profile: "TCP_STREAM"
+    duration: 10
+    samples: 3
+    messagesize: 1024


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Add conditional sriov/macvlan flags based on mode settings
    
Pass sriov and macvlan interface flags only when the respective mode is enabled via SRIOV_MODE and MACVLAN_MODE environment variables.

## Related Tickets & Documents

- Related Issue #
- Closes #

## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [ ] If it is a core feature, I have added thorough tests.

## Testing
- Please describe the System Under Test.
- Please provide detailed steps to perform tests related to this code change.
- How were the fix/results from this change verified? Please provide relevant screenshots or results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enabling SR-IOV and macvlan modes in network performance tests, including their corresponding physical interfaces.
  * Added a telco dataplane TCP stream workload with configurable test parameters, including one parallel stream, 10-second duration, three samples, and 1,024-byte messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->